### PR TITLE
fix PlanarFreehandROITool bugs

### DIFF
--- a/packages/tools/src/tools/annotation/planarFreehandROITool/closedContourEditLoop.ts
+++ b/packages/tools/src/tools/annotation/planarFreehandROITool/closedContourEditLoop.ts
@@ -444,6 +444,8 @@ function completeClosedContourEdit(element: HTMLDivElement) {
     annotation.data.polyline = worldPoints;
     annotation.data.isOpenContour = false;
 
+    annotation.invalidated = true;
+
     this.triggerAnnotationModified(annotation, enabledElement);
   }
 

--- a/packages/tools/src/tools/annotation/planarFreehandROITool/drawLoop.ts
+++ b/packages/tools/src/tools/annotation/planarFreehandROITool/drawLoop.ts
@@ -229,8 +229,11 @@ function completeDrawClosedContour(element: HTMLDivElement): boolean {
 
   annotation.data.polyline = worldPoints;
   annotation.data.isOpenContour = false;
+  const { textBox } = annotation.data.handles;
 
-  this.triggerAnnotationCompleted(annotation);
+  if (!textBox.hasMoved) {
+    this.triggerAnnotationCompleted(annotation);
+  }
 
   this.isDrawing = false;
   this.drawData = undefined;
@@ -296,6 +299,7 @@ function completeDrawOpenContour(element: HTMLDivElement): boolean {
 
   annotation.data.polyline = worldPoints;
   annotation.data.isOpenContour = true;
+  const { textBox } = annotation.data.handles;
 
   // Add the first and last points to the list of handles. These means they
   // will render handles on mouse hover.
@@ -310,7 +314,9 @@ function completeDrawOpenContour(element: HTMLDivElement): boolean {
       findOpenUShapedContourVectorToPeak(canvasPoints, viewport);
   }
 
-  this.triggerAnnotationCompleted(annotation);
+  if (!textBox.hasMoved) {
+    this.triggerAnnotationCompleted(annotation);
+  }
 
   this.isDrawing = false;
   this.drawData = undefined;

--- a/packages/tools/src/tools/annotation/planarFreehandROITool/openContourEditLoop.ts
+++ b/packages/tools/src/tools/annotation/planarFreehandROITool/openContourEditLoop.ts
@@ -563,6 +563,8 @@ function completeOpenContourEdit(element: HTMLDivElement) {
         findOpenUShapedContourVectorToPeak(fusedCanvasPoints, viewport);
     }
 
+    annotation.invalidated = true;
+
     this.triggerAnnotationModified(annotation, enabledElement);
   }
 


### PR DESCRIPTION
Fixed these bugs on PlanarFreehandROITool

- Cached stats are not re-calculated on modification.
- ANNOTATION_COMPLETED events are triggered when moving textbox.