### PR TITLE
Fix PlanarFreehandROITool _caculateCachedStats

### DIFF
--- a/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
+++ b/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
@@ -851,6 +851,8 @@ class PlanarFreehandROITool extends AnnotationTool {
       };
     }
 
+    this.triggerAnnotationModified(annotation, enabledElement);
+
     annotation.invalidated = false;
 
     return cachedStats;


### PR DESCRIPTION
Trigger ANNOTATION_MODIFIED event when calculate cached stats on PlanarFreehandROI tool, so that we can get up-to-date cached data on listeners.