### PR TITLE
[WIP] feat: Make the dispatch handling for wheel and double click work like other dispatchers

### DIFF
--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -2855,6 +2855,7 @@ type IToolBinding = {
     mouseButton?: ToolBindingMouseType;
     modifierKey?: ToolBindingKeyboardType;
     numTouchPoints?: number;
+    namedEvent?: string;
 };
 
 // @public (undocumented)
@@ -3488,6 +3489,9 @@ type MouseWheelEventDetail = NormalizedInteractionEventDetail & MouseCustomEvent
         pixelX: number;
         pixelY: number;
         direction: number;
+    };
+    deltaPoints: {
+        canvas: [number, number];
     };
     points: IPoints;
 };
@@ -4721,6 +4725,8 @@ export class StackScrollTool extends BaseTool {
     // (undocumented)
     mouseDragCallback(evt: EventTypes_2.InteractionEventType): void;
     // (undocumented)
+    mouseWheelCallback(evt: any): void;
+    // (undocumented)
     static toolName: any;
     // (undocumented)
     touchDragCallback(evt: EventTypes_2.InteractionEventType): void;
@@ -5550,6 +5556,8 @@ export class ZoomTool extends BaseTool {
     initialMousePosWorld: Types_2.Point3;
     // (undocumented)
     mouseDragCallback: (evt: EventTypes_2.InteractionEventType) => void;
+    // (undocumented)
+    mouseWheelCallback(evt: any): void;
     // (undocumented)
     _panCallback(evt: EventTypes_2.InteractionEventType): void;
     // (undocumented)

--- a/packages/docs/docs/concepts/cornerstone-tools/namedEvents.md
+++ b/packages/docs/docs/concepts/cornerstone-tools/namedEvents.md
@@ -1,0 +1,36 @@
+---
+id: namedEvents
+title: NamedEvents
+---
+
+# Named Events
+
+There are some events that are named, the only one currently supported is the
+`wheel` event, but the handling of this is intended to be similar to other
+events such as the touch and mouse button events.
+
+### Activating a Tool
+
+You can use `setToolActive` for each toolGroup to activate a tool providing a corresponding namedEvent bindings key.
+
+```js
+// Set the ToolGroup's ToolMode for each tool
+// Possible modes include: 'Active', 'Passive', 'Enabled', 'Disabled'
+ctToolGroup.setToolActive(ZoomTool.toolName, {
+  bindings: [
+    // Handles the wheel as the event
+    { namedEvent: 'wheel' },
+    // ALSO handles drag on secondary
+    { mouseButton: MouseBindings.Secondary },
+  ],
+});
+ctToolGroup.setToolActive(StackScrollMouseWheelTool.toolName, {
+  bindings: [
+    // Secondary binding to wheel to stack scroll
+    {
+      namedEvent: 'wheel',
+      modifierKey: KeyboardBindings.Meta,
+    },
+  ],
+});
+```

--- a/packages/tools/examples/modifierKeys/index.ts
+++ b/packages/tools/examples/modifierKeys/index.ts
@@ -16,6 +16,9 @@ const {
   LengthTool,
   RectangleROITool,
   BidirectionalTool,
+  ZoomTool,
+  PanTool,
+  StackScrollTool,
   ToolGroupManager,
   Enums: csToolsEnums,
 } = cornerstoneTools;
@@ -45,10 +48,14 @@ content.appendChild(element);
 
 const instructions = document.createElement('p');
 instructions.innerText = `
-- Left click to use the Window/Level tool.
-- Shift + Left click to use the Length tool.
-- Ctrl + Left click to use the Bidirectional tool.
-- Alt/Option + Left click to use the RectangleROI tool.
+- Single touch is equivalent to left click.
+- Left or Meta+Left for stack scroll.
+- Right or Option to use the Window/Level tool.
+- Center or Ctrl to Pan.
+- Wheel or Shift to Zoom.
+- Shift/Ctrl click to use the Length tool.
+- Ctrl/Alt click to use the Bidirectional tool.
+- Shift/Alt + Left click to use the RectangleROI tool.
 `;
 
 content.append(instructions);
@@ -68,6 +75,9 @@ async function run() {
   cornerstoneTools.addTool(LengthTool);
   cornerstoneTools.addTool(RectangleROITool);
   cornerstoneTools.addTool(BidirectionalTool);
+  cornerstoneTools.addTool(StackScrollTool);
+  cornerstoneTools.addTool(PanTool);
+  cornerstoneTools.addTool(ZoomTool);
 
   // Define a tool group, which defines how mouse events map to tool commands for
   // Any viewport using the group
@@ -78,15 +88,76 @@ async function run() {
   toolGroup.addTool(LengthTool.toolName);
   toolGroup.addTool(RectangleROITool.toolName);
   toolGroup.addTool(BidirectionalTool.toolName);
-
-  // TODO Why doesn't this work?
+  toolGroup.addTool(StackScrollTool.toolName);
+  toolGroup.addTool(PanTool.toolName);
+  toolGroup.addTool(ZoomTool.toolName);
 
   // Set the initial state of the tools, here we set one tool active on left click.
   // This means left click will draw that tool.
-  toolGroup.setToolActive(WindowLevelTool.toolName, {
+  toolGroup.setToolActive(StackScrollTool.toolName, {
     bindings: [
       {
         mouseButton: MouseBindings.Primary, // Left Click
+      },
+      {
+        namedEvent: 'wheel',
+        modifierKey: KeyboardBindings.Meta,
+      },
+      {
+        mouseButton: MouseBindings.Primary, // Left Click
+        modifierKey: KeyboardBindings.Meta,
+      },
+      {
+        numTouchPoints: 1,
+        modifierKey: KeyboardBindings.Meta,
+      },
+    ],
+  });
+  toolGroup.setToolActive(WindowLevelTool.toolName, {
+    bindings: [
+      {
+        mouseButton: MouseBindings.Secondary, // Right Click
+      },
+      {
+        mouseButton: MouseBindings.Primary, // Left Click
+        modifierKey: KeyboardBindings.Alt,
+      },
+      {
+        numTouchPoints: 1,
+        modifierKey: KeyboardBindings.Alt,
+      },
+    ],
+  });
+  toolGroup.setToolActive(PanTool.toolName, {
+    bindings: [
+      {
+        mouseButton: MouseBindings.Primary_And_Secondary,
+      },
+      {
+        mouseButton: MouseBindings.Auxiliary, // Right Click
+      },
+      {
+        mouseButton: MouseBindings.Primary, // Left Click
+        modifierKey: KeyboardBindings.Ctrl,
+      },
+      {
+        numTouchPoints: 1,
+        modifierKey: KeyboardBindings.Ctrl,
+      },
+    ],
+  });
+  toolGroup.setToolActive(ZoomTool.toolName, {
+    bindings: [
+      {
+        namedEvent: 'wheel',
+      },
+      {
+        mouseButton: MouseBindings.Primary, // Left Click
+        modifierKey: KeyboardBindings.Shift,
+      },
+      {
+        numTouchPoints: 1,
+        modifierKey: KeyboardBindings.Shift,
       },
     ],
   });
@@ -94,23 +165,27 @@ async function run() {
     bindings: [
       {
         mouseButton: MouseBindings.Primary, // Shift + Left Click
-        modifierKey: KeyboardBindings.Shift,
+        modifierKey: KeyboardBindings.ShiftCtrl,
+      },
+      {
+        numTouchPoints: 1,
+        modifierKey: KeyboardBindings.ShiftCtrl,
       },
     ],
   });
   toolGroup.setToolActive(RectangleROITool.toolName, {
     bindings: [
       {
-        mouseButton: MouseBindings.Primary, // Ctrl + Left Click
-        modifierKey: KeyboardBindings.Ctrl,
+        mouseButton: MouseBindings.Primary, // Shift/Alt + Left Click
+        modifierKey: KeyboardBindings.ShiftAlt,
       },
     ],
   });
   toolGroup.setToolActive(BidirectionalTool.toolName, {
     bindings: [
       {
-        mouseButton: MouseBindings.Primary, // Alt/Meta + Left Click
-        modifierKey: KeyboardBindings.Alt,
+        mouseButton: MouseBindings.Primary, // Ctrl/Alt + Left Click
+        modifierKey: KeyboardBindings.CtrlAlt,
       },
     ],
   });
@@ -149,11 +224,8 @@ async function run() {
     renderingEngine.getViewport(viewportId)
   );
 
-  // Define a stack containing a single image
-  const stack = [imageIds[0]];
-
   // Set the stack on the viewport
-  viewport.setStack(stack);
+  viewport.setStack(imageIds);
 
   // Render the image
   viewport.render();

--- a/packages/tools/src/eventDispatchers/shared/getActiveToolForNamedEvent.ts
+++ b/packages/tools/src/eventDispatchers/shared/getActiveToolForNamedEvent.ts
@@ -1,5 +1,5 @@
 import { ToolGroupManager } from '../../store';
-import { MouseBindings, ToolModes } from '../../enums';
+import { ToolModes } from '../../enums';
 import { keyEventListener } from '../../eventListeners';
 import { EventTypes } from '../../types';
 import getMouseModifier from './getMouseModifier';
@@ -8,25 +8,25 @@ const { Active } = ToolModes;
 
 /**
  * Iterate tool group tools until we find a tool that has a "ToolBinding"
- * that matches our MouseEvent's `buttons`. It's possible there will be no match
- * (no active tool for that mouse button combination).
+ * that matches the named event. It's possible there will be no match.
  *
  * @param evt - The event dispatcher mouse event.
  *
  * @returns tool
  */
 export default function getActiveToolForMouseEvent(
-  evt: EventTypes.NormalizedMouseEventType
+  name: string,
+  evt: EventTypes.MouseWheelEventType
 ) {
   // Todo: we should refactor this to use getToolsWithModesForMouseEvent instead
   const { renderingEngineId, viewportId } = evt.detail;
-  const mouseEvent = evt.detail.event;
+  const namedEvent = evt.detail.event;
 
   // If any keyboard modifier key is also pressed - get the mouse version
   // first since it handle combinations, while the key event handles non-modifier
   // keys
   const modifierKey =
-    getMouseModifier(mouseEvent) || keyEventListener.getModifierKey();
+    getMouseModifier(namedEvent) || keyEventListener.getModifierKey();
 
   const toolGroup = ToolGroupManager.getToolGroupForViewport(
     viewportId,
@@ -49,9 +49,7 @@ export default function getActiveToolForMouseEvent(
       toolOptions.bindings.length &&
       toolOptions.bindings.some((binding) => {
         return (
-          binding.mouseButton ===
-            (mouseEvent ? mouseEvent.buttons : MouseBindings.Primary) &&
-          binding.modifierKey === modifierKey
+          binding.namedEvent === name && binding.modifierKey === modifierKey
         );
       });
 

--- a/packages/tools/src/eventDispatchers/shared/getActiveToolForTouchEvent.ts
+++ b/packages/tools/src/eventDispatchers/shared/getActiveToolForTouchEvent.ts
@@ -2,6 +2,7 @@ import { ToolGroupManager } from '../../store';
 import { MouseBindings, ToolModes } from '../../enums';
 import { EventTypes } from '../../types';
 import getMouseModifier from './getMouseModifier';
+import { keyEventListener } from '../../eventListeners';
 
 const { Active } = ToolModes;
 
@@ -35,7 +36,8 @@ export default function getActiveToolForTouchEvent(
   const numTouchPoints = Object.keys(touchEvent.touches).length;
 
   // If any keyboard modifier key is also pressed
-  const modifierKey = getMouseModifier(touchEvent);
+  const modifierKey =
+    getMouseModifier(touchEvent) || keyEventListener.getModifierKey();
 
   for (let j = 0; j < toolGroupToolNames.length; j++) {
     const toolName = toolGroupToolNames[j];

--- a/packages/tools/src/eventDispatchers/shared/getMouseModifier.ts
+++ b/packages/tools/src/eventDispatchers/shared/getMouseModifier.ts
@@ -22,7 +22,7 @@ const getMouseModifierKey = (evt) => {
     return (evt.metaKey && kb.AltMeta) || kb.Alt;
   }
   if (evt.metaKey) {
-    kb.Meta;
+    return kb.Meta;
   }
   return undefined;
 };

--- a/packages/tools/src/eventListeners/mouse/mouseDownListener.ts
+++ b/packages/tools/src/eventListeners/mouse/mouseDownListener.ts
@@ -134,7 +134,7 @@ function mouseDownListener(evt: MouseEvent) {
   // on anything except left double click.
   doubleClickState.doubleClickTimeout = setTimeout(
     _doStateMouseDownAndUp,
-    evt.button === 1 ? DOUBLE_CLICK_TOLERANCE_MS : 0
+    evt.buttons === 1 ? DOUBLE_CLICK_TOLERANCE_MS : 0
   );
 
   // First mouse down of a potential double click. So save it and start
@@ -144,7 +144,7 @@ function mouseDownListener(evt: MouseEvent) {
 
   state.element = <HTMLDivElement>evt.currentTarget;
 
-  state.mouseButton = evt.button;
+  state.mouseButton = evt.buttons;
 
   const enabledElement = getEnabledElement(state.element);
   const { renderingEngineId, viewportId } = enabledElement;

--- a/packages/tools/src/store/ToolGroupManager/ToolGroup.ts
+++ b/packages/tools/src/store/ToolGroupManager/ToolGroup.ts
@@ -330,12 +330,13 @@ export default class ToolGroup implements IToolGroup {
     // modifier keys.
     const bindingsToUse = [...prevBindings, ...newBindings].reduce(
       (unique, binding) => {
-        const TouchBinding = binding.numTouchPoints !== undefined;
-        const MouseBinding = binding.mouseButton !== undefined;
+        const touchBinding = binding.numTouchPoints !== undefined;
+        const mouseBinding = binding.mouseButton !== undefined;
+        const namedBinding = !!binding.namedEvent;
 
         if (
           !unique.some((obj) => hasSameBinding(obj, binding)) &&
-          (TouchBinding || MouseBinding)
+          (touchBinding || mouseBinding || namedBinding)
         ) {
           unique.push(binding);
         }
@@ -671,9 +672,7 @@ function hasSameBinding(
   binding1: IToolBinding,
   binding2: IToolBinding
 ): boolean {
-  if (binding1.mouseButton !== binding2.mouseButton) {
-    return false;
-  }
-
+  if (binding1.mouseButton !== binding2.mouseButton) return false;
+  if (binding1.namedEvent !== binding2.namedEvent) return false;
   return binding1.modifierKey === binding2.modifierKey;
 }

--- a/packages/tools/src/tools/StackScrollTool.ts
+++ b/packages/tools/src/tools/StackScrollTool.ts
@@ -22,12 +22,16 @@ class StackScrollTool extends BaseTool {
       configuration: {
         invert: false,
         debounceIfNotLoaded: true,
-        loop: false
+        loop: false,
       },
     }
   ) {
     super(toolProps, defaultToolProps);
     this.deltaY = 1;
+  }
+
+  mouseWheelCallback(evt): void {
+    this._dragCallback(evt);
   }
 
   mouseDragCallback(evt: EventTypes.InteractionEventType) {
@@ -65,7 +69,7 @@ class StackScrollTool extends BaseTool {
         delta: invert ? -imageIdIndexOffset : imageIdIndexOffset,
         volumeId,
         debounceLoading: debounceIfNotLoaded,
-        loop: loop
+        loop: loop,
       });
 
       this.deltaY = deltaY % pixelsPerImage;

--- a/packages/tools/src/tools/ZoomTool.ts
+++ b/packages/tools/src/tools/ZoomTool.ts
@@ -79,6 +79,11 @@ class ZoomTool extends BaseTool {
     }
   };
 
+  // Zoom on mouse wheel
+  public mouseWheelCallback(evt): void {
+    this._dragCallback(evt);
+  }
+
   _pinchCallback(evt: EventTypes.InteractionEventType) {
     const pointsList = (evt as EventTypes.TouchStartEventType).detail
       .currentPointsList;

--- a/packages/tools/src/types/EventTypes.ts
+++ b/packages/tools/src/types/EventTypes.ts
@@ -376,6 +376,10 @@ type MouseWheelEventDetail = NormalizedInteractionEventDetail &
       pixelY: number;
       direction: number;
     };
+    /** Pretend to be a drag */
+    deltaPoints: {
+      canvas: [number, number];
+    };
     /** Mouse Points */
     points: IPoints;
   };

--- a/packages/tools/src/types/ISetToolModeOptions.ts
+++ b/packages/tools/src/types/ISetToolModeOptions.ts
@@ -1,9 +1,9 @@
 import { ToolModes, MouseBindings, KeyboardBindings } from '../enums';
 
-type ToolBindingMouseType = typeof MouseBindings[keyof typeof MouseBindings];
+type ToolBindingMouseType = (typeof MouseBindings)[keyof typeof MouseBindings];
 
 type ToolBindingKeyboardType =
-  typeof KeyboardBindings[keyof typeof KeyboardBindings];
+  (typeof KeyboardBindings)[keyof typeof KeyboardBindings];
 
 type IToolBinding = {
   /** Mouse button bindings e.g., MouseBindings.Primary/Secondary etc. */
@@ -12,6 +12,8 @@ type IToolBinding = {
   modifierKey?: ToolBindingKeyboardType;
   /** Number of touch points */
   numTouchPoints?: number;
+  /** Name of the event, eg 'wheel' */
+  namedEvent?: string;
 };
 
 type SetToolBindingsType = {


### PR DESCRIPTION
The dispatch handling for wheel and double click do not go through the normal binding process, so it is first come first served as to who gets the call.