### PR TITLE
Annotation Label - dashed label indicator position can obstruct ROI

### DIFF
--- a/packages/tools/src/tools/annotation/ArrowAnnotateTool.ts
+++ b/packages/tools/src/tools/annotation/ArrowAnnotateTool.ts
@@ -778,7 +778,8 @@ class ArrowAnnotateTool extends AnnotationTool {
 
       // Need to update to sync w/ annotation while unlinked/not moved
       if (!data.handles.textBox.hasMoved) {
-        const canvasTextBoxCoords = getTextBoxCoordsCanvas(canvasCoordinates);
+        // linked to the point that doesn't have the arrowhead by default
+        const canvasTextBoxCoords = canvasCoordinates[1];
 
         data.handles.textBox.worldPosition =
           viewport.canvasToWorld(canvasTextBoxCoords);


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

Here is an example where the dashed line connecting the annotation Arrow Head extends over the ROI... it gives the impression this is part of the annotation line and can cause confusion and also could obstruct the ROI. In this case, the label also obstructs the ROI.

![image](https://github.com/cornerstonejs/cornerstone3D/assets/93064150/19edb062-1e6a-4f45-a639-876d9a3e46b9)

Workaround would be deleting and re-drawing the annotation with a different tail direction and HOPE that label and dashed line are positioned differently.

@sedghi

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

Now by default, the textbox line is linked to the opposite side of the arrowhead, and it will stay that way unless the text box is specifically moved by the user so that they still have that option if they want it.

Before:-
![Before](https://github.com/cornerstonejs/cornerstone3D/assets/93064150/35cf3e1a-e1e1-4a6b-91b8-ad46c737203f)


After:-

![After](https://github.com/cornerstonejs/cornerstone3D/assets/93064150/99fb58cf-f539-4ba1-badd-83689c0f50fa)

### Testing

- Go to the examples directory in the repo
- Use the double click with stack annotations tool example to test the annotation tool

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [X] My code has been well-documented (function documentation, inline comments,
  etc.)

- [X] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [X] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [X] "OS: Windows 10
- [X] "Node version: 18.15.0
- [X] "Browser: Chrome


