### PR TITLE
fix(color): Convert color space for useRGBA false

### DIFF
--- a/packages/dicomImageLoader/src/imageLoader/colorSpaceConverters/convertRGBColorByPlane.ts
+++ b/packages/dicomImageLoader/src/imageLoader/colorSpaceConverters/convertRGBColorByPlane.ts
@@ -29,10 +29,11 @@ export default function (
       colorBuffer[bufferIndex++] = imageFrame[bIndex++]; // blue
       colorBuffer[bufferIndex++] = 255; // alpha
     }
-
-    return;
+  } else {
+    for (let i = 0; i < numPixels; i++) {
+      colorBuffer[bufferIndex++] = imageFrame[rIndex++]; // red
+      colorBuffer[bufferIndex++] = imageFrame[gIndex++]; // green
+      colorBuffer[bufferIndex++] = imageFrame[bIndex++]; // blue
+    }
   }
-
-  // if RGB buffer
-  colorBuffer.set(imageFrame);
 }

--- a/packages/dicomImageLoader/src/imageLoader/convertColorSpace.ts
+++ b/packages/dicomImageLoader/src/imageLoader/convertColorSpace.ts
@@ -24,6 +24,7 @@ function convertYBRFull(imageFrame, colorBuffer, useRGBA) {
 }
 
 export default function convertColorSpace(imageFrame, colorBuffer, useRGBA) {
+  console.log('convertColorSpace', imageFrame, useRGBA);
   // convert based on the photometric interpretation
   if (imageFrame.photometricInterpretation === 'RGB') {
     convertRGB(imageFrame, colorBuffer, useRGBA);

--- a/packages/dicomImageLoader/src/imageLoader/convertColorSpace.ts
+++ b/packages/dicomImageLoader/src/imageLoader/convertColorSpace.ts
@@ -24,7 +24,6 @@ function convertYBRFull(imageFrame, colorBuffer, useRGBA) {
 }
 
 export default function convertColorSpace(imageFrame, colorBuffer, useRGBA) {
-  console.log('convertColorSpace', imageFrame, useRGBA);
   // convert based on the photometric interpretation
   if (imageFrame.photometricInterpretation === 'RGB') {
     convertRGB(imageFrame, colorBuffer, useRGBA);

--- a/packages/dicomImageLoader/src/imageLoader/convertColorSpace.ts
+++ b/packages/dicomImageLoader/src/imageLoader/convertColorSpace.ts
@@ -8,7 +8,6 @@ import {
 } from './colorSpaceConverters/index';
 
 function convertRGB(imageFrame, colorBuffer, useRGBA) {
-  console.log('* convertRGB', imageFrame, useRGBA);
   if (imageFrame.planarConfiguration === 0) {
     convertRGBColorByPixel(imageFrame.pixelData, colorBuffer, useRGBA);
   } else {
@@ -39,6 +38,7 @@ export default function convertColorSpace(imageFrame, colorBuffer, useRGBA) {
   } else if (imageFrame.photometricInterpretation === 'YBR_FULL') {
     convertYBRFull(imageFrame, colorBuffer, useRGBA);
   } else {
+    // TODO - handle YBR_PARTIAL and 420 colour spaces
     throw new Error(
       `No color space conversion for photometric interpretation ${imageFrame.photometricInterpretation}`
     );

--- a/packages/dicomImageLoader/src/imageLoader/convertColorSpace.ts
+++ b/packages/dicomImageLoader/src/imageLoader/convertColorSpace.ts
@@ -8,6 +8,7 @@ import {
 } from './colorSpaceConverters/index';
 
 function convertRGB(imageFrame, colorBuffer, useRGBA) {
+  console.log('* convertRGB', imageFrame, useRGBA);
   if (imageFrame.planarConfiguration === 0) {
     convertRGBColorByPixel(imageFrame.pixelData, colorBuffer, useRGBA);
   } else {

--- a/packages/dicomImageLoader/src/imageLoader/createImage.ts
+++ b/packages/dicomImageLoader/src/imageLoader/createImage.ts
@@ -160,7 +160,6 @@ function createImage(
   return new Promise<DICOMLoaderIImage | ImageFrame>((resolve, reject) => {
     // eslint-disable-next-line complexity
     decodePromise.then(function (imageFrame: ImageFrame) {
-      console.log('decodePromise resolve', imageFrame);
       // if it is desired to skip creating image, return the imageFrame
       // after the decode. This might be useful for some applications
       // that only need the decoded pixel data and not the image object

--- a/packages/dicomImageLoader/src/imageLoader/createImage.ts
+++ b/packages/dicomImageLoader/src/imageLoader/createImage.ts
@@ -283,7 +283,18 @@ function createImage(
           imageFrame.pixelDataLength = imageFrame.pixelData.length;
         } else {
           console.log('Calling convert color space', imageFrame);
+          canvas.height = imageFrame.rows;
+          canvas.width = imageFrame.columns;
+          const context = canvas.getContext('2d');
+          const imageData = context.createImageData(
+            imageFrame.columns,
+            imageFrame.rows
+          );
+
           convertColorSpace(imageFrame, imageData.data, useRGBA);
+          imageFrame.imageData = imageData;
+          imageFrame.pixelData = imageData.data;
+          imageFrame.pixelDataLength = imageData.data.length;
         }
 
         /** @todo check as any */

--- a/packages/dicomImageLoader/src/imageLoader/createImage.ts
+++ b/packages/dicomImageLoader/src/imageLoader/createImage.ts
@@ -22,8 +22,9 @@ import isJPEGBaseline8BitColor from './isJPEGBaseline8BitColor';
  * When using typical decompressors to decompress compressed color images,
  * the resulting output is in RGB or RGBA format. Additionally, these images
  * are in planar configuration 0, meaning they are arranged by plane rather
- * than by color. Consequently, the images only require a transformation from
- * RGBA to RGB without needing to alter the photometric interpretation
+ * than by color.  Consequently, the images only require a transformation from
+ * RGBA to RGB without needing to use the photometric interpretation to convert
+ * to RGB or adjust the planar configuration.
  */
 const TRANSFER_SYNTAX_USING_PHOTOMETRIC_COLOR = {
   '1.2.840.10008.1.2.1': 'application/octet-stream',

--- a/packages/dicomImageLoader/src/imageLoader/createImage.ts
+++ b/packages/dicomImageLoader/src/imageLoader/createImage.ts
@@ -19,14 +19,11 @@ import isColorImageFn from '../shared/isColorImage';
 import isJPEGBaseline8BitColor from './isJPEGBaseline8BitColor';
 
 /**
- * Compressed colour images being decomrpessed by the typical decompressors
- * we are using come out of the decompressor in RGB or RGBA.  As well, they
- * come out in planar configuration 0 (by plane, not by colour), so the images
- * only need the RGBA to RGB transform without any photometric interpretation
- * changes.  However, RLE and other uncompressed syntaxes all need to have
- * the color space transforms applied, so this object defines the set of
- * transfer syntaxes for which the photometric color/planar configuration
- * gets used after the decompressor.
+ * When using typical decompressors to decompress compressed color images,
+ * the resulting output is in RGB or RGBA format. Additionally, these images
+ * are in planar configuration 0, meaning they are arranged by plane rather
+ * than by color. Consequently, the images only require a transformation from
+ * RGBA to RGB without needing to alter the photometric interpretation
  */
 const TRANSFER_SYNTAX_USING_PHOTOMETRIC_COLOR = {
   '1.2.840.10008.1.2.1': 'application/octet-stream',

--- a/packages/dicomImageLoader/src/imageLoader/createImage.ts
+++ b/packages/dicomImageLoader/src/imageLoader/createImage.ts
@@ -257,10 +257,11 @@ function createImage(
           );
 
           imageFrame.pixelDataLength = imageFrame.pixelData.length;
-        } else {
-          // No need to do any conversion - already RGB
-          // Consider RGB to RGBA conversion?
         }
+        // else {
+        // No need to do any conversion - already RGB
+        // Consider RGB to RGBA conversion?
+
         /** @todo check as any */
         // calculate smallest and largest PixelValue of the converted pixelData
         const minMax = getMinMax(imageFrame.pixelData as any);

--- a/packages/dicomImageLoader/src/imageLoader/createImage.ts
+++ b/packages/dicomImageLoader/src/imageLoader/createImage.ts
@@ -214,6 +214,12 @@ function createImage(
       const sopCommonModule: MetadataSopCommonModule =
         cornerstone.metaData.get('sopCommonModule', imageId) || {};
       if (isColorImage) {
+        console.log(
+          '* createImage isColorImage',
+          imageFrame,
+          useRGBA,
+          transferSyntax
+        );
         if (useRGBA) {
           // JPEGBaseline (8 bits) is already returning the pixel data in the right format (rgba)
           // because it's using a canvas to load and decode images.
@@ -244,6 +250,7 @@ function createImage(
             (imageFrame.pixelData.length / 4) * 3
           );
 
+          console.log('* isJPEGBaseline8BitColor', transferSyntax);
           // remove the A from the RGBA of the imageFrame
           imageFrame.pixelData = removeAFromRGBA(
             imageFrame.pixelData,
@@ -274,6 +281,9 @@ function createImage(
             removeAFromRGBA(imageData.data, colorBuffer)
           );
           imageFrame.pixelDataLength = imageFrame.pixelData.length;
+        } else {
+          console.log('Calling convert color space', imageFrame);
+          convertColorSpace(imageFrame, imageData.data, useRGBA);
         }
 
         /** @todo check as any */

--- a/packages/dicomImageLoader/src/imageLoader/decodeImageFrame.ts
+++ b/packages/dicomImageLoader/src/imageLoader/decodeImageFrame.ts
@@ -44,6 +44,7 @@ function decodeImageFrame(
   options = {},
   decodeConfig
 ) {
+  console.log('* decodeImageFrame', imageFrame);
   switch (transferSyntax) {
     case '1.2.840.10008.1.2':
       // Implicit VR Little Endian

--- a/packages/dicomImageLoader/src/imageLoader/decodeImageFrame.ts
+++ b/packages/dicomImageLoader/src/imageLoader/decodeImageFrame.ts
@@ -44,7 +44,6 @@ function decodeImageFrame(
   options = {},
   decodeConfig
 ) {
-  console.log('* decodeImageFrame', imageFrame);
   switch (transferSyntax) {
     case '1.2.840.10008.1.2':
       // Implicit VR Little Endian


### PR DESCRIPTION
Fixes #3354

### Context

The convertColorSpace function wasn't being called consistently or correclty for all situations.
According to the DICOM standard, as best I understand it:
1. The Photometric Interpretation (PMI) is used for uncompressed + RLE encodings
2. For colour images encoded in compressed syntaxes (JPEG, JPEG-LS, JPEG-LOSSLESS, JP2000, HTJ2K), the PMI and Planar Configuration are assumed to be whatever the decompressor provides - which is typically RGB, as the colour space is (usually) encoded in the image.  

This does NOT get 100% of images correct because there can be mismatches between what is encoded and decoded, however, it gets the majority of them correct, and it is really obvious when they are wrong.

### Changes & Results

Consistently use the RGB colour space as the output from compressed images, assuming the decoder takes care of conversion to RGB
Apply RGBA to RGB for RGBA decoders not applying colour space (that is, for JPEG)
Add colour space RGB with RGBA to RGB conversion included

### Testing

Run the test dataset from 
https://github.com/OHIF/Viewers/issues/3354#issuecomment-1669470931
Suggest using the dcm4che toolkit to convert some of these to various encodings
Then use static-dicomweb to store locally (including some unconverted instances)
**** Use a local/udpated version of mkdicomweb as a change was added to fix a bug in conversion

Make sure the images look right (see the original bug issue)

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
