### PR TITLE
feat(VolumeViewport): Add reset properties to volume viewport

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -86,6 +86,8 @@ export abstract class BaseVolumeViewport extends Viewport implements IVolumeView
     // (undocumented)
     removeVolumeActors(actorUIDs: Array<string>, immediate?: boolean): void;
     // (undocumented)
+    abstract resetProperties(): void;
+    // (undocumented)
     protected resetVolumeViewportClippingRange(): void;
     // (undocumented)
     abstract setBlendMode(blendMode: BlendModes, filterActorUIDs?: Array<string>, immediate?: boolean): void;
@@ -105,8 +107,6 @@ export abstract class BaseVolumeViewport extends Viewport implements IVolumeView
     static get useCustomRenderingPipeline(): boolean;
     // (undocumented)
     worldToCanvas: (worldPos: Point3) => Point2;
-    // (undocumented)
-    resetProperties(): void;
 }
 
 // @public (undocumented)
@@ -1894,6 +1894,8 @@ interface IVolumeViewport extends IViewport {
     // (undocumented)
     resetCamera(resetPan?: boolean, resetZoom?: boolean, resetToCenter?: boolean): boolean;
     // (undocumented)
+    resetProperties(): void;
+    // (undocumented)
     setBlendMode(blendMode: BlendModes, filterActorUIDs?: Array<string>, immediate?: boolean): void;
     // (undocumented)
     setOrientation(orientation: OrientationAxis): void;
@@ -2887,6 +2889,8 @@ export class VolumeViewport extends BaseVolumeViewport {
     // (undocumented)
     resetCamera(resetPan?: boolean, resetZoom?: boolean, resetToCenter?: boolean): boolean;
     // (undocumented)
+    resetProperties(): void;
+    // (undocumented)
     setBlendMode(blendMode: BlendModes, filterActorUIDs?: any[], immediate?: boolean): void;
     // (undocumented)
     setOrientation(orientation: OrientationAxis, immediate?: boolean): void;
@@ -2894,8 +2898,6 @@ export class VolumeViewport extends BaseVolumeViewport {
     setSlabThickness(slabThickness: number, filterActorUIDs?: any[]): void;
     // (undocumented)
     setVolumes(volumeInputArray: Array<IVolumeInput>, immediate?: boolean, suppressEvents?: boolean): Promise<void>;
-    // (undocumented)
-    resetProperties(): void;
 }
 
 // @public (undocumented)
@@ -2909,6 +2911,8 @@ export class VolumeViewport3D extends BaseVolumeViewport {
     getRotation: () => number;
     // (undocumented)
     resetCamera(resetPan?: boolean, resetZoom?: boolean, resetToCenter?: boolean): boolean;
+    // (undocumented)
+    resetProperties(): void;
     // (undocumented)
     setBlendMode(blendMode: BlendModes, filterActorUIDs?: string[], immediate?: boolean): void;
     // (undocumented)

--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -105,6 +105,8 @@ export abstract class BaseVolumeViewport extends Viewport implements IVolumeView
     static get useCustomRenderingPipeline(): boolean;
     // (undocumented)
     worldToCanvas: (worldPos: Point3) => Point2;
+    // (undocumented)
+    resetProperties(): void;
 }
 
 // @public (undocumented)
@@ -2892,6 +2894,8 @@ export class VolumeViewport extends BaseVolumeViewport {
     setSlabThickness(slabThickness: number, filterActorUIDs?: any[]): void;
     // (undocumented)
     setVolumes(volumeInputArray: Array<IVolumeInput>, immediate?: boolean, suppressEvents?: boolean): Promise<void>;
+    // (undocumented)
+    resetProperties(): void;
 }
 
 // @public (undocumented)

--- a/common/reviews/api/streaming-image-volume-loader.api.md
+++ b/common/reviews/api/streaming-image-volume-loader.api.md
@@ -1303,7 +1303,6 @@ interface IVolumeViewport extends IViewport {
     flip(flipDirection: FlipDirection): void;
     getBounds(): any;
     getCurrentImageId: () => string;
-    resetProperties(): void;
     getCurrentImageIdIndex: () => number;
     // (undocumented)
     getFrameOfReferenceUID: () => string;
@@ -1319,6 +1318,7 @@ interface IVolumeViewport extends IViewport {
     resetZoom?: boolean,
     resetToCenter?: boolean
     ): boolean;
+    resetProperties(): void;
     setBlendMode(
     blendMode: BlendModes,
     filterActorUIDs?: Array<string>,

--- a/common/reviews/api/streaming-image-volume-loader.api.md
+++ b/common/reviews/api/streaming-image-volume-loader.api.md
@@ -1303,6 +1303,7 @@ interface IVolumeViewport extends IViewport {
     flip(flipDirection: FlipDirection): void;
     getBounds(): any;
     getCurrentImageId: () => string;
+    resetProperties(): void;
     getCurrentImageIdIndex: () => number;
     // (undocumented)
     getFrameOfReferenceUID: () => string;

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -3129,7 +3129,6 @@ interface IVolumeViewport extends IViewport {
     getImageData(volumeId?: string): IImageData | undefined;
     getIntensityFromWorld(point: Point3): number;
     getProperties: () => VolumeViewportProperties;
-    resetProperties(): void;
     getSlabThickness(): number;
     hasImageURI: (imageURI: string) => boolean;
     hasVolumeId: (volumeId: string) => boolean;
@@ -3139,6 +3138,7 @@ interface IVolumeViewport extends IViewport {
     resetZoom?: boolean,
     resetToCenter?: boolean
     ): boolean;
+    resetProperties(): void;
     setBlendMode(
     blendMode: BlendModes,
     filterActorUIDs?: Array<string>,

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -3129,6 +3129,7 @@ interface IVolumeViewport extends IViewport {
     getImageData(volumeId?: string): IImageData | undefined;
     getIntensityFromWorld(point: Point3): number;
     getProperties: () => VolumeViewportProperties;
+    resetProperties(): void;
     getSlabThickness(): number;
     hasImageURI: (imageURI: string) => boolean;
     hasVolumeId: (volumeId: string) => boolean;

--- a/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
@@ -1094,6 +1094,8 @@ abstract class BaseVolumeViewport extends Viewport implements IVolumeViewport {
     slabThickness: number,
     filterActorUIDs?: Array<string>
   ): void;
+
+  abstract resetProperties(): void;
 }
 
 export default BaseVolumeViewport;

--- a/packages/core/src/RenderingEngine/VolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/VolumeViewport.ts
@@ -14,7 +14,8 @@ import type {
 import type { ViewportInput } from '../types/IViewport';
 import { actorIsA, getClosestImageId } from '../utilities';
 import BaseVolumeViewport from './BaseVolumeViewport';
-import setDefaultVolumeVOI from './helpers/setDefaultVolumeVOI'
+import setDefaultVolumeVOI from './helpers/setDefaultVolumeVOI';
+import vtkVolume from '@kitware/vtk.js/Rendering/Core/Volume';
 
 /**
  * An object representing a VolumeViewport. VolumeViewports are used to render
@@ -359,13 +360,13 @@ class VolumeViewport extends BaseVolumeViewport {
    */
   public resetProperties(): void {
     this._resetProperties();
-  };
+  }
 
   private _resetProperties() {
     const volumeActor = this.getDefaultActor();
     const imageVolume = cache.getVolume(volumeActor.uid);
-    setDefaultVolumeVOI(volumeActor.actor, imageVolume, false);
-  };
+    setDefaultVolumeVOI(volumeActor.actor as vtkVolume, imageVolume, false);
+  }
 }
 
 export default VolumeViewport;

--- a/packages/core/src/RenderingEngine/VolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/VolumeViewport.ts
@@ -14,6 +14,7 @@ import type {
 import type { ViewportInput } from '../types/IViewport';
 import { actorIsA, getClosestImageId } from '../utilities';
 import BaseVolumeViewport from './BaseVolumeViewport';
+import setDefaultVolumeVOI from './helpers/setDefaultVolumeVOI'
 
 /**
  * An object representing a VolumeViewport. VolumeViewports are used to render
@@ -350,6 +351,21 @@ class VolumeViewport extends BaseVolumeViewport {
   };
 
   getRotation = (): number => 0;
+
+  /**
+   * Reset the viewport properties to the default values
+   *
+   * @returns void
+   */
+  public resetProperties(): void {
+    this._resetProperties();
+  };
+
+  private _resetProperties() {
+    const volumeActor = this.getDefaultActor();
+    const imageVolume = cache.getVolume(volumeActor.uid);
+    setDefaultVolumeVOI(volumeActor.actor, imageVolume, false);
+  };
 }
 
 export default VolumeViewport;

--- a/packages/core/src/RenderingEngine/VolumeViewport3D.ts
+++ b/packages/core/src/RenderingEngine/VolumeViewport3D.ts
@@ -60,6 +60,10 @@ class VolumeViewport3D extends BaseVolumeViewport {
   ): void {
     return null;
   }
+
+  resetProperties(): void {
+    return null;
+  }
 }
 
 export default VolumeViewport3D;

--- a/packages/core/src/types/IVolumeViewport.ts
+++ b/packages/core/src/types/IVolumeViewport.ts
@@ -138,6 +138,8 @@ export default interface IVolumeViewport extends IViewport {
   getImageData(volumeId?: string): IImageData | undefined;
 
   setOrientation(orientation: OrientationAxis): void;
-
-  re
+  /**
+   * Reset the viewport properties to the default values
+   */
+  resetProperties(): void;
 }

--- a/packages/core/src/types/IVolumeViewport.ts
+++ b/packages/core/src/types/IVolumeViewport.ts
@@ -138,4 +138,6 @@ export default interface IVolumeViewport extends IViewport {
   getImageData(volumeId?: string): IImageData | undefined;
 
   setOrientation(orientation: OrientationAxis): void;
+
+  re
 }


### PR DESCRIPTION
### Context

This adds the `resetProperties` method to the `VolumeViewport`. It behaves similarly to the one in `StackViewport`. This will be useful for usage in OHIF or other viewers to reset the view in MPR mode.


### Changes & Results

Added  `resetProperties` to the `VolumeViewport` class, now you can reset the properties for volume views.



### Testing

- clone OHIF locally
- go to `commandModule.js`, in the `resetViewport` method, line 482, add `viewport.resetProperties()` [L478](https://github.com/OHIF/Viewers/blob/fe0ee050ed4236a8a4d58a23410f99165331605c/extensions/cornerstone/src/commandsModule.ts#L478)
- load any study, go into MPR view, modify the window level, then click the reset view tool, it should restore the window to the default value.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [X] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [X] My code has been well-documented (function documentation, inline comments,
  etc.)

- [X] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [X] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [X] "OS: Windows 10
- [X] "Node version: 18.15.0
- [X] "Browser: Chrome Version 115.0.5790.170 (Official Build) (64-bit)


![ezgif com-optimize](https://github.com/cornerstonejs/cornerstone3D/assets/93064150/3d2add48-157c-4d41-856d-e89e17d8779e)

