### PR TITLE
fix(4D utility): wrong array type returned by getDataInTime

### DIFF
--- a/packages/tools/src/utilities/dynamicVolume/getDataInTime.ts
+++ b/packages/tools/src/utilities/dynamicVolume/getDataInTime.ts
@@ -40,7 +40,6 @@ function getDataInTime(
 
   if (options.maskVolumeId) {
     const segmentationVolume = cache.getVolume(options.maskVolumeId);
-    const startTime = performance.now();
     const segScalarData = segmentationVolume.getScalarData();
     const indexArray = [];
 
@@ -50,9 +49,6 @@ function getDataInTime(
         indexArray.push(i);
       }
     }
-
-    // eslint-disable-next-line
-    console.log('>>>>> total time: ', performance.now() - startTime);
 
     const dataInTime = _getTimePointDataMask(frames, indexArray, dynamicVolume);
 

--- a/packages/tools/src/utilities/dynamicVolume/getDataInTime.ts
+++ b/packages/tools/src/utilities/dynamicVolume/getDataInTime.ts
@@ -40,13 +40,20 @@ function getDataInTime(
 
   if (options.maskVolumeId) {
     const segmentationVolume = cache.getVolume(options.maskVolumeId);
+    const startTime = performance.now();
+    const segScalarData = segmentationVolume.getScalarData();
+    const indexArray = [];
 
-    // Get the index of every non-zero voxel in mask by mapping indexes to
-    // new array, then using the array to filter
-    const indexArray = segmentationVolume
-      .getScalarData()
-      .map((_, i) => i)
-      .filter((i) => segmentationVolume.getScalarData()[i] !== 0);
+    // Get the index of every non-zero voxel in mask
+    for (let i = 0, len = segScalarData.length; i < len; i++) {
+      if (segScalarData[i] !== 0) {
+        indexArray.push(i);
+      }
+    }
+
+    // eslint-disable-next-line
+    console.log('>>>>> total time: ', performance.now() - startTime);
+
     const dataInTime = _getTimePointDataMask(frames, indexArray, dynamicVolume);
 
     return dataInTime;


### PR DESCRIPTION
Since `segmentationVolume` is an `Uint8Array` and the type returned by a `map` function is exaclty the same which made  `indexArray` array to be an `Uint8Array` but that type of array may not have values greater than 255 breaking all pixel indexes returned.