### PR TITLE
fix(SVGCursorDescriptor): improve CursorSVG typing

### DIFF
--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -1363,43 +1363,7 @@ declare namespace cursors {
 export { cursors }
 
 // @public (undocumented)
-const CursorSVG: {
-    Angle: SVGCursorDescriptor;
-    ArrowAnnotate: SVGCursorDescriptor;
-    Bidirectional: SVGCursorDescriptor;
-    CobbAngle: SVGCursorDescriptor;
-    CircleROI: SVGCursorDescriptor;
-    EllipticalROI: SVGCursorDescriptor;
-    FreehandROI: SVGCursorDescriptor;
-    FreehandROISculptor: SVGCursorDescriptor;
-    Length: SVGCursorDescriptor;
-    Probe: SVGCursorDescriptor;
-    RectangleROI: SVGCursorDescriptor;
-    TextMarker: SVGCursorDescriptor;
-    Crosshairs: SVGCursorDescriptor;
-    Eraser: SVGCursorDescriptor;
-    Magnify: SVGCursorDescriptor;
-    Pan: SVGCursorDescriptor;
-    Rotate: SVGCursorDescriptor;
-    StackScroll: SVGCursorDescriptor;
-    WindowLevelRegion: SVGCursorDescriptor;
-    WindowLevel: SVGCursorDescriptor;
-    Zoom: SVGCursorDescriptor;
-    SegmentationFreeHandEraseInside: SVGCursorDescriptor;
-    SegmentationFreeHandFillInside: SVGCursorDescriptor;
-    SegmentationFreeHandEraseOutside: SVGCursorDescriptor;
-    SegmentationFreeHandFillOutside: SVGCursorDescriptor;
-    SegmentationRectangleEraseInside: SVGCursorDescriptor;
-    RectangleScissor: SVGCursorDescriptor;
-    'RectangleScissor.FILL_INSIDE': SVGCursorDescriptor;
-    'RectangleScissor.FILL_OUTSIDE': SVGCursorDescriptor;
-    'RectangleScissor.ERASE_OUTSIDE': SVGCursorDescriptor;
-    'RectangleScissor.ERASE_INSIDE': SVGCursorDescriptor;
-    CircleScissor: SVGCursorDescriptor;
-    'CircleScissor.FILL_INSIDE': SVGCursorDescriptor;
-    'CircleScissor.ERASE_OUTSIDE': SVGCursorDescriptor;
-    'CircleScissor.FILL_OUTSIDE': SVGCursorDescriptor;
-};
+const CursorSVG: Record<string, SVGCursorDescriptor>;
 
 // @public (undocumented)
 interface CustomEvent_2<T = any> extends Event {

--- a/packages/tools/src/cursors/SVGCursorDescriptor.ts
+++ b/packages/tools/src/cursors/SVGCursorDescriptor.ts
@@ -39,7 +39,7 @@ const SCISSOR_ICON = `<path fill="{{color}}" d="M82.89,10a12.09,12.09,0,0,0-16.8
 const RECTANGLE_ICON = `<path fill="{{color}}" d="M8.86,2.25V66.08H72.69V2.25H8.86ZM65.28,58.67h-49v-49h49v49Z" transform="translate(-8.86 -2.25)"/>`;
 const CIRCLE_ICON = `<path fill="{{color}}" d="M40.77,2.25A31.92,31.92,0,1,0,72.69,34.16,31.92,31.92,0,0,0,40.77,2.25Zm0,57.63A25.71,25.71,0,1,1,66.48,34.16,25.71,25.71,0,0,1,40.77,59.87Z" transform="translate(-8.86 -2.25)"/>`;
 
-const CursorSVG = {
+const CursorSVG: Record<string, SVGCursorDescriptor> = {
   Angle: extend(BASE, {
     iconContent: `<path fill="{{color}}" d="M1203 544q0 13-10 23l-393 393 393 393q10 10 10 23t-10 23l-50
     50q-10 10-23 10t-23-10l-466-466q-10-10-10-23t10-23l466-466q10-10 23-10t23
@@ -444,9 +444,7 @@ function registerCursor(
 function getDefinedSVGCursorDescriptor(
   name: string
 ): SVGCursorDescriptor | undefined {
-  if (Object.prototype.hasOwnProperty.call(CursorSVG, name)) {
-    return CursorSVG[name];
-  }
+  return CursorSVG[name];
 }
 
 /*


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
`CursorSVG` had a implicit type that did not reflect, that cursors for new tool names can be added.
`registerCursor` can add any string as toolname to `CursorSVG`.

`svgCursorNames` has a similar problem. It only returns the initial cursor names.
Maybe it should be a function instead of a variable to return the current keys of `CursorSVG`. 
I did not changed it because I did not want to risk changing the public API on my first PR here. :)
<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

`CursorSVG` has a broader type.

Small refactoring in `getDefinedSVGCursorDescriptor`. Should not affect functionality.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
Only typing change. No change in runtime behavior.
<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Ubuntu 22.04
- [x] "Node version: 16.17.0
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
