### PR TITLE
Fix an off by 0.5/1 error in window level calculations

### DIFF
--- a/packages/core/examples/webLoader/hardcodedMetaDataProvider.ts
+++ b/packages/core/examples/webLoader/hardcodedMetaDataProvider.ts
@@ -2,7 +2,9 @@
 export default function hardcodedMetaDataProvider(type, imageId, imageIds) {
   const colonIndex = imageId.indexOf(':');
   const scheme = imageId.substring(0, colonIndex);
-  if (scheme !== 'web') return;
+  if (scheme !== 'web') {
+    return;
+  }
 
   if (type === 'imagePixelModule') {
     const imagePixelModule = {
@@ -45,7 +47,11 @@ export default function hardcodedMetaDataProvider(type, imageId, imageIds) {
     return imagePlaneModule;
   } else if (type === 'voiLutModule') {
     return {
-      windowWidth: [255],
+      // According to the DICOM standard, the width is the number of samples
+      // in the input, so 256 samples.
+      windowWidth: [256],
+      // The center is offset by 0.5 to allow for an integer value for even
+      // sample counts
       windowCenter: [128],
     };
   } else if (type === 'modalityLutModule') {

--- a/packages/core/src/RenderingEngine/helpers/cpuFallback/rendering/getVOILut.ts
+++ b/packages/core/src/RenderingEngine/helpers/cpuFallback/rendering/getVOILut.ts
@@ -15,6 +15,10 @@
  */
 
 /**
+ * Generates the linear VOI LUT function.
+ * From the DICOM standard, that is:
+ * ((x - (c - 0.5)) / (w-1) + 0.5) * (ymax- ymin) + ymin
+ * clipped to the ymin...ymax range
  *
  * @param {Number} windowWidth Window Width
  * @param {Number} windowCenter Window Center
@@ -23,7 +27,10 @@
  */
 function generateLinearVOILUT(windowWidth: number, windowCenter: number) {
   return function (modalityLutValue) {
-    return ((modalityLutValue - windowCenter) / windowWidth + 0.5) * 255.0;
+    const value =
+      ((modalityLutValue - (windowCenter - 0.5)) / (windowWidth - 1) + 0.5) *
+      255.0;
+    return Math.min(Math.max(value, 0), 255);
   };
 }
 

--- a/packages/core/src/RenderingEngine/helpers/cpuFallback/rendering/getVOILut.ts
+++ b/packages/core/src/RenderingEngine/helpers/cpuFallback/rendering/getVOILut.ts
@@ -16,7 +16,8 @@
 
 /**
  * Generates the linear VOI LUT function.
- * From the DICOM standard, that is:
+ * From the DICOM standard:
+ * https://dicom.nema.org/medical/dicom/current/output/html/part03.html#sect_C.11.2.1.2.1
  * ((x - (c - 0.5)) / (w-1) + 0.5) * (ymax- ymin) + ymin
  * clipped to the ymin...ymax range
  *

--- a/packages/core/src/RenderingEngine/helpers/cpuFallback/rendering/renderColorImage.ts
+++ b/packages/core/src/RenderingEngine/helpers/cpuFallback/rendering/renderColorImage.ts
@@ -72,10 +72,12 @@ function getRenderCanvas(
   const renderCanvas = enabledElement.renderingTools.renderCanvas;
 
   // The ww/wc is identity and not inverted - get a canvas with the image rendered into it for
-  // Fast drawing
+  // Fast drawing.  Note that this is 256/128, and NOT 255/127, per the DICOM
+  // standard, but allow either.
+  const { windowWidth, windowCenter } = enabledElement.viewport.voi;
   if (
-    enabledElement.viewport.voi.windowWidth === 255 &&
-    enabledElement.viewport.voi.windowCenter === 127 &&
+    (windowWidth === 256 || windowWidth === 255) &&
+    (windowCenter === 128 || windowCenter === 127) &&
     enabledElement.viewport.invert === false &&
     image.getCanvas &&
     image.getCanvas()

--- a/packages/core/src/utilities/windowLevel.ts
+++ b/packages/core/src/utilities/windowLevel.ts
@@ -1,5 +1,8 @@
 /**
  * Given a low and high window level, return the window width and window center
+ * Formulas from note 4 in
+ * https://dicom.nema.org/medical/dicom/current/output/html/part03.html#sect_C.11.2.1.2.1
+ * extended to allow for low/high swapping
  * @param low - The low window level.
  * @param high - The high window level.
  * @returns a JavaScript object with two properties: windowWidth and windowCenter.
@@ -11,14 +14,20 @@ function toWindowLevel(
   windowWidth: number;
   windowCenter: number;
 } {
-  const windowWidth = Math.abs(low - high);
-  const windowCenter = low + windowWidth / 2;
+  // Allow for swapping high/low
+  const windowWidth = Math.abs(high - low) + 1;
+  const windowCenter = (low + high + 1) / 2;
 
   return { windowWidth, windowCenter };
 }
 
 /**
  * Given a window width and center, return the lower and upper bounds of the window
+ * The formulas for the calculation are specified in
+ * https://dicom.nema.org/medical/dicom/current/output/html/part03.html#sect_C.11.2.1.2.1
+ * if (x <= c - 0.5 - (w-1) /2), then y = ymin
+ * else if (x > c - 0.5 + (w-1) /2), then y = ymax
+ * else y = ((x - (c - 0.5)) / (w-1) + 0.5) * (ymax- ymin) + ymin
  * @param windowWidth - the width of the window in HU
  * @param windowCenter - The center of the window.
  * @returns a JavaScript object with two properties: lower and upper.
@@ -30,8 +39,8 @@ function toLowHighRange(
   lower: number;
   upper: number;
 } {
-  const lower = windowCenter - windowWidth / 2.0;
-  const upper = windowCenter + windowWidth / 2.0;
+  const lower = windowCenter - 0.5 - (windowWidth - 1) / 2;
+  const upper = windowCenter - 0.5 + (windowWidth - 1) / 2;
 
   return { lower, upper };
 }

--- a/packages/dicomImageLoader/src/imageLoader/createImage.ts
+++ b/packages/dicomImageLoader/src/imageLoader/createImage.ts
@@ -394,8 +394,10 @@ function createImage(
       }
 
       if (image.color) {
-        image.windowWidth = 255;
-        image.windowCenter = 127;
+        // Note that by the DICOM definition, the window width and center are
+        // 256/128 for an identity transform.
+        image.windowWidth = 256;
+        image.windowCenter = 128;
       }
 
       // set the ww/wc to cover the dynamic range of the image if no values are supplied


### PR DESCRIPTION
### Context

The DICOM standard specifies that the window center is offset by 0.5 and the width to be the count of unique values to map, rather than being (upper+lower)/2 and upper-lower respectively.  This was done to allow for integer values for most
standard window levels for an even number of instances.

### Changes & Results

Change the values for the range.

### Testing

This is hard to test because the change is very subtle - very few images will change at all.  Suggest examining the TG-18 dataset (which is incorporated into the test dataset) for the mapping values being consistent.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
