### PR TITLE
feat(brush): update data only once when Brush interaction is done

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -94,7 +94,7 @@ export abstract class BaseVolumeViewport extends Viewport implements IVolumeView
     // (undocumented)
     setOrientation(orientation: OrientationAxis, immediate?: boolean): void;
     // (undocumented)
-    setProperties({ voiRange, VOILUTFunction, invert, colormap, preset, }?: VolumeViewportProperties, volumeId?: string, suppressEvents?: boolean): void;
+    setProperties({ voiRange, VOILUTFunction, invert, colormap, preset, interpolationType, }?: VolumeViewportProperties, volumeId?: string, suppressEvents?: boolean): void;
     // (undocumented)
     abstract setSlabThickness(slabThickness: number, filterActorUIDs?: Array<string>): void;
     // (undocumented)
@@ -2738,6 +2738,7 @@ type ViewportProperties = {
     voiRange?: VOIRange;
     VOILUTFunction?: VOILUTFunctionType;
     invert?: boolean;
+    interpolationType?: InterpolationType;
 };
 
 // @public (undocumented)

--- a/common/reviews/api/streaming-image-volume-loader.api.md
+++ b/common/reviews/api/streaming-image-volume-loader.api.md
@@ -1343,6 +1343,7 @@ interface IVolumeViewport extends IViewport {
     // (undocumented)
     useCPURendering: boolean;
     worldToCanvas: (worldPos: Point3) => Point2;
+
 }
 
 // @public
@@ -1611,6 +1612,7 @@ type ViewportProperties = {
     voiRange?: VOIRange;
     VOILUTFunction?: VOILUTFunctionType;
     invert?: boolean;
+    interpolationType?: InterpolationType;
 };
 
 // @public (undocumented)

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -562,12 +562,34 @@ declare namespace boundingBox {
 type BoundsIJK = [Types_2.Point2, Types_2.Point2, Types_2.Point2];
 
 // @public (undocumented)
-export class BrushTool extends BaseTool {
+interface BrushCursor extends Annotation {
+    // (undocumented)
+    data: {
+        handles: {
+            points: [Types_2.Point3];
+        };
+    };
+}
+
+// @public (undocumented)
+export class BrushTool extends AnnotationTool {
     constructor(toolProps?: PublicToolProps, defaultToolProps?: ToolProps);
+    // (undocumented)
+    addNewAnnotation: (evt: EventTypes_2.MouseDownActivateEventType) => BrushCursor;
+    // (undocumented)
+    cancel: () => void;
+    // (undocumented)
+    handleSelectedCallback: () => void;
     // (undocumented)
     invalidateBrushCursor(): void;
     // (undocumented)
-    mouseMoveCallback: (evt: EventTypes_2.InteractionEventType) => void;
+    isPointNearTool(): boolean;
+    // (undocumented)
+    mouseMoveCallback: (evt: EventTypes_2.MouseMoveEventType) => boolean;
+    // (undocumented)
+    onSetConfiguration: () => void;
+    // (undocumented)
+    onSetToolActive: () => void;
     // (undocumented)
     onSetToolDisabled: () => void;
     // (undocumented)
@@ -575,11 +597,11 @@ export class BrushTool extends BaseTool {
     // (undocumented)
     onSetToolPassive: () => void;
     // (undocumented)
-    preMouseDownCallback: (evt: EventTypes_2.MouseDownActivateEventType) => boolean;
-    // (undocumented)
-    renderAnnotation(enabledElement: Types_2.IEnabledElement, svgDrawingHelper: SVGDrawingHelper): void;
+    renderAnnotation(enabledElement: Types_2.IEnabledElement, svgDrawingHelper: SVGDrawingHelper): boolean;
     // (undocumented)
     static toolName: any;
+    // (undocumented)
+    toolSelectedCallback: () => void;
 }
 
 // @public (undocumented)
@@ -3163,6 +3185,7 @@ interface IVolumeViewport extends IViewport {
     // (undocumented)
     useCPURendering: boolean;
     worldToCanvas: (worldPos: Point3) => Point2;
+
 }
 
 // @public (undocumented)
@@ -5143,7 +5166,8 @@ declare namespace ToolSpecificAnnotationTypes {
         AngleAnnotation,
         ReferenceCursor,
         ReferenceLineAnnotation,
-        ScaleOverlayAnnotation
+        ScaleOverlayAnnotation,
+        BrushCursor
     }
 }
 
@@ -5449,6 +5473,7 @@ type ViewportProperties = {
     voiRange?: VOIRange;
     VOILUTFunction?: VOILUTFunctionType;
     invert?: boolean;
+    interpolationType?: InterpolationType;
 };
 
 declare namespace visibility {

--- a/packages/adapters/examples/segmentationExport/index.ts
+++ b/packages/adapters/examples/segmentationExport/index.ts
@@ -14,8 +14,10 @@ import {
     createImageIdsAndCacheMetaData
 } from "../../../../utils/demo/helpers";
 import * as cornerstoneTools from "@cornerstonejs/tools";
-import { adaptersSEG } from "@cornerstonejs/adapters";
+import { adaptersSEG, helpers } from "@cornerstonejs/adapters";
 import dcmjs from "dcmjs";
+
+const { downloadDICOMData } = helpers;
 
 // This is for debugging purposes
 console.warn(
@@ -130,15 +132,14 @@ addButtonToToolbar({
             labelmapObj.metadata[segmentIndex] = segmentMetadata;
         });
 
-        const segBlob = Cornerstone3D.Segmentation.generateSegmentation(
-            images,
-            labelmapObj,
-            metaData
-        );
+        const generatedSegmentation =
+            Cornerstone3D.Segmentation.generateSegmentation(
+                images,
+                labelmapObj,
+                metaData
+            );
 
-        //Create a URL for the binary.
-        const objectUrl = URL.createObjectURL(segBlob);
-        window.open(objectUrl);
+        downloadDICOMData(generatedSegmentation.dataset, "mySEG.dcm");
     }
 });
 

--- a/packages/adapters/src/adapters/Cornerstone/Segmentation_4X.js
+++ b/packages/adapters/src/adapters/Cornerstone/Segmentation_4X.js
@@ -7,7 +7,6 @@ import {
 } from "dcmjs";
 import ndarray from "ndarray";
 import cloneDeep from "lodash.clonedeep";
-import { Buffer } from "buffer";
 
 import { Events } from "../enums";
 
@@ -19,8 +18,7 @@ const {
     nearlyEqual
 } = utilities.orientation;
 
-const { datasetToDict, BitArray, DicomMessage, DicomMetaDictionary } =
-    dcmjsData;
+const { BitArray, DicomMessage, DicomMetaDictionary } = dcmjsData;
 
 const { Normalizer } = normalizers;
 const { Segmentation: SegmentationDerivation } = derivations;
@@ -61,12 +59,13 @@ function generateSegmentation(images, inputLabelmaps3D, userOptions = {}) {
 }
 
 /**
- * fillSegmentation - Fills a derived segmentation dataset with cornerstoneTools `LabelMap3D` data.
+ * Fills a given segmentation object with data from the input labelmaps3D
  *
- * @param  {object[]} segmentation An empty segmentation derived dataset.
- * @param  {Object|Object[]} inputLabelmaps3D The cornerstone `Labelmap3D` object, or an array of objects.
- * @param  {Object} userOptions Options object to override default options.
- * @returns {Blob}           description
+ * @param segmentation - The segmentation object to be filled.
+ * @param inputLabelmaps3D - An array of 3D labelmaps, or a single 3D labelmap.
+ * @param userOptions - Optional configuration settings. Will override the default options.
+ *
+ * @returns {object} The filled segmentation object.
  */
 function fillSegmentation(segmentation, inputLabelmaps3D, userOptions = {}) {
     const options = Object.assign(

--- a/packages/adapters/src/adapters/Cornerstone/Segmentation_4X.js
+++ b/packages/adapters/src/adapters/Cornerstone/Segmentation_4X.js
@@ -191,10 +191,7 @@ function fillSegmentation(segmentation, inputLabelmaps3D, userOptions = {}) {
         segmentation.bitPackPixelData();
     }
 
-    const buffer = Buffer.from(datasetToDict(segmentation.dataset).write());
-    const segBlob = new Blob([buffer], { type: "application/dicom" });
-
-    return segBlob;
+    return segmentation;
 }
 
 function _getLabelmapsFromReferencedFrameIndicies(

--- a/packages/adapters/src/adapters/Cornerstone3D/Segmentation/generateSegmentation.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/Segmentation/generateSegmentation.ts
@@ -10,7 +10,7 @@ const { Segmentation: SegmentationDerivation } = derivations;
  * @param images - An array of the cornerstone image objects, which includes imageId and metadata
  * @param labelmaps - An array of the 3D Volumes that contain the segmentation data.
  */
-function generateSegmentation(images, labelmaps, metadata, options) {
+function generateSegmentation(images, labelmaps, metadata, options = {}) {
     const segmentation = _createMultiframeSegmentationFromReferencedImages(
         images,
         metadata,
@@ -41,8 +41,8 @@ function _createMultiframeSegmentationFromReferencedImages(
             ...image,
             ...instance,
             // Todo: move to dcmjs tag style
-            SOPClassUID: instance.SopClassUID,
-            SOPInstanceUID: instance.SopInstanceUID,
+            SOPClassUID: instance.SopClassUID || instance.SOPClassUID,
+            SOPInstanceUID: instance.SopInstanceUID || instance.SOPInstanceUID,
             PixelData: image.getPixelData(),
             _vrMap: {
                 PixelData: "OW"

--- a/packages/adapters/src/adapters/helpers/downloadDICOMData.ts
+++ b/packages/adapters/src/adapters/helpers/downloadDICOMData.ts
@@ -1,0 +1,35 @@
+import { data } from "dcmjs";
+import { Buffer } from "buffer";
+const { datasetToDict } = data;
+
+interface DicomDataset {
+    _meta?: any;
+    // other properties
+}
+
+/**
+ * Trigger file download from an array buffer
+ * @param bufferOrDataset - ArrayBuffer or DicomDataset
+ * @param filename - name of the file to download
+ */
+export function downloadDICOMData(
+    bufferOrDataset: ArrayBuffer | DicomDataset,
+    filename: string
+) {
+    let blob;
+    if (bufferOrDataset instanceof ArrayBuffer) {
+        blob = new Blob([bufferOrDataset], { type: "application/dicom" });
+    } else {
+        if (!bufferOrDataset._meta) {
+            throw new Error("Dataset must have a _meta property");
+        }
+
+        const buffer = Buffer.from(datasetToDict(bufferOrDataset).write());
+        blob = new Blob([buffer], { type: "application/dicom" });
+    }
+
+    const link = document.createElement("a");
+    link.href = window.URL.createObjectURL(blob);
+    link.download = filename;
+    link.click();
+}

--- a/packages/adapters/src/adapters/helpers/index.ts
+++ b/packages/adapters/src/adapters/helpers/index.ts
@@ -1,5 +1,6 @@
 import { toArray } from "./toArray";
 import { codeMeaningEquals } from "./codeMeaningEquals";
 import { graphicTypeEquals } from "./graphicTypeEquals";
+import { downloadDICOMData } from "./downloadDICOMData";
 
-export { toArray, codeMeaningEquals, graphicTypeEquals };
+export { toArray, codeMeaningEquals, graphicTypeEquals, downloadDICOMData };

--- a/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
@@ -12,6 +12,7 @@ import {
 import {
   BlendModes,
   Events,
+  InterpolationType,
   OrientationAxis,
   ViewportStatus,
   VOILUTFunctionType,
@@ -367,6 +368,23 @@ abstract class BaseVolumeViewport extends Viewport implements IVolumeViewport {
     return newRGBTransferFunction;
   }
 
+  private setInterpolationType(
+    interpolationType: InterpolationType,
+    volumeId?: string
+  ) {
+    const applicableVolumeActorInfo = this._getApplicableVolumeActor(volumeId);
+
+    if (!applicableVolumeActorInfo) {
+      return;
+    }
+
+    const { volumeActor } = applicableVolumeActorInfo;
+    const volumeProperty = volumeActor.getProperty();
+
+    // @ts-ignore
+    volumeProperty.setInterpolationType(interpolationType);
+  }
+
   /**
    * Sets the properties for the volume viewport on the volume
    * (if fusion, it sets it for the first volume in the fusion)
@@ -449,6 +467,7 @@ abstract class BaseVolumeViewport extends Viewport implements IVolumeViewport {
       invert,
       colormap,
       preset,
+      interpolationType,
     }: VolumeViewportProperties = {},
     volumeId?: string,
     suppressEvents = false
@@ -465,6 +484,10 @@ abstract class BaseVolumeViewport extends Viewport implements IVolumeViewport {
 
     if (voiRange !== undefined) {
       this.setVOI(voiRange, volumeId, suppressEvents);
+    }
+
+    if (typeof interpolationType !== 'undefined') {
+      this.setInterpolationType(interpolationType);
     }
 
     if (VOILUTFunction !== undefined) {

--- a/packages/core/src/types/ViewportProperties.ts
+++ b/packages/core/src/types/ViewportProperties.ts
@@ -1,4 +1,4 @@
-import { VOILUTFunctionType } from '../enums';
+import { InterpolationType, VOILUTFunctionType } from '../enums';
 import { VOIRange } from './voi';
 
 /**
@@ -11,6 +11,8 @@ type ViewportProperties = {
   VOILUTFunction?: VOILUTFunctionType;
   /** invert flag - whether the image is inverted */
   invert?: boolean;
+  /** interpolation type */
+  interpolationType?: InterpolationType;
 };
 
 export type { ViewportProperties };

--- a/packages/dicomImageLoader/src/imageLoader/wadouri/metaData/metaDataProvider.ts
+++ b/packages/dicomImageLoader/src/imageLoader/wadouri/metaData/metaDataProvider.ts
@@ -243,10 +243,10 @@ function metaDataProvider(type, imageId) {
 
   if (type === 'petImageModule') {
     return {
-      frameReferenceTime: dicomParser.floatString(
+      frameReferenceTime: dataSet.floatString(
         dataSet.string('x00541300') || ''
       ),
-      actualFrameDuration: dicomParser.intString(dataSet.string('x00181242')),
+      actualFrameDuration: dataSet.intString(dataSet.string('x00181242')),
     };
   }
 

--- a/packages/tools/examples/stackToVolumeWithAnnotations/_setViewports.ts
+++ b/packages/tools/examples/stackToVolumeWithAnnotations/_setViewports.ts
@@ -66,6 +66,8 @@ async function _convertStackToVolumeViewport(
 
   const { id, element } = viewport;
 
+  const prevCamera = viewport.getCamera();
+
   let imageIds = viewport.getImageIds();
   imageIds = imageIds.map((imageId) => {
     const imageURI = utilities.imageIdToURI(imageId);
@@ -78,7 +80,6 @@ async function _convertStackToVolumeViewport(
       type: ViewportType.ORTHOGRAPHIC,
       element,
       defaultOptions: {
-        orientation: Enums.OrientationAxis.SAGITTAL,
         background: <Types.Point3>[0.2, 0.4, 0.2],
       },
     },
@@ -98,11 +99,27 @@ async function _convertStackToVolumeViewport(
 
   // Set the volume to load
   volume.load();
+  const volumeViewport = <Types.IVolumeViewport>renderingEngine.getViewport(id);
 
-  setVolumesForViewports(renderingEngine, [{ volumeId }], [id]);
+  setVolumesForViewports(
+    renderingEngine,
+    [
+      {
+        volumeId,
+      },
+    ],
+    [id]
+  );
 
-  // Render the image
-  renderingEngine.renderViewports([id]);
+  // preserve the slice location when switching from stack to volume
+  element.addEventListener(Enums.Events.VOLUME_VIEWPORT_NEW_VOLUME, () => {
+    volumeViewport.setCamera({
+      focalPoint: prevCamera.focalPoint,
+    });
+    volumeViewport.render();
+  });
+
+  volumeViewport.render();
 }
 
 export { _convertStackToVolumeViewport, _convertVolumeToStackViewport };

--- a/packages/tools/src/drawingSvg/drawCircle.ts
+++ b/packages/tools/src/drawingSvg/drawCircle.ts
@@ -15,13 +15,23 @@ function drawCircle(
   options = {},
   dataId = ''
 ): void {
-  const { color, fill, width, lineWidth, lineDash } = Object.assign(
+  const {
+    color,
+    fill,
+    width,
+    lineWidth,
+    lineDash,
+    fillOpacity,
+    strokeOpacity,
+  } = Object.assign(
     {
       color: 'dodgerblue',
       fill: 'transparent',
       width: '2',
       lineDash: undefined,
       lineWidth: undefined,
+      strokeOpacity: 1,
+      fillOpacity: 1,
     },
     options
   );
@@ -42,6 +52,8 @@ function drawCircle(
     fill,
     'stroke-width': strokeWidth,
     'stroke-dasharray': lineDash,
+    'fill-opacity': fillOpacity, // setting fill opacity
+    'stroke-opacity': strokeOpacity, // setting stroke opacity
   };
 
   if (existingCircleElement) {

--- a/packages/tools/src/tools/base/AnnotationTool.ts
+++ b/packages/tools/src/tools/base/AnnotationTool.ts
@@ -185,24 +185,26 @@ abstract class AnnotationTool extends AnnotationDisplayTool {
 
     const { data } = annotation;
     const { points, textBox } = data.handles;
-    const { worldBoundingBox } = textBox;
 
-    if (worldBoundingBox) {
-      const canvasBoundingBox = {
-        topLeft: viewport.worldToCanvas(worldBoundingBox.topLeft),
-        topRight: viewport.worldToCanvas(worldBoundingBox.topRight),
-        bottomLeft: viewport.worldToCanvas(worldBoundingBox.bottomLeft),
-        bottomRight: viewport.worldToCanvas(worldBoundingBox.bottomRight),
-      };
+    if (textBox) {
+      const { worldBoundingBox } = textBox;
+      if (worldBoundingBox) {
+        const canvasBoundingBox = {
+          topLeft: viewport.worldToCanvas(worldBoundingBox.topLeft),
+          topRight: viewport.worldToCanvas(worldBoundingBox.topRight),
+          bottomLeft: viewport.worldToCanvas(worldBoundingBox.bottomLeft),
+          bottomRight: viewport.worldToCanvas(worldBoundingBox.bottomRight),
+        };
 
-      if (
-        canvasCoords[0] >= canvasBoundingBox.topLeft[0] &&
-        canvasCoords[0] <= canvasBoundingBox.bottomRight[0] &&
-        canvasCoords[1] >= canvasBoundingBox.topLeft[1] &&
-        canvasCoords[1] <= canvasBoundingBox.bottomRight[1]
-      ) {
-        data.handles.activeHandleIndex = null;
-        return textBox;
+        if (
+          canvasCoords[0] >= canvasBoundingBox.topLeft[0] &&
+          canvasCoords[0] <= canvasBoundingBox.bottomRight[0] &&
+          canvasCoords[1] >= canvasBoundingBox.topLeft[1] &&
+          canvasCoords[1] <= canvasBoundingBox.bottomRight[1]
+        ) {
+          data.handles.activeHandleIndex = null;
+          return textBox;
+        }
       }
     }
 

--- a/packages/tools/src/tools/segmentation/BrushTool.ts
+++ b/packages/tools/src/tools/segmentation/BrushTool.ts
@@ -237,6 +237,7 @@ class BrushTool extends AnnotationTool {
     const centerCanvas = currentPoints.canvas;
     const enabledElement = getEnabledElement(element);
     const { renderingEngine, viewport } = enabledElement;
+    const { viewPlaneNormal, viewUp } = viewport.getCamera();
 
     let annotation = getAnnotation('brushCursorUID');
     if (!drag && !annotation) {
@@ -247,6 +248,12 @@ class BrushTool extends AnnotationTool {
       annotation.data.handles.points = [
         ...this._calculateBrushLocation(viewport, currentPoints.canvas),
       ];
+
+      // Update the camera props since we might have changed the cursor location
+      // and have been moving to a new viewport with different orientation without
+      // dragging or clicking
+      annotation.metadata.viewUp = viewUp;
+      annotation.metadata.viewPlaneNormal = viewPlaneNormal;
       annotation.data.invalidated = false;
     }
 
@@ -456,7 +463,6 @@ class BrushTool extends AnnotationTool {
     const { element } = viewport;
 
     const viewportIdsToRender = this._hoverData.viewportIdsToRender;
-
     if (!viewportIdsToRender.includes(viewport.id)) {
       return;
     }
@@ -478,10 +484,11 @@ class BrushTool extends AnnotationTool {
 
     const annotation = annotations[0];
 
+    // If brush size programmatically has been changed then we need to invalidate
+    // the cursor points to be recalculated for the rendering
     if (annotation.data.invalidated === true) {
       const { centerCanvas } = this._hoverData;
-      // This can be set true when changing the brush size programmatically
-      // whilst the cursor is being rendered.
+
       this._calculateBrushLocation(viewport, centerCanvas);
     }
 

--- a/packages/tools/src/tools/segmentation/strategies/eraseCircle.ts
+++ b/packages/tools/src/tools/segmentation/strategies/eraseCircle.ts
@@ -10,6 +10,7 @@ type OperationData = {
   segmentIndex: number;
   segmentsLocked: number[];
   viewPlaneNormal: number[];
+  lazyCalculation?: boolean;
   viewUp: number[];
   strategySpecificConfiguration: any;
   constraintFn: () => boolean;

--- a/packages/tools/src/tools/segmentation/strategies/fillCircle.ts
+++ b/packages/tools/src/tools/segmentation/strategies/fillCircle.ts
@@ -16,7 +16,7 @@ type OperationData = {
   segmentationId: string;
   imageVolume: Types.IImageVolume;
   points: any;
-  lazyCalculation: boolean;
+  lazyCalculation?: boolean;
   volume: Types.IImageVolume;
   segmentIndex: number;
   segmentsLocked: number[];

--- a/packages/tools/src/tools/segmentation/strategies/fillCircle.ts
+++ b/packages/tools/src/tools/segmentation/strategies/fillCircle.ts
@@ -15,7 +15,8 @@ const { transformWorldToIndex } = csUtils;
 type OperationData = {
   segmentationId: string;
   imageVolume: Types.IImageVolume;
-  points: any; // Todo:fix
+  points: any;
+  lazyCalculation: boolean;
   volume: Types.IImageVolume;
   segmentIndex: number;
   segmentsLocked: number[];
@@ -24,6 +25,35 @@ type OperationData = {
   strategySpecificConfiguration: any;
   constraintFn: () => boolean;
 };
+
+function calculateEllipseAndBounds(points, viewport, imageData, dimensions) {
+  const center = vec3.fromValues(0, 0, 0);
+  points.forEach((point) => vec3.add(center, center, point));
+  vec3.scale(center, center, 1 / points.length);
+
+  const canvasCoordinates = points.map((p) => viewport.worldToCanvas(p));
+  const [topLeftCanvas, bottomRightCanvas] =
+    getCanvasEllipseCorners(canvasCoordinates);
+
+  const topLeftWorld = viewport.canvasToWorld(topLeftCanvas);
+  const bottomRightWorld = viewport.canvasToWorld(bottomRightCanvas);
+
+  const ellipsoidCornersIJK = [
+    <Types.Point3>transformWorldToIndex(imageData, topLeftWorld),
+    <Types.Point3>transformWorldToIndex(imageData, bottomRightWorld),
+  ];
+
+  const boundsIJK = getBoundingBoxAroundShape(ellipsoidCornersIJK, dimensions);
+
+  const ellipseObj = {
+    center: center as Types.Point3,
+    xRadius: Math.abs(topLeftWorld[0] - bottomRightWorld[0]) / 2,
+    yRadius: Math.abs(topLeftWorld[1] - bottomRightWorld[1]) / 2,
+    zRadius: Math.abs(topLeftWorld[2] - bottomRightWorld[2]) / 2,
+  };
+
+  return { ellipseObj, boundsIJK };
+}
 
 function fillCircle(
   enabledElement: Types.IEnabledElement,
@@ -38,83 +68,56 @@ function fillCircle(
     segmentIndex,
     segmentationId,
     strategySpecificConfiguration,
+    lazyCalculation,
   } = operationData;
   const { imageData, dimensions } = segmentationVolume;
   const scalarData = segmentationVolume.getScalarData();
   const { viewport } = enabledElement;
 
-  // Average the points to get the center of the ellipse
-  const center = vec3.fromValues(0, 0, 0);
   const modifiedSlicesToUse = new Set() as Set<number>;
+  const indicesToFill = new Set() as Set<number>;
 
-  points?.map((points) => {
-    points.forEach((point) => {
-      vec3.add(center, center, point);
-    });
-    vec3.scale(center, center, 1 / points.length);
+  function callback({ value, index, pointIJK }) {
+    if (segmentsLocked.includes(value)) {
+      return;
+    }
+    if (
+      !threshold ||
+      isWithinThreshold(index, imageVolume, strategySpecificConfiguration)
+    ) {
+      indicesToFill.add(index);
+      modifiedSlicesToUse.add(pointIJK[2]);
+    }
+  }
 
-    const canvasCoordinates = points.map((p) => viewport.worldToCanvas(p));
+  let pointsChunks;
+  if (lazyCalculation) {
+    pointsChunks = [];
+    for (let i = 0; i < points.length; i += 4) {
+      pointsChunks.push(points.slice(i, i + 4));
+    }
+  } else {
+    pointsChunks = [points];
+  }
 
-    // 1. From the drawn tool: Get the ellipse (circle) topLeft and bottomRight
-    // corners in canvas coordinates
-    const [topLeftCanvas, bottomRightCanvas] =
-      getCanvasEllipseCorners(canvasCoordinates);
-
-    // 2. Find the extent of the ellipse (circle) in IJK index space of the image
-    const topLeftWorld = viewport.canvasToWorld(topLeftCanvas);
-    const bottomRightWorld = viewport.canvasToWorld(bottomRightCanvas);
-
-    const ellipsoidCornersIJK = [
-      <Types.Point3>transformWorldToIndex(imageData, topLeftWorld),
-      <Types.Point3>transformWorldToIndex(imageData, bottomRightWorld),
-    ];
-
-    const boundsIJK = getBoundingBoxAroundShape(
-      ellipsoidCornersIJK,
+  for (let i = 0; i < pointsChunks.length; i++) {
+    const pointsChunk = pointsChunks[i];
+    const { ellipseObj, boundsIJK } = calculateEllipseAndBounds(
+      pointsChunk,
+      viewport,
+      imageData,
       dimensions
     );
-
-    // using circle as a form of ellipse
-    const ellipseObj = {
-      center: center as Types.Point3,
-      xRadius: Math.abs(topLeftWorld[0] - bottomRightWorld[0]) / 2,
-      yRadius: Math.abs(topLeftWorld[1] - bottomRightWorld[1]) / 2,
-      zRadius: Math.abs(topLeftWorld[2] - bottomRightWorld[2]) / 2,
-    };
-
-    let callback;
-
-    if (threshold) {
-      callback = ({ value, index, pointIJK }) => {
-        if (segmentsLocked.includes(value)) {
-          return;
-        }
-
-        if (
-          isWithinThreshold(index, imageVolume, strategySpecificConfiguration)
-        ) {
-          scalarData[index] = segmentIndex;
-          //Todo: I don't think this will always be index 2 in streamingImageVolume?
-          modifiedSlicesToUse.add(pointIJK[2]);
-        }
-      };
-    } else {
-      callback = ({ value, index, pointIJK }) => {
-        if (segmentsLocked.includes(value)) {
-          return;
-        }
-        scalarData[index] = segmentIndex;
-        //Todo: I don't think this will always be index 2 in streamingImageVolume?
-        modifiedSlicesToUse.add(pointIJK[2]);
-      };
-    }
-
     pointInShapeCallback(
       imageData,
       (pointLPS, pointIJK) => pointInEllipse(ellipseObj, pointLPS),
       callback,
       boundsIJK
     );
+  }
+
+  indicesToFill.forEach((index) => {
+    scalarData[index] = segmentIndex;
   });
 
   const arrayOfSlices: number[] = Array.from(modifiedSlicesToUse);

--- a/packages/tools/src/tools/segmentation/strategies/fillSphere.ts
+++ b/packages/tools/src/tools/segmentation/strategies/fillSphere.ts
@@ -57,22 +57,22 @@ function fillSphere(
     pointsChunks = [points];
   }
 
+  const inPlane = dimensions[0] * dimensions[1];
+
+  const callback = ({ index, value }) => {
+    if (segmentsLocked.includes(value)) {
+      return;
+    }
+    scalarData[index] = segmentIndex;
+    modifiedSlicesToUse.add(Math.floor(index / inPlane));
+  };
+
   for (let i = 0; i < pointsChunks.length; i++) {
     const pointsChunk = pointsChunks[i];
 
-    const callback = ({ index, value, pointIJK }) => {
-      if (segmentsLocked.includes(value)) {
-        return;
-      }
-      scalarData[index] = segmentIndex;
-      modifiedSlicesToUse.add(
-        Math.floor(index / (dimensions[0] * dimensions[1]))
-      );
-    };
-
     pointInSurroundingSphereCallback(
       imageData,
-      pointsChunk.slice(0, 2),
+      [pointsChunk[0], pointsChunk[1]],
       callback,
       viewport as Types.IVolumeViewport
     );

--- a/packages/tools/src/types/ToolSpecificAnnotationTypes.ts
+++ b/packages/tools/src/types/ToolSpecificAnnotationTypes.ts
@@ -310,3 +310,11 @@ export interface ScaleOverlayAnnotation extends Annotation {
     viewportId: string;
   };
 }
+
+export interface BrushCursor extends Annotation {
+  data: {
+    handles: {
+      points: [Types.Point3];
+    };
+  };
+}

--- a/packages/tools/src/types/ToolSpecificAnnotationTypes.ts
+++ b/packages/tools/src/types/ToolSpecificAnnotationTypes.ts
@@ -312,6 +312,14 @@ export interface ScaleOverlayAnnotation extends Annotation {
 }
 
 export interface BrushCursor extends Annotation {
+  metadata: {
+    toolName: string;
+    viewUp: Types.Point3;
+    viewPlaneNormal: Types.Point3;
+    FrameOfReferenceUID: string;
+    referencedImageId: string;
+    isBrushTool: boolean;
+  };
   data: {
     handles: {
       points: [Types.Point3];

--- a/packages/tools/src/utilities/planar/filterAnnotationsWithinSlice.ts
+++ b/packages/tools/src/utilities/planar/filterAnnotationsWithinSlice.ts
@@ -83,17 +83,12 @@ export default function filterAnnotationsWithinSlice(
   const annotationsWithinSlice = [];
 
   for (const annotation of annotationsWithParallelNormals) {
+    const data = annotation.data;
+    const point = data.handles.points[0];
+
     if (!annotation.isVisible) {
       continue;
     }
-
-    const data = annotation.data;
-
-    // pick a sample point from the annotation
-    const point = Array.isArray(data.handles.points)
-      ? data.handles.points[0][0]
-      : data.handles.points[0];
-
     // A = point
     // B = focal point
     // P = normal

--- a/packages/tools/src/utilities/planar/filterAnnotationsWithinSlice.ts
+++ b/packages/tools/src/utilities/planar/filterAnnotationsWithinSlice.ts
@@ -83,12 +83,17 @@ export default function filterAnnotationsWithinSlice(
   const annotationsWithinSlice = [];
 
   for (const annotation of annotationsWithParallelNormals) {
-    const data = annotation.data;
-    const point = data.handles.points[0];
-
     if (!annotation.isVisible) {
       continue;
     }
+
+    const data = annotation.data;
+
+    // pick a sample point from the annotation
+    const point = Array.isArray(data.handles.points)
+      ? data.handles.points[0][0]
+      : data.handles.points[0];
+
     // A = point
     // B = focal point
     // P = normal


### PR DESCRIPTION
### Context

#### Segmentation Export 

Make the generateSegmentation function to return the segmentation dataset instead of the arraybuffer since one might need to push it to the server 


#### Brush Tool

Previously the brush tool modifications/interaction were updating the scalarData and triggering the segmentaion_data_modified A LOT, which is not performance optimized and later when we add the history undo/redo we will end up with problems (since each transaction should be undo/redoable not the whole drag). This PR will show an intermediate step showing the brush locations (similar to volview and 3D Slicer) and when the mouse up happens it does the scalar data update, we call this `lazyCalculation`

#### Brush Tool size

Previously the brush tool size was in canvas, which means that when you zoomed in the image the brush size would become smaller which is unexpected by the user. This PR changes it to the world coordinates in mm units

Before

https://github.com/cornerstonejs/cornerstone3D/assets/7490180/bafebec1-1886-4b2f-a8a1-e9b95de88c2d




Now


https://github.com/cornerstonejs/cornerstone3D/assets/7490180/13aad39f-7ff5-4904-9c02-775096ef4863




### Testing

Test it in the labelmapsegmentationtools example

https://deploy-preview-762--cornerstone-3d-docs.netlify.app/live-examples/labelmapsegmentationtools

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
