### PR TITLE
feat(transfer function editor): various improvements and fixes

### DIFF
--- a/packages/core/examples/volumeViewport3D/index.ts
+++ b/packages/core/examples/volumeViewport3D/index.ts
@@ -164,7 +164,8 @@ async function run() {
     panel: {
       isCollapsible: true,
       position: 'bottom',
-      background: '#090c29',
+      background: '#0f0f0f',
+      border: '1px solid #090c29',
     },
     histogram: {
       // style: 'bars',

--- a/utils/ExampleRunner/template.html
+++ b/utils/ExampleRunner/template.html
@@ -90,6 +90,10 @@
       cursor: pointer;
     }
 
+    #tf-panel {
+      overflow: hidden;
+    }
+
     #tf-panel .handle {
       opacity: 0.8;
       cursor: pointer;
@@ -130,19 +134,28 @@
     #tf-panel .tooltip {
       visibility: hidden;
       display: inline-block;
-      min-width: 52px;
+      min-width: 56px;
       font-size: 10px;
       /* color: #fff;*/
       text-align: left;
       padding: 5px 8px;
-      margin: 5px;
       border-radius: 6px;
       position: absolute;
       z-index: 10;
+      white-space: nowrap;
+    }
+
+    #tf-panel .histogram-tooltip {
+      min-width: 24px;
     }
 
     .dark {
       background-color: #333;
+      color: #fff !important;
+    }
+
+    .dark-transparent {
+      background-color: #333333a6;
       color: #fff !important;
     }
 
@@ -195,7 +208,14 @@
     }
 
     /* Show the tooltip text when you mouse over the tooltip container */
-    #tf-panel:hover .tooltip {
+    #tf-panel:hover .histogram-tooltip {
+      visibility: visible;
+    }
+
+    #tf-panel .control-point-tooltip-parent.anchor-move .control-endpoint-tooltip,
+    #tf-panel .control-point-tooltip-parent.anchor-hover:not(.control-point-move) .control-endpoint-tooltip,
+    #tf-panel .control-point-tooltip-parent.control-point-move .control-point-tooltip,
+    #tf-panel .control-point-tooltip-parent.control-point-hover:not(.anchor-move) .control-point-tooltip {
       visibility: visible;
     }
 


### PR DESCRIPTION
Fixed the position of the toolitp to the top-left and added transparency to its background.

Clamped the anchor point such that no portion of it goes beyond the canvas bounds.

Prevent deletion of control points when only two remain.

Control endpoint tooltips added. They are shown on anchor hover and drag.

Added a control point tooltip when hovering and movig a control point.

Update the TF_widget anchor whenever a control point gets deleted.

Updated histogram colours.

Moved context menus to document.body so that they are not clipped by the TF_panel.

Added a div (with css class name 'control-point-tooltip-parent') containing the control point tooltips for each separate TF_widget. This simplifies showing/hiding the tooltips on a per TF_widget basis.
