### PR TITLE
targetBuffer.type modified for RGB file (GPU)

### DIFF
--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -1818,9 +1818,21 @@ class StackViewport extends Viewport implements IStackViewport {
       const priority = -5;
       const requestType = RequestType.Interaction;
       const additionalDetails = { imageId };
+      //
+      // issues : https://github.com/OHIF/Viewers/issues/3354
+      //
+      //
+      // 'Float32Array' as targetBuffer.type causes inproper ImageRendering
+      //  for DICOM with Photometric Interpretation (0028,0004)= RGB or PALETTE_COLOR
+      //
+      //  tested on RGB/MONOCHROME/YBR_XXX/PALETTE_COLOR ( mostly US modality)
+      //
+      //  requires better analysis and evalaution
+      //
       const options = {
         targetBuffer: {
-          type: this.useNativeDataType ? undefined : 'Float32Array',
+          //type: this.useNativeDataType ? undefined : 'Float32Array',
+          type: undefined,
         },
         preScale: {
           enabled: true,


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

<!--
The only change is modification of private method  _loadAndDisplayImageGPU in core/src/RenderingEngine/StackViewport.ts
options.targetBuffer.type set to undefined unconditionally
Before the fix Dicom files with Photometric Interpretation (0028,0004)= RGB or PALETTE_COLOR were displayed mangled in 
case **GPU rendering** 
 After the fix files are displayed properly ( same as in CPU rendering)
-->

### Testing

<!--
Open example "local"( P10 DICOM load from local computer).
Apply DICOM with RGB photometric interpretation RGB.
See image before and after the fix,
Dicoms with MONOCHROMEX or YBR_XXX supposed to work before and after fix
-->

### Checklist

#### PR

<!--

-->

- [v] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [v] My code has been well-documented (function documentation, inline comments,
  etc.)

- [N/A] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [N/A] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [Windows 10] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [19.1.0] "Node version: <!--[e.g. 16.14.0]"-->
- [Chrome 115.0.5790.110 ,FF  115.0.2,Edge 115.0.1901.183 ] "Browser:


<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
