### PR TITLE
fix(Stack prefetch): should not remove other requests 

### DIFF
--- a/packages/tools/src/utilities/stackPrefetch/stackPrefetch.ts
+++ b/packages/tools/src/utilities/stackPrefetch/stackPrefetch.ts
@@ -16,7 +16,13 @@ const addToBeginning = true;
 
 let configuration = {
   maxImagesToPrefetch: Infinity,
-  preserveExistingPool: false,
+  // Preserving the existing pool should be the default behaviour, as there might
+  // be a volume of the same series already being loaded in the pool, and we don't want
+  // to cancel it middle of the way when the other stack viewport mounts. Worst case scenario
+  // there will be a few extra images in the pool but by the time that their turn comes
+  // we will have already loaded the volume and it will get read from the CACHE,
+  // so who cares
+  preserveExistingPool: true,
 };
 
 let resetPrefetchTimeout;


### PR DESCRIPTION


### Context

If the viewport Grid has a stack and a volume of the same displaySet then the volume would not load complete for the bug this PR fixes. I don't know why we set the clearRequests for the stack prefetch


### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
