### PR TITLE
fix(PT measurement units): Non-SUV scaled, but pre-scaled PTs should show proper units

### DIFF
--- a/packages/tools/src/tools/annotation/DragProbeTool.ts
+++ b/packages/tools/src/tools/annotation/DragProbeTool.ts
@@ -155,6 +155,14 @@ class DragProbeTool extends ProbeTool {
 
     const color = this.getStyle('color', styleSpecifier, annotation);
 
+    const isPreScaled = isViewportPreScaled(viewport, targetId);
+
+    const isSuvScaled = this.isSuvScaled(
+      viewport,
+      targetId,
+      annotation.metadata.referencedImageId
+    );
+
     if (!data.cachedStats[targetId]) {
       data.cachedStats[targetId] = {
         Modality: null,
@@ -162,9 +170,21 @@ class DragProbeTool extends ProbeTool {
         value: null,
       };
 
-      this._calculateCachedStats(annotation, renderingEngine, enabledElement);
+      this._calculateCachedStats(
+        annotation,
+        renderingEngine,
+        enabledElement,
+        isPreScaled,
+        isSuvScaled
+      );
     } else if (annotation.invalidated) {
-      this._calculateCachedStats(annotation, renderingEngine, enabledElement);
+      this._calculateCachedStats(
+        annotation,
+        renderingEngine,
+        enabledElement,
+        isPreScaled,
+        isSuvScaled
+      );
     }
 
     // If rendering engine has been destroyed while rendering
@@ -185,20 +205,7 @@ class DragProbeTool extends ProbeTool {
 
     renderStatus = true;
 
-    const isPreScaled = isViewportPreScaled(viewport, targetId);
-
-    const isSuvScaled = this.isSuvScaled(
-      viewport,
-      targetId,
-      annotation.metadata.referencedImageId
-    );
-
-    const textLines = this._getTextLines(
-      data,
-      targetId,
-      isPreScaled,
-      isSuvScaled
-    );
+    const textLines = this._getTextLines(data, targetId);
     if (textLines) {
       const textCanvasCoordinates = [
         canvasCoordinates[0] + 6,

--- a/packages/tools/src/tools/annotation/ProbeTool.ts
+++ b/packages/tools/src/tools/annotation/ProbeTool.ts
@@ -46,6 +46,7 @@ import { ProbeAnnotation } from '../../types/ToolSpecificAnnotationTypes';
 import { StyleSpecifier } from '../../types/AnnotationStyle';
 import { getModalityUnit } from '../../utilities/getModalityUnit';
 import { isViewportPreScaled } from '../../utilities/viewport/isViewportPreScaled';
+import { annotation } from '@cornerstonejs/tools';
 
 const { transformWorldToIndex } = csUtils;
 
@@ -437,6 +438,14 @@ class ProbeTool extends AnnotationTool {
 
       const color = this.getStyle('color', styleSpecifier, annotation);
 
+      const isPreScaled = isViewportPreScaled(viewport, targetId);
+
+      const isSuvScaled = this.isSuvScaled(
+        viewport,
+        targetId,
+        annotation.metadata.referencedImageId
+      );
+
       if (!data.cachedStats[targetId]) {
         data.cachedStats[targetId] = {
           Modality: null,
@@ -444,9 +453,21 @@ class ProbeTool extends AnnotationTool {
           value: null,
         };
 
-        this._calculateCachedStats(annotation, renderingEngine, enabledElement);
+        this._calculateCachedStats(
+          annotation,
+          renderingEngine,
+          enabledElement,
+          isPreScaled,
+          isSuvScaled
+        );
       } else if (annotation.invalidated) {
-        this._calculateCachedStats(annotation, renderingEngine, enabledElement);
+        this._calculateCachedStats(
+          annotation,
+          renderingEngine,
+          enabledElement,
+          isPreScaled,
+          isSuvScaled
+        );
 
         // If the invalidated data is as a result of volumeViewport manipulation
         // of the tools, we need to invalidate the related stackViewports data if
@@ -502,20 +523,7 @@ class ProbeTool extends AnnotationTool {
 
       renderStatus = true;
 
-      const isPreScaled = isViewportPreScaled(viewport, targetId);
-
-      const isSuvScaled = this.isSuvScaled(
-        viewport,
-        targetId,
-        annotation.metadata.referencedImageId
-      );
-
-      const textLines = this._getTextLines(
-        data,
-        targetId,
-        isPreScaled,
-        isSuvScaled
-      );
+      const textLines = this._getTextLines(data, targetId);
       if (textLines) {
         const textCanvasCoordinates = [
           canvasCoordinates[0] + 6,
@@ -537,71 +545,30 @@ class ProbeTool extends AnnotationTool {
     return renderStatus;
   };
 
-  _getTextLines(
-    data,
-    targetId: string,
-    isPreScaled: boolean,
-    isSuvScaled: boolean
-  ): string[] | undefined {
+  _getTextLines(data, targetId: string): string[] | undefined {
     const cachedVolumeStats = data.cachedStats[targetId];
-    const { index, Modality, value, SUVBw, SUVLbm, SUVBsa } = cachedVolumeStats;
+    const { index, value, modalityUnit } = cachedVolumeStats;
 
-    if (value === undefined && SUVBw === undefined) {
+    if (value === undefined) {
       return;
     }
 
     const textLines = [];
-    const unit = getModalityUnit(Modality, isPreScaled, isSuvScaled);
 
     textLines.push(`(${index[0]}, ${index[1]}, ${index[2]})`);
 
-    // Check if we have scaling for the other 2 SUV types for the PET.
-    if (Modality === 'PT' && isPreScaled === true && SUVBw !== undefined) {
-      textLines.push(`${SUVBw.toFixed(2)} SUV bw`);
-      if (SUVLbm) {
-        textLines.push(`${SUVLbm.toFixed(2)} SUV lbm`);
-      }
-      if (SUVBsa) {
-        textLines.push(`${SUVBsa.toFixed(2)} SUV bsa`);
-      }
-    } else {
-      textLines.push(`${value.toFixed(2)} ${unit}`);
-    }
+    textLines.push(`${value.toFixed(2)} ${modalityUnit}`);
 
     return textLines;
   }
 
-  _getValueForModality(value, imageVolume, modality) {
-    const values = {};
-
-    values['value'] = value;
-
-    // Check if we have scaling for the other 2 SUV types for the PET.
-    if (
-      modality === 'PT' &&
-      imageVolume.scaling?.PT &&
-      (imageVolume.scaling.PT.suvbwToSuvbsa ||
-        imageVolume.scaling.PT.suvbwToSuvlbm)
-    ) {
-      const { suvbwToSuvlbm, suvbwToSuvbsa } = imageVolume.scaling.PT;
-
-      values['SUVBw'] = value;
-
-      if (suvbwToSuvlbm) {
-        const SUVLbm = value * suvbwToSuvlbm;
-        values['SUVLbm'] = SUVLbm;
-      }
-
-      if (suvbwToSuvbsa) {
-        const SUVBsa = value * suvbwToSuvbsa;
-        values['SUVBsa'] = SUVBsa;
-      }
-    }
-
-    return values;
-  }
-
-  _calculateCachedStats(annotation, renderingEngine, enabledElement) {
+  _calculateCachedStats(
+    annotation,
+    renderingEngine,
+    enabledElement,
+    isPreScaled,
+    isSuvScaled
+  ) {
     const data = annotation.data;
     const { viewportId, renderingEngineId } = enabledElement;
 
@@ -656,12 +623,18 @@ class ProbeTool extends AnnotationTool {
           index[2] = viewport.getCurrentImageIdIndex();
         }
 
-        const values = this._getValueForModality(value, image, modality);
+        const modalityUnit = getModalityUnit(
+          modality,
+          isPreScaled,
+          isSuvScaled,
+          annotation.metadata.referencedImageId
+        );
 
         cachedStats[targetId] = {
           index,
-          ...values,
+          value,
           Modality: modality,
+          modalityUnit,
         };
       } else {
         this.isHandleOutsideImage = true;

--- a/packages/tools/src/utilities/getModalityUnit.ts
+++ b/packages/tools/src/utilities/getModalityUnit.ts
@@ -1,16 +1,30 @@
+import { metaData } from '@cornerstonejs/core';
+
 function getModalityUnit(
   modality: string,
   isPreScaled: boolean,
-  isSuvScaled: boolean
+  isSuvScaled: boolean,
+  imageId: string
 ): string {
   if (modality === 'CT') {
     return 'HU';
-  } else if (
-    modality === 'PT' &&
-    isPreScaled === true &&
-    isSuvScaled === true
-  ) {
-    return 'SUV';
+  } else if (modality === 'PT') {
+    if (isPreScaled === true) {
+      if (isSuvScaled === true) {
+        return 'SUV';
+      }
+
+      const petSeriesModule = metaData.get('petSeriesModule', imageId);
+      const units = petSeriesModule?.units;
+
+      if (units) {
+        return units;
+      } else {
+        return 'unitless';
+      }
+    } else {
+      return 'raw';
+    }
   } else {
     return '';
   }


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
The various ROI measurements (i.e. rectangle, ellipse, circle, etc.) on non-SUV scaled PTs were showing no units at all. Instead, the units should come from DICOM (0054,1001)/units tag.

SUV scaled PTs should continue to show 'SUV' as the units.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

Non-SUV scaled, but pre-scaled PTs show the units from the DICOM (0054,1001)/units tag.
SUV scaled PTs show SUV units. 
The modality unit displayed as part of the measurement is now also added to the cached stats and fired with the ANNOTATION_ADDED event.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

Add an ROI measurement to a PT and depending on its scaling, the appropriate unit should display for the statistics units.

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Windows 11 <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [x] "Node version: 16.14.0<!--[e.g. 16.14.0]"-->
- [x] "Browser: Chrome 114.0.5735.199 
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
