### PR TITLE
fix(modifier key): reset modifier keys when browser tab loses focus/is hidden

### DIFF
--- a/packages/tools/src/eventListeners/keyboard/keyDownListener.ts
+++ b/packages/tools/src/eventListeners/keyboard/keyDownListener.ts
@@ -64,9 +64,21 @@ function keyListener(evt: KeyboardEvent): void {
   triggerEvent(eventDetail.element, Events.KEY_DOWN, eventDetail);
 
   document.addEventListener('keyup', _onKeyUp);
+  document.addEventListener('visibilitychange', _onVisibilityChange);
 
   // Todo: handle combination of keys
   state.element.removeEventListener('keydown', keyListener);
+}
+
+/**
+ * Whenever the visibility (i.e. tab focus) changes such that the tab is NOT the
+ * active tab, reset the modifier key.
+ */
+function _onVisibilityChange(): void {
+  document.removeEventListener('visibilitychange', _onVisibilityChange);
+  if (document.visibilityState === 'hidden') {
+    resetModifierKey();
+  }
 }
 
 function _onKeyUp(evt: KeyboardEvent): void {
@@ -81,6 +93,7 @@ function _onKeyUp(evt: KeyboardEvent): void {
 
   // Remove our temporary handlers
   document.removeEventListener('keyup', _onKeyUp);
+  document.removeEventListener('visibilitychange', _onVisibilityChange);
   state.element.addEventListener('keydown', keyListener);
 
   // Restore `state` to `defaultState`


### PR DESCRIPTION

<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

Fixes CS3D issue #733.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

In `packages\tools\src\eventListeners\keyboard\keyDownListener.ts`, reset the modifier key whenever the browser tab is 'hidden' (i.e. loses focus). Prior to this PR, the modifier key for changing tab (e.g. Ctrl) or app (e.g. Alt) focus would remain in the modifier key state and was never cleared until a subsequent key-up event.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

First and foremost, ensure issue #733 is resolved.

Test A:
1. Run the `doubleClickWithStackAnnotationTools` example.
2. Add various annotations.
3. Either `Ctrl-tab` or `Alt-tab` to change the tab/app focus.
4. In the destination app/window/tab perform some mouse clicks/wheels and/or key strokes.
5. Return to the tab running the example.
6. One should still be able to add and edit annotations.

Test B:
1. Run the `modifierkeys` example.
2. Exercise the various aspects of the example.
3. Either `Ctrl-tab` or `Alt-tab` to change the tab/app focus.
4. In the destination window/tab perform some mouse clicks/wheels and/or key strokes.
5. Return to the tab running the example.
6. The example should continue to behave as before.

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Windows 11<!--[e.g. Windows 10, macOS 10.15.4]"-->
- [x] "Node version: 16.14.0<!--[e.g. 16.14.0]"-->
- [x] "Browser: Chrome 116.0.5845.111
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
