### PR TITLE
fix(color volume viewport): fix incorrect property on volume actor

### DIFF
--- a/packages/core/examples/webLoader/registerWebImageLoader.ts
+++ b/packages/core/examples/webLoader/registerWebImageLoader.ts
@@ -78,7 +78,7 @@ function createImage(image, imageId) {
     height: rows,
     width: columns,
     color: true,
-    // since the canvas return rgba we should tell the cornerstone that we have 4 components per pixel
+    // we converted the canvas rgba already to rgb above
     rgba: false,
     columnPixelSpacing: 1, // for web it's always 1
     rowPixelSpacing: 1, // for web it's always 1

--- a/packages/core/examples/webLoader/registerWebImageLoader.ts
+++ b/packages/core/examples/webLoader/registerWebImageLoader.ts
@@ -204,9 +204,23 @@ function _loadImageIntoBuffer(
 
           // @ts-ignore
           const pixelDataRGBA = image.getPixelData();
+          const pixelDataRGB = new Uint8ClampedArray(
+            (pixelDataRGBA.length * 3) / 4
+          );
+
+          let j = 0;
+          for (let i = 0; i < pixelDataRGBA.length; i += 4) {
+            pixelDataRGB[j] = pixelDataRGBA[i];
+            pixelDataRGB[j + 1] = pixelDataRGBA[i + 1];
+            pixelDataRGB[j + 2] = pixelDataRGBA[i + 2];
+            j += 3;
+          }
+
           const targetArray = new Uint8Array(arrayBuffer, offset, length);
 
-          targetArray.set(pixelDataRGBA, 0);
+          // TypedArray.Set is api level and ~50x faster than copying elements even for
+          // Arrays of different types, which aren't simply memcpy ops.
+          targetArray.set(pixelDataRGB, 0);
 
           resolve(true);
         },

--- a/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
@@ -1,6 +1,7 @@
 import vtkVolume from '@kitware/vtk.js/Rendering/Core/Volume';
 import vtkColorTransferFunction from '@kitware/vtk.js/Rendering/Core/ColorTransferFunction';
 import vtkColorMaps from '@kitware/vtk.js/Rendering/Core/ColorTransferFunction/ColorMaps';
+import vtkPiecewiseFunction from '@kitware/vtk.js/Common/DataModel/PiecewiseFunction';
 
 import cache from '../cache';
 import {
@@ -50,7 +51,6 @@ import volumeNewImageEventDispatcher, {
 import Viewport from './Viewport';
 import type { vtkSlabCamera as vtkSlabCameraType } from './vtkClasses/vtkSlabCamera';
 import vtkSlabCamera from './vtkClasses/vtkSlabCamera';
-import vtkPiecewiseFunction from '@kitware/vtk.js/Common/DataModel/PiecewiseFunction';
 
 /**
  * Abstract base class for volume viewports. VolumeViewports are used to render

--- a/packages/core/src/RenderingEngine/helpers/createVolumeActor.ts
+++ b/packages/core/src/RenderingEngine/helpers/createVolumeActor.ts
@@ -57,6 +57,15 @@ async function createVolumeActor(
   const volumeActor = vtkVolume.newInstance();
   volumeActor.setMapper(volumeMapper);
 
+  const numberOfComponents = imageData
+    .getPointData()
+    .getScalars()
+    .getNumberOfComponents();
+
+  if (numberOfComponents === 3) {
+    volumeActor.getProperty().setIndependentComponents(false);
+  }
+
   // If the volume is composed of imageIds, we can apply a default VOI based
   // on either the metadata or the min/max of the middle slice. Example of other
   // types of volumes which might not be composed of imageIds would be e.g., nrrd, nifti

--- a/packages/core/src/loaders/volumeLoader.ts
+++ b/packages/core/src/loaders/volumeLoader.ts
@@ -93,7 +93,7 @@ function createInternalVTKRepresentation(
   imageData.setDirection(direction);
   imageData.setOrigin(origin);
 
-  // Add scalar datas to 3D or 4D volume
+  // Add scalar data to 3D or 4D volume
   if (volume.isDynamicVolume()) {
     const scalarDataArrays = (<Types.IDynamicImageVolume>(
       volume

--- a/packages/core/test/volumeViewport_gpu_render_test.js
+++ b/packages/core/test/volumeViewport_gpu_render_test.js
@@ -770,7 +770,6 @@ describe('Volume Viewport GPU -- ', () => {
       });
 
       const callback = ({ volumeActor }) => {
-        volumeActor.getProperty().setIndependentComponents(false);
         volumeActor.getProperty().setInterpolationTypeToNearest();
       };
 
@@ -814,7 +813,6 @@ describe('Volume Viewport GPU -- ', () => {
       });
 
       const callback = ({ volumeActor }) => {
-        volumeActor.getProperty().setIndependentComponents(false);
         volumeActor.getProperty().setInterpolationTypeToLinear();
       };
 

--- a/packages/dicomImageLoader/src/shared/decodeImageFrame.ts
+++ b/packages/dicomImageLoader/src/shared/decodeImageFrame.ts
@@ -201,11 +201,7 @@ function postProcessDecodedPixels(
     Float32Array,
   };
 
-  if (
-    options.targetBuffer &&
-    options.targetBuffer.type &&
-    !isColorImage(imageFrame.photometricInterpretation)
-  ) {
+  if (options.targetBuffer && options.targetBuffer.type) {
     pixelDataArray = _handleTargetBuffer(
       options,
       imageFrame,

--- a/packages/streaming-image-volume-loader/src/BaseStreamingImageVolume.ts
+++ b/packages/streaming-image-volume-loader/src/BaseStreamingImageVolume.ts
@@ -107,7 +107,8 @@ export default class BaseStreamingImageVolume extends ImageVolume {
       windowCenter,
       windowWidth,
       color,
-      // we don't use rgb for the volume actors, so this is always false
+      // we use rgb (3 components) for the color volumes (and not rgba), and not rgba (which is used
+      // in some parts of the lib for stack viewing in CPU)
       rgba: false,
       spacing: this.spacing,
       dimensions: this.dimensions,

--- a/packages/streaming-image-volume-loader/src/BaseStreamingImageVolume.ts
+++ b/packages/streaming-image-volume-loader/src/BaseStreamingImageVolume.ts
@@ -107,6 +107,8 @@ export default class BaseStreamingImageVolume extends ImageVolume {
       windowCenter,
       windowWidth,
       color,
+      // we don't use rgb for the volume actors, so this is always false
+      rgba: false,
       spacing: this.spacing,
       dimensions: this.dimensions,
       PhotometricInterpretation,
@@ -858,9 +860,11 @@ export default class BaseStreamingImageVolume extends ImageVolume {
       windowWidth,
       voiLUTFunction,
       color,
+      rgba: false,
       numComps: numComponents,
-      rows: dimensions[0],
-      columns: dimensions[1],
+      // Note the dimensions were defined as [Columns, Rows, Frames]
+      rows: dimensions[1],
+      columns: dimensions[0],
       sizeInBytes: imageScalarData.byteLength,
       getPixelData: () => imageScalarData,
       minPixelValue: minMax.min,
@@ -871,7 +875,6 @@ export default class BaseStreamingImageVolume extends ImageVolume {
       getCanvas: undefined, // todo: which canvas?
       height: dimensions[0],
       width: dimensions[1],
-      rgba: undefined, // todo: how
       columnPixelSpacing: spacing[0],
       rowPixelSpacing: spacing[1],
       invert,


### PR DESCRIPTION
### Context

Webloader was returning RGBA true which volume viewport could not handle. It is fixed now. Also the volume viewports color was not working either because of it is changed now to reflect `setIndependentComponents(false)` . In addition streaming into the volume for color was not working since we had a short circute

### Changes & Results

- Modify webloader to be volumetric 
- add setIndependentComponents for color volume actor
- !isColorImage(imageFrame.photometricInterpretation) is not necessary in decdeImageFrame


### Testing

yarn run example webloader 

should work now

https://deploy-preview-683--cornerstone-3d-docs.netlify.app/live-examples/webloader

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
