### PR TITLE
fix: MIP jump to image click

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "build:update-api:adapters": "cd packages/adapters && npm run build:update-api",
     "build:update-api:streaming": "cd packages/streaming-image-volume-loader && npm run build:update-api",
     "build:update-api": "npm run build:update-api:core && npm run build:update-api:tools && npm run build:update-api:streaming",
+    "clean": "npx lerna run clean --stream",
     "example": "node ./utils/ExampleRunner/example-runner-cli.js",
     "all-examples": "node ./utils/ExampleRunner/build-all-examples-cli.js --fromRoot",
     "build-all-examples": "node ./utils/ExampleRunner/build-all-examples-cli.js --build --fromRoot",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,6 +19,7 @@
     "build:esm": "tsc --project ./tsconfig.esm.json",
     "build:umd": "cross-env NODE_ENV=production webpack --config .webpack/webpack.prod.js",
     "build:all": "yarn run build:umd && yarn run build:cjs && yarn run build:esm",
+    "clean": "shx rm -rf dist",
     "copy-dts": "copyfiles -u 1 \"src/**/*.d.ts\" dist/cjs && copyfiles -u 1 \"src/**/*.d.ts\" dist/esm",
     "build": "yarn run build:all && yarn run copy-dts",
     "api-check": "api-extractor --debug run",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -21,6 +21,7 @@
     "build:all": "yarn run build:umd && yarn run build:cjs && yarn run build:esm",
     "build": "yarn run build:all",
     "api-check": "api-extractor --debug run",
+    "clean": "shx rm -rf dist",
     "build:update-api": "yarn run build && api-extractor run --local",
     "prepublishOnly": "yarn run build",
     "webpack:watch": "webpack --mode development --progress --watch  --config ./.webpack/webpack.dev.js"

--- a/packages/tools/src/tools/MIPJumpToClickTool.ts
+++ b/packages/tools/src/tools/MIPJumpToClickTool.ts
@@ -41,8 +41,6 @@ class MIPJumpToClickTool extends BaseTool {
   mouseClickCallback(evt): void {
     const { element, currentPoints } = evt.detail;
 
-    console.log('MIPjumpToClick event', evt);
-
     // 1. Getting the enabled element
     const enabledElement = getEnabledElement(element);
     const { viewport, renderingEngine } = enabledElement;

--- a/packages/tools/src/tools/MIPJumpToClickTool.ts
+++ b/packages/tools/src/tools/MIPJumpToClickTool.ts
@@ -4,6 +4,7 @@ import type { Types } from '@cornerstonejs/core';
 import { getPointInLineOfSightWithCriteria } from '../utilities/planar';
 import jumpToWorld from '../utilities/viewport/jumpToWorld';
 import { PublicToolProps, ToolProps } from '../types';
+import { getToolGroupForViewport } from '../store/ToolGroupManager';
 
 /**
  * On a Maximum Intensity Projection (MIP) viewport, MIPJumpToClickTool allows the
@@ -39,6 +40,8 @@ class MIPJumpToClickTool extends BaseTool {
    */
   mouseClickCallback(evt): void {
     const { element, currentPoints } = evt.detail;
+
+    console.log('MIPjumpToClick event', evt);
 
     // 1. Getting the enabled element
     const enabledElement = getEnabledElement(element);
@@ -76,14 +79,19 @@ class MIPJumpToClickTool extends BaseTool {
       return;
     }
 
-    const { targetViewportIds } = this.configuration;
+    const { targetViewportIds, toolGroupId } = this.configuration;
+    // TODO - consider making this a utility
+    const viewports = renderingEngine.getViewports().filter((vp) => {
+      if (targetViewportIds?.indexOf(vp.id) >= 0) return true;
+      const foundToolGroup = getToolGroupForViewport(vp.id, renderingEngine.id);
+      if (toolGroupId && toolGroupId === foundToolGroup?.id) return true;
+      return false;
+    });
 
     // 6. Update all the targetedViewports to jump
-    targetViewportIds.forEach((viewportId) => {
+    viewports.forEach((viewport) => {
       // Todo: current limitation is that we cannot jump in viewports
       // that don't belong to the renderingEngine of the source clicked viewport
-      const viewport = renderingEngine.getViewport(viewportId);
-
       if (viewport instanceof VolumeViewport) {
         jumpToWorld(viewport, brightestPoint);
       } else {


### PR DESCRIPTION
### Context

The MIP jump to image on click tool directly used viewportId's, but these aren't stable in CS3D because they get updated when the viewport gets a new display set or changes size in certain ways.  Instead, this tool is switched to use a new concept pt axial

### Changes & Results

Added viewport categories to the viewport options and a getViewportsInCategory to allow getting all the categorized viewports.  That allows getting a set of viewports by some common condition.

### Testing

Run the updated OHIF build containing the settings for the viewport categories or run the mipJumpToClick example
On mipJumpToClick, use the right panel to click on to navigate

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
