### PR TITLE
fix(memory leak): array buffer was sticking around because of exception

### DIFF
--- a/packages/core/examples/volumeAPI/index.ts
+++ b/packages/core/examples/volumeAPI/index.ts
@@ -279,10 +279,10 @@ async function run() {
   // Get Cornerstone imageIds and fetch metadata into RAM
   const imageIds = await createImageIdsAndCacheMetaData({
     StudyInstanceUID:
-      '1.3.6.1.4.1.14519.5.2.1.7009.2403.334240657131972136850343327463',
+      '1.3.6.1.4.1.14519.5.2.1.7009.2403.871108593056125491804754960339',
     SeriesInstanceUID:
-      '1.3.6.1.4.1.14519.5.2.1.7009.2403.226151125820845824875394858561',
-    wadoRsRoot: 'https://d3t6nz73ql33tx.cloudfront.net/dicomweb',
+      '1.3.6.1.4.1.14519.5.2.1.7009.2403.367700692008930469189923116409',
+    wadoRsRoot: 'https://d33do7qe4w26qo.cloudfront.net/dicomweb',
   });
 
   // Instantiate a rendering engine

--- a/packages/core/src/cache/classes/ImageVolume.ts
+++ b/packages/core/src/cache/classes/ImageVolume.ts
@@ -151,12 +151,12 @@ export class ImageVolume implements IImageVolume {
    */
   destroy(): void {
     // TODO: GPU memory associated with volume is not cleared.
-    this.vtkOpenGLTexture.releaseGraphicsResources();
-    this.vtkOpenGLTexture.destroyTexture();
-    this.vtkOpenGLTexture.delete();
     this.imageData.delete();
     this.imageData = null;
     this.scalarData = null;
+
+    this.vtkOpenGLTexture.releaseGraphicsResources();
+    this.vtkOpenGLTexture.delete();
   }
 }
 


### PR DESCRIPTION


### Context

purge cache was not freeing up memory since the deactivate texture calls had an exception which caused the scalardata to hang around

### Changes & Results

re-order the destroy calls


### Testing

after
![CleanShot 2023-08-21 at 18 41 38](https://github.com/cornerstonejs/cornerstone3D/assets/7490180/468fd4ed-4c63-4ca8-aaca-59c8aae02acb)

Before 
![CleanShot 2023-08-21 at 18 44 00](https://github.com/cornerstonejs/cornerstone3D/assets/7490180/f15ca7fc-ac39-42db-9420-2db79398a08b)

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
