### PR TITLE
fix(dicomImageLoader): Error when loading Wadouri JPEG Image

### DIFF
--- a/packages/dicomImageLoader/codecs/jpeg.js
+++ b/packages/dicomImageLoader/codecs/jpeg.js
@@ -561,8 +561,11 @@ var JpegImage = (function jpegImage() {
     return a <= 0 ? 0 : a >= 255 ? 255 : a | 0;
   }
 
+  // create a JPEG Image class
   class JpegImage {}
 
+  // setting up all the prototype functions
+  // javascript new version of setting up prototype functions
   Object.setPrototypeOf(JpegImage.prototype, {
     load: function load(path) {
       var handleData = function (data) {

--- a/packages/dicomImageLoader/codecs/jpeg.js
+++ b/packages/dicomImageLoader/codecs/jpeg.js
@@ -561,7 +561,9 @@ var JpegImage = (function jpegImage() {
     return a <= 0 ? 0 : a >= 255 ? 255 : a | 0;
   }
 
-  constructor.prototype = {
+  class JpegImage {}
+
+  Object.setPrototypeOf(JpegImage.prototype, {
     load: function load(path) {
       var handleData = function (data) {
         this.parse(data);
@@ -1088,7 +1090,7 @@ var JpegImage = (function jpegImage() {
       }
       return data;
     },
-  };
+  });
 
-  return constructor;
+  return JpegImage
 })();


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

There is an error in JPEG.js class when tring parsing JPEG image, the object prototype of this class is assigned using constructor.prototype but apparently this assign is not working in Javascript newer versions, the best way to use it is using Object.setPrototypeOf as mdn post [MDN Prototype Post](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain).

When I was implementing a wadouri image download, the following error was shown:
[Error Image](https://imgur.com/DnKJrk7)
[Line Error Image](https://imgur.com/uaY0z2V)

### Changes & Results

- Change the way of assign the prototype of the object.

What are the effects of this change?
- Before vs After
- Before: 
[Before](https://imgur.com/xsxXfCM)

- After:
[After](https://imgur.com/TmAEDG2)

### Testing

- Using Wadouri Legacy test
- Download a Wadouri JPEG compressed image
- The error is shown in console "Uncaught (in promise) TypeError: Cannot assign to read only property 'prototype' of function 'function DedicatedWorkerGlobalScope()"

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Windows 10 <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [x] "Node version: v16.20.0 <!--[e.g. 16.14.0]"-->
- [x] "Browser: Chrome 83.0.4103.116
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
