### PR TITLE
Have renderedState to store the status of whether an image has been rendered yet

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -572,7 +572,7 @@ declare namespace Enums {
         ContourType,
         VOILUTFunctionType,
         DynamicOperatorType,
-        RenderedState
+        ViewportStatus
     }
 }
 export { Enums }
@@ -1375,7 +1375,7 @@ type ImageRenderedEventDetail = {
     viewportId: string;
     renderingEngineId: string;
     suppressEvents?: boolean;
-    renderedState: RenderedState;
+    viewportStatus: ViewportStatus;
 };
 
 // @public (undocumented)
@@ -1701,8 +1701,6 @@ interface IViewport {
     // (undocumented)
     render(): void;
     // (undocumented)
-    renderedState: RenderedState;
-    // (undocumented)
     renderingEngineId: string;
     // (undocumented)
     reset(immediate: boolean): void;
@@ -1734,6 +1732,8 @@ interface IViewport {
     type: ViewportType;
     // (undocumented)
     updateRenderingPipeline: () => void;
+    // (undocumented)
+    viewportStatus: ViewportStatus;
     // (undocumented)
     worldToCanvas: (worldPos: Point3) => Point2;
 }
@@ -2028,20 +2028,6 @@ function removeProvider(provider: (type: string, query: any) => {
 }): void;
 
 // @public (undocumented)
-enum RenderedState {
-    // (undocumented)
-    LOADING = "loading",
-    // (undocumented)
-    NO_DATA = "noData",
-    // (undocumented)
-    READY = "ready",
-    // (undocumented)
-    RENDERED = "rendered",
-    // (undocumented)
-    RESIZE = "resize"
-}
-
-// @public (undocumented)
 const RENDERING_DEFAULTS: {
     MINIMUM_SLAB_THICKNESS: number;
     MAXIMUM_RAY_DISTANCE: number;
@@ -2230,7 +2216,7 @@ export class StackViewport extends Viewport implements IStackViewport {
         element: HTMLDivElement;
         viewportId: string;
         renderingEngineId: string;
-        renderedState: RenderedState;
+        viewportStatus: ViewportStatus;
     };
     // (undocumented)
     getActor: (actorUID: string) => ActorEntry;
@@ -2594,8 +2580,6 @@ export class Viewport implements IViewport {
     // (undocumented)
     render(): void;
     // (undocumented)
-    renderedState: RenderedState;
-    // (undocumented)
     readonly renderingEngineId: string;
     // (undocumented)
     reset(immediate?: boolean): void;
@@ -2650,6 +2634,8 @@ export class Viewport implements IViewport {
     // (undocumented)
     static get useCustomRenderingPipeline(): boolean;
     // (undocumented)
+    viewportStatus: ViewportStatus;
+    // (undocumented)
     worldToCanvas: (worldPos: Point3) => Point2;
 }
 
@@ -2692,6 +2678,20 @@ type ViewportProperties = {
     VOILUTFunction?: VOILUTFunctionType;
     invert?: boolean;
 };
+
+// @public (undocumented)
+enum ViewportStatus {
+    // (undocumented)
+    LOADING = "loading",
+    // (undocumented)
+    NO_DATA = "noData",
+    // (undocumented)
+    PRE_RENDER = "preRender",
+    // (undocumented)
+    RENDERED = "rendered",
+    // (undocumented)
+    RESIZE = "resize"
+}
 
 // @public (undocumented)
 enum ViewportType {

--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -1375,6 +1375,7 @@ type ImageRenderedEventDetail = {
     viewportId: string;
     renderingEngineId: string;
     suppressEvents?: boolean;
+    renderedState: RenderedState;
 };
 
 // @public (undocumented)
@@ -2229,6 +2230,7 @@ export class StackViewport extends Viewport implements IStackViewport {
         element: HTMLDivElement;
         viewportId: string;
         renderingEngineId: string;
+        renderedState: RenderedState;
     };
     // (undocumented)
     getActor: (actorUID: string) => ActorEntry;

--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -571,7 +571,8 @@ declare namespace Enums {
         GeometryType,
         ContourType,
         VOILUTFunctionType,
-        DynamicOperatorType
+        DynamicOperatorType,
+        RenderedState
     }
 }
 export { Enums }
@@ -1699,6 +1700,8 @@ interface IViewport {
     // (undocumented)
     render(): void;
     // (undocumented)
+    renderedState: RenderedState;
+    // (undocumented)
     renderingEngineId: string;
     // (undocumented)
     reset(immediate: boolean): void;
@@ -1712,6 +1715,8 @@ interface IViewport {
     setOptions(options: ViewportInputOptions, immediate: boolean): void;
     // (undocumented)
     setPan(pan: Point2, storeAsInitialCamera?: boolean): any;
+    // (undocumented)
+    setRendered(): void;
     // (undocumented)
     setZoom(zoom: number, storeAsInitialCamera?: boolean): any;
     // (undocumented)
@@ -2020,6 +2025,20 @@ function removeAllProviders(): void;
 function removeProvider(provider: (type: string, query: any) => {
     any: any;
 }): void;
+
+// @public (undocumented)
+enum RenderedState {
+    // (undocumented)
+    LOADING = "loading",
+    // (undocumented)
+    NO_DATA = "noData",
+    // (undocumented)
+    READY = "ready",
+    // (undocumented)
+    RENDERED = "rendered",
+    // (undocumented)
+    RESIZE = "resize"
+}
 
 // @public (undocumented)
 const RENDERING_DEFAULTS: {
@@ -2573,6 +2592,8 @@ export class Viewport implements IViewport {
     // (undocumented)
     render(): void;
     // (undocumented)
+    renderedState: RenderedState;
+    // (undocumented)
     readonly renderingEngineId: string;
     // (undocumented)
     reset(immediate?: boolean): void;
@@ -2600,6 +2621,8 @@ export class Viewport implements IViewport {
     setOrientationOfClippingPlanes(vtkPlanes: Array<vtkPlane>, slabThickness: number, viewPlaneNormal: Point3, focalPoint: Point3): void;
     // (undocumented)
     setPan(pan: Point2, storeAsInitialCamera?: boolean): void;
+    // (undocumented)
+    setRendered(): void;
     // (undocumented)
     setZoom(value: number, storeAsInitialCamera?: boolean): void;
     // (undocumented)

--- a/common/reviews/api/streaming-image-volume-loader.api.md
+++ b/common/reviews/api/streaming-image-volume-loader.api.md
@@ -980,6 +980,7 @@ type ImageRenderedEventDetail = {
     viewportId: string;
     renderingEngineId: string;
     suppressEvents?: boolean;
+    renderedState: RenderedState;
 };
 
 // @public (undocumented)

--- a/common/reviews/api/streaming-image-volume-loader.api.md
+++ b/common/reviews/api/streaming-image-volume-loader.api.md
@@ -1166,6 +1166,7 @@ interface IViewport {
     removeActors(actorUIDs: Array<string>): void;
     removeAllActors(): void;
     render(): void;
+    renderedState: RenderedState;
     renderingEngineId: string;
     reset(immediate: boolean): void;
     setActors(actors: Array<ActorEntry>): void;
@@ -1177,6 +1178,7 @@ interface IViewport {
     );
     setOptions(options: ViewportInputOptions, immediate: boolean): void;
     setPan(pan: Point2, storeAsInitialCamera?: boolean);
+    setRendered(): void;
     setZoom(zoom: number, storeAsInitialCamera?: boolean);
     sHeight: number;
     suppressEvents: boolean;
@@ -1402,6 +1404,15 @@ type PublicViewportInput = {
     type: ViewportType;
     defaultOptions?: ViewportInputOptions;
 };
+
+// @public (undocumented)
+enum RenderedState {
+    LOADING = 'loading',
+    NO_DATA = 'noData',
+    READY = 'ready',
+    RENDERED = 'rendered',
+    RESIZE = 'resize',
+}
 
 // @public
 enum RequestType {

--- a/common/reviews/api/streaming-image-volume-loader.api.md
+++ b/common/reviews/api/streaming-image-volume-loader.api.md
@@ -980,7 +980,7 @@ type ImageRenderedEventDetail = {
     viewportId: string;
     renderingEngineId: string;
     suppressEvents?: boolean;
-    renderedState: RenderedState;
+    viewportStatus: ViewportStatus;
 };
 
 // @public (undocumented)
@@ -1167,7 +1167,6 @@ interface IViewport {
     removeActors(actorUIDs: Array<string>): void;
     removeAllActors(): void;
     render(): void;
-    renderedState: RenderedState;
     renderingEngineId: string;
     reset(immediate: boolean): void;
     setActors(actors: Array<ActorEntry>): void;
@@ -1189,6 +1188,7 @@ interface IViewport {
     type: ViewportType;
     // (undocumented)
     updateRenderingPipeline: () => void;
+    viewportStatus: ViewportStatus;
     worldToCanvas: (worldPos: Point3) => Point2;
 }
 
@@ -1406,15 +1406,6 @@ type PublicViewportInput = {
     defaultOptions?: ViewportInputOptions;
 };
 
-// @public (undocumented)
-enum RenderedState {
-    LOADING = 'loading',
-    NO_DATA = 'noData',
-    READY = 'ready',
-    RENDERED = 'rendered',
-    RESIZE = 'resize',
-}
-
 // @public
 enum RequestType {
     Interaction = 'interaction',
@@ -1580,6 +1571,15 @@ type ViewportProperties = {
     VOILUTFunction?: VOILUTFunctionType;
     invert?: boolean;
 };
+
+// @public (undocumented)
+enum ViewportStatus {
+    LOADING = 'loading',
+    NO_DATA = 'noData',
+    PRE_RENDER = 'preRender',
+    RENDERED = 'rendered',
+    RESIZE = 'resize',
+}
 
 // @public
 enum ViewportType {

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -2690,7 +2690,7 @@ type ImageRenderedEventDetail = {
     viewportId: string;
     renderingEngineId: string;
     suppressEvents?: boolean;
-    renderedState: RenderedState;
+    viewportStatus: ViewportStatus;
 };
 
 // @public (undocumented)
@@ -3028,7 +3028,6 @@ interface IViewport {
     removeActors(actorUIDs: Array<string>): void;
     removeAllActors(): void;
     render(): void;
-    renderedState: RenderedState;
     renderingEngineId: string;
     reset(immediate: boolean): void;
     setActors(actors: Array<ActorEntry>): void;
@@ -3050,6 +3049,7 @@ interface IViewport {
     type: ViewportType;
     // (undocumented)
     updateRenderingPipeline: () => void;
+    viewportStatus: ViewportStatus;
     worldToCanvas: (worldPos: Point3) => Point2;
 }
 

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -3027,6 +3027,7 @@ interface IViewport {
     removeActors(actorUIDs: Array<string>): void;
     removeAllActors(): void;
     render(): void;
+    renderedState: RenderedState;
     renderingEngineId: string;
     reset(immediate: boolean): void;
     setActors(actors: Array<ActorEntry>): void;
@@ -3038,6 +3039,7 @@ interface IViewport {
     );
     setOptions(options: ViewportInputOptions, immediate: boolean): void;
     setPan(pan: Point2, storeAsInitialCamera?: boolean);
+    setRendered(): void;
     setZoom(zoom: number, storeAsInitialCamera?: boolean);
     sHeight: number;
     suppressEvents: boolean;

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -2690,6 +2690,7 @@ type ImageRenderedEventDetail = {
     viewportId: string;
     renderingEngineId: string;
     suppressEvents?: boolean;
+    renderedState: RenderedState;
 };
 
 // @public (undocumented)

--- a/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
@@ -13,6 +13,7 @@ import {
   BlendModes,
   Events,
   OrientationAxis,
+  RenderedState,
   VOILUTFunctionType,
 } from '../enums';
 import ViewportType from '../enums/ViewportType';
@@ -591,6 +592,7 @@ abstract class BaseVolumeViewport extends Viewport implements IVolumeViewport {
     }
 
     this._setVolumeActors(volumeActors);
+    this.renderedState = RenderedState.READY;
 
     triggerEvent(this.element, Events.VOLUME_VIEWPORT_NEW_VOLUME, {
       viewportId: this.id,

--- a/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
@@ -13,7 +13,7 @@ import {
   BlendModes,
   Events,
   OrientationAxis,
-  RenderedState,
+  ViewportStatus,
   VOILUTFunctionType,
 } from '../enums';
 import ViewportType from '../enums/ViewportType';
@@ -592,7 +592,7 @@ abstract class BaseVolumeViewport extends Viewport implements IVolumeViewport {
     }
 
     this._setVolumeActors(volumeActors);
-    this.renderedState = RenderedState.READY;
+    this.viewportStatus = ViewportStatus.PRE_RENDER;
 
     triggerEvent(this.element, Events.VOLUME_VIEWPORT_NEW_VOLUME, {
       viewportId: this.id,

--- a/packages/core/src/RenderingEngine/RenderingEngine.ts
+++ b/packages/core/src/RenderingEngine/RenderingEngine.ts
@@ -1252,6 +1252,7 @@ class RenderingEngine implements IRenderingEngine {
       suppressEvents,
       viewportId,
       renderingEngineId,
+      renderedState: viewport.renderedState,
     };
   }
 

--- a/packages/core/src/RenderingEngine/RenderingEngine.ts
+++ b/packages/core/src/RenderingEngine/RenderingEngine.ts
@@ -20,7 +20,7 @@ import type {
   InternalViewportInput,
   NormalizedViewportInput,
 } from '../types/IViewport';
-import { OrientationAxis, RenderedState } from '../enums';
+import { OrientationAxis, ViewportStatus } from '../enums';
 import VolumeViewport3D from './VolumeViewport3D';
 
 type ViewportDisplayCoords = {
@@ -1252,7 +1252,7 @@ class RenderingEngine implements IRenderingEngine {
       suppressEvents,
       viewportId,
       renderingEngineId,
-      renderedState: viewport.renderedState,
+      viewportStatus: viewport.viewportStatus,
     };
   }
 

--- a/packages/core/src/RenderingEngine/RenderingEngine.ts
+++ b/packages/core/src/RenderingEngine/RenderingEngine.ts
@@ -20,7 +20,7 @@ import type {
   InternalViewportInput,
   NormalizedViewportInput,
 } from '../types/IViewport';
-import { OrientationAxis } from '../enums';
+import { OrientationAxis, RenderedState } from '../enums';
 import VolumeViewport3D from './VolumeViewport3D';
 
 type ViewportDisplayCoords = {
@@ -1107,6 +1107,7 @@ class RenderingEngine implements IRenderingEngine {
         const eventDetail =
           this.renderViewportUsingCustomOrVtkPipeline(viewport);
         eventDetailArray.push(eventDetail);
+        viewport.setRendered();
 
         // This viewport has been rendered, we can remove it from the set
         this._needsRender.delete(viewport.id);

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -74,7 +74,7 @@ import {
   ImagePixelModule,
   ImagePlaneModule,
 } from '../types';
-import { RenderedState } from '../enums';
+import ViewportStatus from '../enums/ViewportStatus';
 
 const EPSILON = 1; // Slice Thickness
 
@@ -697,9 +697,9 @@ class StackViewport extends Viewport implements IStackViewport {
     }: StackViewportProperties = {},
     suppressEvents = false
   ): void {
-    this.renderedState = this.csImage
-      ? RenderedState.READY
-      : RenderedState.LOADING;
+    this.viewportStatus = this.csImage
+      ? ViewportStatus.PRE_RENDER
+      : ViewportStatus.LOADING;
     // if voi is not applied for the first time, run the setVOI function
     // which will apply the default voi based on the range
     if (typeof voiRange !== 'undefined') {
@@ -757,7 +757,7 @@ class StackViewport extends Viewport implements IStackViewport {
   public resetProperties(): void {
     this.cpuRenderingInvalidated = true;
     this.voiUpdatedWithSetProperties = false;
-    this.renderedState = RenderedState.READY;
+    this.viewportStatus = ViewportStatus.PRE_RENDER;
 
     this.fillWithBackgroundColor();
 
@@ -1499,7 +1499,7 @@ class StackViewport extends Viewport implements IStackViewport {
     this.voiRange = null;
     this.interpolationType = InterpolationType.LINEAR;
     this.invert = false;
-    this.renderedState = RenderedState.LOADING;
+    this.viewportStatus = ViewportStatus.LOADING;
 
     this.fillWithBackgroundColor();
 
@@ -1721,7 +1721,7 @@ class StackViewport extends Viewport implements IStackViewport {
         }
 
         this._setCSImage(image);
-        this.renderedState = RenderedState.READY;
+        this.viewportStatus = ViewportStatus.PRE_RENDER;
 
         const eventDetail: EventTypes.StackNewImageEventDetail = {
           image,
@@ -2655,7 +2655,7 @@ class StackViewport extends Viewport implements IStackViewport {
       element: this.element,
       viewportId: this.id,
       renderingEngineId: this.renderingEngineId,
-      renderedState: this.renderedState,
+      viewportStatus: this.viewportStatus,
     };
   };
 

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -74,6 +74,7 @@ import {
   ImagePixelModule,
   ImagePlaneModule,
 } from '../types';
+import { RenderedState } from '../enums';
 
 const EPSILON = 1; // Slice Thickness
 
@@ -1494,6 +1495,7 @@ class StackViewport extends Viewport implements IStackViewport {
     this.voiRange = null;
     this.interpolationType = InterpolationType.LINEAR;
     this.invert = false;
+    this.renderedState = RenderedState.LOADING;
 
     this.fillWithBackgroundColor();
 
@@ -1715,6 +1717,7 @@ class StackViewport extends Viewport implements IStackViewport {
         }
 
         this._setCSImage(image);
+        this.renderedState = RenderedState.READY;
 
         const eventDetail: EventTypes.StackNewImageEventDetail = {
           image,

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -697,6 +697,9 @@ class StackViewport extends Viewport implements IStackViewport {
     }: StackViewportProperties = {},
     suppressEvents = false
   ): void {
+    this.renderedState = this.csImage
+      ? RenderedState.READY
+      : RenderedState.LOADING;
     // if voi is not applied for the first time, run the setVOI function
     // which will apply the default voi based on the range
     if (typeof voiRange !== 'undefined') {
@@ -754,6 +757,7 @@ class StackViewport extends Viewport implements IStackViewport {
   public resetProperties(): void {
     this.cpuRenderingInvalidated = true;
     this.voiUpdatedWithSetProperties = false;
+    this.renderedState = RenderedState.READY;
 
     this.fillWithBackgroundColor();
 
@@ -2651,6 +2655,7 @@ class StackViewport extends Viewport implements IStackViewport {
       element: this.element,
       viewportId: this.id,
       renderingEngineId: this.renderingEngineId,
+      renderedState: this.renderedState,
     };
   };
 

--- a/packages/core/src/RenderingEngine/Viewport.ts
+++ b/packages/core/src/RenderingEngine/Viewport.ts
@@ -7,6 +7,7 @@ import { vec2, vec3 } from 'gl-matrix';
 import _cloneDeep from 'lodash.clonedeep';
 
 import Events from '../enums/Events';
+import RenderedState from '../enums/RenderedState';
 import ViewportType from '../enums/ViewportType';
 import renderingEngineCache from './renderingEngineCache';
 import { triggerEvent, planar, isImageActor, actorIsA } from '../utilities';
@@ -50,6 +51,10 @@ class Viewport implements IViewport {
   protected flipHorizontal = false;
   protected flipVertical = false;
   public isDisabled: boolean;
+  /** Record the renddering status, mostly for testing purposes, but can also
+   * be useful for knowing things like whether the viewport is initialized
+   */
+  public renderedState: RenderedState = RenderedState.NO_DATA;
 
   /** sx of viewport on the offscreen canvas */
   sx: number;
@@ -115,6 +120,11 @@ class Viewport implements IViewport {
 
   static get useCustomRenderingPipeline(): boolean {
     return false;
+  }
+
+  public setRendered() {
+    if (this.renderedState === RenderedState.NO_DATA) return;
+    this.renderedState = RenderedState.RENDERED;
   }
 
   /**

--- a/packages/core/src/RenderingEngine/Viewport.ts
+++ b/packages/core/src/RenderingEngine/Viewport.ts
@@ -122,8 +122,19 @@ class Viewport implements IViewport {
     return false;
   }
 
+  /**
+   * Indicate that the image has been rendered.
+   * This will set hte renderedState to RENDERED if there is image data
+   * available to actually be rendered - otherwise, the rendering simply showed
+   * the background image.
+   */
   public setRendered() {
-    if (this.renderedState === RenderedState.NO_DATA) return;
+    if (
+      this.renderedState === RenderedState.NO_DATA ||
+      this.renderedState === RenderedState.LOADING
+    ) {
+      return;
+    }
     this.renderedState = RenderedState.RENDERED;
   }
 

--- a/packages/core/src/RenderingEngine/Viewport.ts
+++ b/packages/core/src/RenderingEngine/Viewport.ts
@@ -7,7 +7,7 @@ import { vec2, vec3 } from 'gl-matrix';
 import _cloneDeep from 'lodash.clonedeep';
 
 import Events from '../enums/Events';
-import RenderedState from '../enums/RenderedState';
+import ViewportStatus from '../enums/ViewportStatus';
 import ViewportType from '../enums/ViewportType';
 import renderingEngineCache from './renderingEngineCache';
 import { triggerEvent, planar, isImageActor, actorIsA } from '../utilities';
@@ -54,7 +54,7 @@ class Viewport implements IViewport {
   /** Record the renddering status, mostly for testing purposes, but can also
    * be useful for knowing things like whether the viewport is initialized
    */
-  public renderedState: RenderedState = RenderedState.NO_DATA;
+  public viewportStatus: ViewportStatus = ViewportStatus.NO_DATA;
 
   /** sx of viewport on the offscreen canvas */
   sx: number;
@@ -124,18 +124,18 @@ class Viewport implements IViewport {
 
   /**
    * Indicate that the image has been rendered.
-   * This will set hte renderedState to RENDERED if there is image data
+   * This will set hte viewportStatus to RENDERED if there is image data
    * available to actually be rendered - otherwise, the rendering simply showed
    * the background image.
    */
   public setRendered() {
     if (
-      this.renderedState === RenderedState.NO_DATA ||
-      this.renderedState === RenderedState.LOADING
+      this.viewportStatus === ViewportStatus.NO_DATA ||
+      this.viewportStatus === ViewportStatus.LOADING
     ) {
       return;
     }
-    this.renderedState = RenderedState.RENDERED;
+    this.viewportStatus = ViewportStatus.RENDERED;
   }
 
   /**

--- a/packages/core/src/enums/RenderedState.ts
+++ b/packages/core/src/enums/RenderedState.ts
@@ -1,0 +1,14 @@
+enum RenderedState {
+  /** Initial state before any volumes or stacks are available*/
+  NO_DATA = 'noData',
+  /** Stack/volumes are available but are in progress */
+  LOADING = 'loading',
+  /** Ready to be rendered */
+  READY = 'ready',
+  /** In the midst of a resize */
+  RESIZE = 'resize',
+  /** Rendered image data */
+  RENDERED = 'rendered',
+}
+
+export default RenderedState;

--- a/packages/core/src/enums/ViewportStatus.ts
+++ b/packages/core/src/enums/ViewportStatus.ts
@@ -1,14 +1,14 @@
-enum RenderedState {
+enum ViewportStatus {
   /** Initial state before any volumes or stacks are available*/
   NO_DATA = 'noData',
   /** Stack/volumes are available but are in progress */
   LOADING = 'loading',
   /** Ready to be rendered */
-  READY = 'ready',
+  PRE_RENDER = 'preRender',
   /** In the midst of a resize */
   RESIZE = 'resize',
   /** Rendered image data */
   RENDERED = 'rendered',
 }
 
-export default RenderedState;
+export default ViewportStatus;

--- a/packages/core/src/enums/index.ts
+++ b/packages/core/src/enums/index.ts
@@ -9,6 +9,7 @@ import GeometryType from './GeometryType';
 import ContourType from './ContourType';
 import VOILUTFunctionType from './VOILUTFunctionType';
 import DynamicOperatorType from './DynamicOperatorType';
+import RenderedState from './RenderedState';
 
 export {
   Events,
@@ -22,4 +23,5 @@ export {
   ContourType,
   VOILUTFunctionType,
   DynamicOperatorType,
+  RenderedState,
 };

--- a/packages/core/src/enums/index.ts
+++ b/packages/core/src/enums/index.ts
@@ -9,7 +9,7 @@ import GeometryType from './GeometryType';
 import ContourType from './ContourType';
 import VOILUTFunctionType from './VOILUTFunctionType';
 import DynamicOperatorType from './DynamicOperatorType';
-import RenderedState from './RenderedState';
+import ViewportStatus from './ViewportStatus';
 
 export {
   Events,
@@ -23,5 +23,5 @@ export {
   ContourType,
   VOILUTFunctionType,
   DynamicOperatorType,
-  RenderedState,
+  ViewportStatus,
 };

--- a/packages/core/src/types/EventTypes.ts
+++ b/packages/core/src/types/EventTypes.ts
@@ -8,6 +8,7 @@ import type IImage from './IImage';
 import type IImageVolume from './IImageVolume';
 import type { VOIRange } from './voi';
 import type VOILUTFunctionType from '../enums/VOILUTFunctionType';
+import type RenderedState from '../enums/RenderedState';
 import type DisplayArea from './displayArea';
 
 /**
@@ -96,6 +97,8 @@ type ImageRenderedEventDetail = {
   renderingEngineId: string;
   /** Whether to suppress the event */
   suppressEvents?: boolean;
+  /** Include information on whether this is a real rendering or just background */
+  renderedState: RenderedState;
 };
 /**
  * IMAGE_VOLUME_MODIFIED Event's data

--- a/packages/core/src/types/EventTypes.ts
+++ b/packages/core/src/types/EventTypes.ts
@@ -8,7 +8,7 @@ import type IImage from './IImage';
 import type IImageVolume from './IImageVolume';
 import type { VOIRange } from './voi';
 import type VOILUTFunctionType from '../enums/VOILUTFunctionType';
-import type RenderedState from '../enums/RenderedState';
+import type ViewportStatus from '../enums/ViewportStatus';
 import type DisplayArea from './displayArea';
 
 /**
@@ -98,7 +98,7 @@ type ImageRenderedEventDetail = {
   /** Whether to suppress the event */
   suppressEvents?: boolean;
   /** Include information on whether this is a real rendering or just background */
-  renderedState: RenderedState;
+  viewportStatus: ViewportStatus;
 };
 /**
  * IMAGE_VOLUME_MODIFIED Event's data

--- a/packages/core/src/types/IViewport.ts
+++ b/packages/core/src/types/IViewport.ts
@@ -4,7 +4,7 @@ import Point3 from './Point3';
 import ViewportInputOptions from './ViewportInputOptions';
 import { ActorEntry } from './IActor';
 import ViewportType from '../enums/ViewportType';
-import RenderedState from '../enums/RenderedState';
+import ViewportStatus from '../enums/ViewportStatus';
 import DisplayArea from './displayArea';
 
 /**
@@ -40,7 +40,7 @@ interface IViewport {
   /** if the viewport has been disabled */
   isDisabled: boolean;
   /** The rendering state of this viewport */
-  renderedState: RenderedState;
+  viewportStatus: ViewportStatus;
   /** the rotation applied to the view */
   getRotation: () => number;
   /** frameOfReferenceUID the viewport's default actor is rendering */

--- a/packages/core/src/types/IViewport.ts
+++ b/packages/core/src/types/IViewport.ts
@@ -4,6 +4,7 @@ import Point3 from './Point3';
 import ViewportInputOptions from './ViewportInputOptions';
 import { ActorEntry } from './IActor';
 import ViewportType from '../enums/ViewportType';
+import RenderedState from '../enums/RenderedState';
 import DisplayArea from './displayArea';
 
 /**
@@ -38,6 +39,8 @@ interface IViewport {
   suppressEvents: boolean;
   /** if the viewport has been disabled */
   isDisabled: boolean;
+  /** The rendering state of this viewport */
+  renderedState: RenderedState;
   /** the rotation applied to the view */
   getRotation: () => number;
   /** frameOfReferenceUID the viewport's default actor is rendering */
@@ -88,6 +91,8 @@ interface IViewport {
   getCanvas(): HTMLCanvasElement;
   /** returns camera object */
   getCamera(): ICamera;
+  /** Sets the rendered state to rendered if the render actually showed image data */
+  setRendered(): void;
   /** returns the parallel zoom relative to the default (eg returns 1 after reset) */
   getZoom(): number;
   /** Sets the relative zoom - set to 1 to reset it */


### PR DESCRIPTION
### Context

Sometimes it is important to know if an initial render has occurred yet, but because of timing, it isn't possible to listen to rendered events.  Also, the image rendered event should include whether this was a real render, or an early render that just shows the background colour.

### Changes & Results

Added a renderedState enum and use it in the viewports to record the rendering state.

### Testing

Run the OHIF integration tests:
https://github.com/OHIF/Viewers/pull/3540
Note this value can be used independently of OHIF, just there didn't seem to be immediate uses of it in the CS3D integration tests.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
