### PR TITLE
fix(multiframe): transfer only portion of data for multiframe to worker

### DIFF
--- a/packages/dicomImageLoader/src/imageLoader/wadouri/getUncompressedImageFrame.ts
+++ b/packages/dicomImageLoader/src/imageLoader/wadouri/getUncompressedImageFrame.ts
@@ -57,9 +57,7 @@ function getUncompressedImageFrame(
     }
 
     return new Uint8Array(
-      dataSet.byteArray.buffer,
-      frameOffset,
-      pixelsPerFrame
+      dataSet.byteArray.buffer.slice(frameOffset, frameOffset + pixelsPerFrame)
     );
   } else if (bitsAllocated === 16) {
     frameOffset = pixelDataOffset + frameIndex * pixelsPerFrame * 2;
@@ -68,9 +66,10 @@ function getUncompressedImageFrame(
     }
 
     return new Uint8Array(
-      dataSet.byteArray.buffer,
-      frameOffset,
-      pixelsPerFrame * 2
+      dataSet.byteArray.buffer.slice(
+        frameOffset,
+        frameOffset + pixelsPerFrame * 2
+      )
     );
   } else if (bitsAllocated === 1) {
     frameOffset = pixelDataOffset + frameIndex * pixelsPerFrame * 0.125;
@@ -86,9 +85,10 @@ function getUncompressedImageFrame(
     }
 
     return new Uint8Array(
-      dataSet.byteArray.buffer,
-      frameOffset,
-      pixelsPerFrame * 4
+      dataSet.byteArray.buffer.slice(
+        frameOffset,
+        frameOffset + pixelsPerFrame * 4
+      )
     );
   }
 


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

https://github.com/cornerstonejs/cornerstoneWADOImageLoader/pull/454

Seems like for multiframe in wadouri, there is a huge performance problem and sometimes a out of memory in windows. It is solved by copying only the portion of the data that is needed to the worker.

### Todo
There might be an optimization using SharedArrayBuffer to get the view out of the original buffer without copy but we will take a look into that later

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

Try the `local` example with this data https://github.com/emelalkim/sampledata/releases/tag/large_multiframe

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
