### PR TITLE
link textbox to vertex unless moved by user

### DIFF
--- a/packages/tools/src/tools/annotation/AngleTool.ts
+++ b/packages/tools/src/tools/annotation/AngleTool.ts
@@ -738,7 +738,8 @@ class AngleTool extends AnnotationTool {
       const textLines = this._getTextLines(data, targetId);
 
       if (!data.handles.textBox.hasMoved) {
-        const canvasTextBoxCoords = getTextBoxCoordsCanvas(canvasCoordinates);
+        // linked to the vertex by default
+        const canvasTextBoxCoords = canvasCoordinates[1];
 
         data.handles.textBox.worldPosition =
           viewport.canvasToWorld(canvasTextBoxCoords);


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

In the angle tool the label for degrees is not linked to the vertex of the angle... this can be confusing as the line that links to the label is similar to the lines of the angle and it can appear that you've drawn some other shape rather than an angle.

![image](https://github.com/cornerstonejs/cornerstone3D/assets/93064150/65ebad8e-461c-47e9-b1ca-68c4e890da99)

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

Now by default, the textbox line is linked to the vertex, and it will stay that way unless the text box is specifically moved by the user so that they still have that option if they want it.

Before:-

![before](https://github.com/cornerstonejs/cornerstone3D/assets/93064150/6843e649-f6ca-45e4-b06b-2b3ef75443c8)

After:-

![Screenshot_2](https://github.com/cornerstonejs/cornerstone3D/assets/93064150/1759ea86-0429-45f3-942f-2d7569141e93)

### Testing

- Go to the examples directory in the repo
- Use the double click with stack annotations tool example to test the angle tool

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [X] My code has been well-documented (function documentation, inline comments,
  etc.)

- [X] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [X] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [X] "OS: Windows 10
- [X] "Node version: 18.15.0
- [X] "Browser: Chrome


