### PR TITLE
feat(voiSync): add optoins to turn of invert sync for voisync

### DIFF
--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -1230,13 +1230,13 @@ function createMergedLabelmapForIndex(labelmaps: Array<Types_2.IImageVolume>, se
 function createStackImageSynchronizer(synchronizerName: string): Synchronizer;
 
 // @public (undocumented)
-function createSynchronizer(synchronizerId: string, eventName: string, eventHandler: ISynchronizerEventHandler): Synchronizer;
+function createSynchronizer(synchronizerId: string, eventName: string, eventHandler: ISynchronizerEventHandler, options?: any): Synchronizer;
 
 // @public (undocumented)
 function createToolGroup(toolGroupId: string): IToolGroup | undefined;
 
 // @public (undocumented)
-function createVOISynchronizer(synchronizerName: string): Synchronizer;
+function createVOISynchronizer(synchronizerName: string, options?: VOISynchronizerOptions): Synchronizer;
 
 // @public (undocumented)
 function createZoomPanSynchronizer(synchronizerName: string): Synchronizer;
@@ -2923,7 +2923,7 @@ function isViewportPreScaled(viewport: Types_2.IStackViewport | Types_2.IVolumeV
 // @public (undocumented)
 interface ISynchronizerEventHandler {
     // (undocumented)
-    (synchronizer: Synchronizer, sourceViewport: Types_2.IViewportId, targetViewport: Types_2.IViewportId, sourceEvent: any): void;
+    (synchronizer: Synchronizer, sourceViewport: Types_2.IViewportId, targetViewport: Types_2.IViewportId, sourceEvent: any, options?: any): void;
 }
 
 // @public (undocumented)
@@ -4977,7 +4977,7 @@ enum Swipe {
 
 // @public (undocumented)
 export class Synchronizer {
-    constructor(synchronizerId: string, eventName: string, eventHandler: ISynchronizerEventHandler);
+    constructor(synchronizerId: string, eventName: string, eventHandler: ISynchronizerEventHandler, options?: any);
     // (undocumented)
     add(viewportInfo: Types_2.IViewportId): void;
     // (undocumented)

--- a/packages/dicomImageLoader/.webpack/webpack-base.js
+++ b/packages/dicomImageLoader/.webpack/webpack-base.js
@@ -74,7 +74,7 @@ module.exports = {
         use: {
           loader: 'babel-loader',
           options: {
-            cacheDirectory: true,
+            cacheDirectory: false,
           },
         },
       },

--- a/packages/tools/src/store/SynchronizerManager/Synchronizer.ts
+++ b/packages/tools/src/store/SynchronizerManager/Synchronizer.ts
@@ -22,12 +22,14 @@ class Synchronizer {
   private _sourceViewports: Array<Types.IViewportId>;
   private _targetViewports: Array<Types.IViewportId>;
   private _viewportOptions: Record<string, Record<string, unknown>> = {};
+  private _options: any;
   public id: string;
 
   constructor(
     synchronizerId: string,
     eventName: string,
-    eventHandler: ISynchronizerEventHandler
+    eventHandler: ISynchronizerEventHandler,
+    options?: any
   ) {
     this._enabled = true;
     this._eventName = eventName;
@@ -35,6 +37,7 @@ class Synchronizer {
     this._ignoreFiredEvents = false;
     this._sourceViewports = [];
     this._targetViewports = [];
+    this._options = options || {};
 
     //
     this.id = synchronizerId;
@@ -212,7 +215,13 @@ class Synchronizer {
           continue;
         }
 
-        this._eventHandler(this, sourceViewport, targetViewport, sourceEvent);
+        this._eventHandler(
+          this,
+          sourceViewport,
+          targetViewport,
+          sourceEvent,
+          this._options
+        );
       }
     } catch (ex) {
       console.warn(`Synchronizer, for: ${this._eventName}`, ex);

--- a/packages/tools/src/store/SynchronizerManager/createSynchronizer.ts
+++ b/packages/tools/src/store/SynchronizerManager/createSynchronizer.ts
@@ -9,12 +9,14 @@ import { ISynchronizerEventHandler } from '../../types';
  * synchronizer.
  * @param eventHandler - The event handler that will be
  * called when the event is emitted.
+ * @param options - Options for the synchronizer.
  * @returns A reference to the synchronizer.
  */
 function createSynchronizer(
   synchronizerId: string,
   eventName: string,
-  eventHandler: ISynchronizerEventHandler
+  eventHandler: ISynchronizerEventHandler,
+  options?: any
 ): Synchronizer {
   const synchronizerWithSameIdExists = state.synchronizers.some(
     (sync) => sync.id === synchronizerId
@@ -28,7 +30,8 @@ function createSynchronizer(
   const synchronizer = new Synchronizer(
     synchronizerId,
     eventName,
-    eventHandler
+    eventHandler,
+    options
   );
 
   // Update state

--- a/packages/tools/src/synchronizers/callbacks/voiSyncCallback.ts
+++ b/packages/tools/src/synchronizers/callbacks/voiSyncCallback.ts
@@ -13,12 +13,14 @@ import {
  * @param sourceViewport - The list of IDs defining the source viewport.
  * @param targetViewport - The list of IDs defining the target viewport.
  * @param voiModifiedEvent - The VOI_MODIFIED event.
+ * @param options - Options for the synchronizer.
  */
 export default function voiSyncCallback(
   synchronizerInstance,
   sourceViewport: Types.IViewportId,
   targetViewport: Types.IViewportId,
-  voiModifiedEvent: Types.EventTypes.VoiModifiedEvent
+  voiModifiedEvent: Types.EventTypes.VoiModifiedEvent,
+  options?: any
 ): void {
   const eventDetail = voiModifiedEvent.detail;
   const { volumeId, range, invertStateChanged, invert } = eventDetail;
@@ -37,7 +39,7 @@ export default function voiSyncCallback(
     voiRange: range,
   };
 
-  if (invertStateChanged) {
+  if (options.syncInvertState && invertStateChanged) {
     tProperties.invert = invert;
   }
 

--- a/packages/tools/src/synchronizers/synchronizers/createVOISynchronizer.ts
+++ b/packages/tools/src/synchronizers/synchronizers/createVOISynchronizer.ts
@@ -3,21 +3,30 @@ import { Enums } from '@cornerstonejs/core';
 import voiSyncCallback from '../callbacks/voiSyncCallback';
 import Synchronizer from '../../store/SynchronizerManager/Synchronizer';
 
+type VOISynchronizerOptions = {
+  syncInvertState: boolean;
+};
+
 /**
  * A helper that creates a new `Synchronizer`
  * which listens to the `VOI_MODIFIED` rendering event and calls the `voiSyncCallback`.
  *
  * @param synchronizerName - The name of the synchronizer.
+ * @param options - The options for the synchronizer. By default the voi
+ * synchronizer will also sync the invert state of the volume, but this can be
+ * disabled by setting `syncInvertState` to false.
  *
  * @returns A new `Synchronizer` instance.
  */
 export default function createVOISynchronizer(
-  synchronizerName: string
+  synchronizerName: string,
+  options = { syncInvertState: true } as VOISynchronizerOptions
 ): Synchronizer {
   const VOISynchronizer = createSynchronizer(
     synchronizerName,
     Enums.Events.VOI_MODIFIED,
-    voiSyncCallback
+    voiSyncCallback,
+    options
   );
 
   return VOISynchronizer;

--- a/packages/tools/src/types/ISynchronizerEventHandler.ts
+++ b/packages/tools/src/types/ISynchronizerEventHandler.ts
@@ -6,6 +6,7 @@ export default interface ISynchronizerEventHandler {
     synchronizer: Synchronizer,
     sourceViewport: Types.IViewportId,
     targetViewport: Types.IViewportId,
-    sourceEvent: any
+    sourceEvent: any,
+    options?: any
   ): void;
 }


### PR DESCRIPTION

### Context

VOISyncCallback syncs the invert by default but for some scenarios it should be modifiable (tmtv mode sync between inverted PT and non inverted fusion)

### Changes & Results

adds an option to be able to turn off invert sync

### Testing

tmtv mode right now is broken if you double click anywhere and go back it shows an inverted fusion

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
