### PR TITLE
fix (angle tool): No text box if angle is incomplete/ value is NaN

### DIFF
--- a/packages/tools/src/tools/annotation/AngleTool.ts
+++ b/packages/tools/src/tools/annotation/AngleTool.ts
@@ -817,7 +817,7 @@ class AngleTool extends AnnotationTool {
       );
 
       cachedStats[targetId] = {
-        angle,
+        angle: isNaN(angle) ? 'Incomplete Angle' : angle,
       };
     }
 


### PR DESCRIPTION
### Context

In the angle tool, if a user draws an angle where point 1, 2 or point 2,3 have the same coordinates, the calculated angle value will be NaN because it is impossible to calculate the angle. This causes the textbox not to be visible. It would be helpful to at least have the textbox say "Incomplete Angle" letting them know to adjust their points.

A better fix could be to prevent the creation of such invalid measurements and to prevent adjusting an existing angle to end up in that invalid state.

![bug](https://github.com/cornerstonejs/cornerstone3D/assets/93064150/8ead0828-4f91-40e0-afc9-a2bd1f9fd72e)


### Changes & Results

Modified the  _calculateCachedStats method to set the angle value to be "Incomplete Angle" instead of NaN if the value is NaN.

![In complete angle](https://github.com/cornerstonejs/cornerstone3D/assets/93064150/f3710c0e-e553-4b48-993a-68bda8478bde)


### Testing

- visit -> [OHIF](https://v3-demo.ohif.org/viewer?StudyInstanceUIDs=2.16.840.1.114362.1.11972228.22789312658.616067305.306.2)
- the link above will already open a study. Select the angle tool
- try to draw an angle where the third point is on top of the second point
- If the above is too difficult, draw a normal angle, then try to adjust the points to overlap.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [X] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [X] My code has been well-documented (function documentation, inline comments,
  etc.)

- [X] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [X] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [X] "OS: Windows 10
- [X] "Node version: 18.15.0
- [X] "Browser: Chrome Version 115.0.5790.170 (Official Build) (64-bit)



