### PR TITLE
fix sorting priority groups

### DIFF
--- a/packages/core/src/requestPool/requestPoolManager.ts
+++ b/packages/core/src/requestPool/requestPoolManager.ts
@@ -307,7 +307,7 @@ class RequestPoolManager {
     const priorities = Object.keys(this.requestPool[type])
       .map(Number)
       .filter((priority) => this.requestPool[type][priority].length)
-      .sort();
+      .sort((a, b) => a - b);
     return priorities;
   }
 


### PR DESCRIPTION
### Context

There's a bug when negative numbers are used for priorities in RequestPoolManager.

### Changes & Results

Fixed the sort compareFn to resolve the issue.
