### PR TITLE
fix(color volume): take into account number of components for the volume length

### DIFF
--- a/packages/streaming-image-volume-loader/src/cornerstoneStreamingImageVolumeLoader.ts
+++ b/packages/streaming-image-volume-loader/src/cornerstoneStreamingImageVolumeLoader.ts
@@ -169,11 +169,11 @@ function cornerstoneStreamingImageVolumeLoader(
             '8 Bit signed images are not yet supported by this plugin.'
           );
         }
-        sizeInBytes = length;
+        sizeInBytes = length * numComponents;
         handleCache(sizeInBytes);
         scalarData = useSharedArrayBuffer
-          ? createUint8SharedArray(length)
-          : new Uint8Array(length);
+          ? createUint8SharedArray(length * numComponents)
+          : new Uint8Array(length * numComponents);
         break;
 
       case 16:


### PR DESCRIPTION

### Context

fixes https://github.com/cornerstonejs/cornerstone3D/issues/680 



### Changes & Results

we were not taking into account the number of components for the 8 bit volume 


### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
