### PR TITLE
feat: added reset option to Crosshairs

### DIFF
--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -1333,6 +1333,8 @@ export class CrosshairsTool extends AnnotationTool {
     // (undocumented)
     renderAnnotation: (enabledElement: Types_2.IEnabledElement, svgDrawingHelper: SVGDrawingHelper) => boolean;
     // (undocumented)
+    resetAnnotations: () => void;
+    // (undocumented)
     setSlabThickness(viewport: any, slabThickness: any): void;
     // (undocumented)
     _subscribeToViewportNewVolumeSet(viewports: any): void;

--- a/packages/tools/src/tools/CrosshairsTool.ts
+++ b/packages/tools/src/tools/CrosshairsTool.ts
@@ -181,6 +181,28 @@ class CrosshairsTool extends AnnotationTool {
       defaultReferenceLineSlabThicknessControlsOn;
   }
 
+  resetAnnotations = () => {
+    const viewportsInfo = this._getViewportsInfo();
+    viewportsInfo.forEach(({ viewportId, renderingEngineId }) => {
+      const enabledElement = getEnabledElementByIds(
+        viewportId,
+        renderingEngineId
+      );
+      const { viewport } = enabledElement;
+      const { element } = viewport;
+      let annotations = this._getAnnotations(enabledElement);
+      annotations = this.filterInteractableAnnotationsForElement(
+        element,
+        annotations
+      );
+      if (annotations.length) {
+        removeAnnotation(annotations[0].annotationUID);
+      }
+    });
+
+    this.computeToolCenter(viewportsInfo);
+  };
+
   /**
    * Gets the camera from the viewport, and adds crosshairs annotation for the viewport
    * to the annotationManager. If any annotation is found in the annotationManager, it


### PR DESCRIPTION
Adds the option to reset the annotation. This can be called manually on the ToolGroup toolInstance for reseting purposes.