### PR TITLE
fix(scale tool): render on viewports with different frameOfReference

### DIFF
--- a/packages/tools/src/tools/ScaleOverlayTool.ts
+++ b/packages/tools/src/tools/ScaleOverlayTool.ts
@@ -25,7 +25,7 @@ import { StyleSpecifier } from '../types/AnnotationStyle';
 import { getToolGroup } from '../store/ToolGroupManager';
 
 const SCALEOVERLAYTOOL_ID = 'scaleoverlay-viewport';
-const viewportsWithAnnotations = [];
+const viewportsFrameWithAnnotations = [];
 
 /**
  * @public
@@ -114,9 +114,17 @@ class ScaleOverlayTool extends AnnotationDisplayTool {
       )[0] as ScaleOverlayAnnotation;
     }
 
-    // viewportsWithAnnotations stores which viewports have an annotation,
-    // if the viewport does not have an annotation, create a new one
-    if (!viewportsWithAnnotations.includes(viewport.id)) {
+    // viewportsFrameWithAnnotations stores which viewports and FrameOfReference have an annotation,
+    // if the viewport and FrameOfReference does not have an annotation, create a new one
+    const viewportId = viewport.id;
+    const isScaleNotInViewportAndFrameOfReference =
+      !viewportsFrameWithAnnotations.find(
+        (viewport) =>
+          viewport.viewportId == viewportId &&
+          viewport.FrameOfReferenceUID == FrameOfReferenceUID
+      );
+
+    if (isScaleNotInViewportAndFrameOfReference) {
       const newAnnotation: ScaleOverlayAnnotation = {
         metadata: {
           toolName: this.getToolName(),
@@ -133,7 +141,10 @@ class ScaleOverlayTool extends AnnotationDisplayTool {
         },
       };
 
-      viewportsWithAnnotations.push(viewport.id);
+      viewportsFrameWithAnnotations.push({
+        FrameOfReferenceUID,
+        viewportId,
+      });
 
       addAnnotation(newAnnotation, viewport.element);
       annotation = newAnnotation;
@@ -188,7 +199,7 @@ class ScaleOverlayTool extends AnnotationDisplayTool {
 
     const renderStatus = false;
 
-    if (!viewport) {
+    if (!viewport || !annotation) {
       return renderStatus;
     }
 


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
Fixes https://github.com/cornerstonejs/cornerstone3D/issues/673. 
<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
Viewport may have assigned multiple frameOfReferences (one at a time) wich have caused not adding new scale annotation for new frameOfReference within one viewport.

Previously checking if scale annotation is added was done by comparing whether it had been added to viewport. But rendering is filtering annotations based on both frameOfReference and viewportId. Adding only one scale annotation per viewport caused it to not show on same viewport but with changed frameOfReference.

PR fixes it by comparing added scale annotation with both viewportId and frameOfReference. With normal way application works nothing changes as all viewports share one frameOfReference, however when vieport may be given different frameOfReference based on loaded series for example it will also check if frameOfReference is the same, allowing new scale annotation for same viewport.
<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [X] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [X] My code has been well-documented (function documentation, inline comments,
  etc.)

- [X] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [X] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [X] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"--> Windows 10,
- [X] "Node version: <!--[e.g. 16.14.0]"--> v20.1.0
- [X] "Browser: Microsoft Edge 114.0.1823.82
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
