### PR TITLE
fix(16bit float): should not use 16bit int for float arrays

### DIFF
--- a/packages/streaming-image-volume-loader/src/cornerstoneStreamingImageVolumeLoader.ts
+++ b/packages/streaming-image-volume-loader/src/cornerstoneStreamingImageVolumeLoader.ts
@@ -110,6 +110,10 @@ function cornerstoneStreamingImageVolumeLoader(
       scalingParameters.rescaleIntercept < 0 ||
       scalingParameters.rescaleSlope < 0;
 
+    const hasFloatRescale =
+      scalingParameters.rescaleIntercept % 1 !== 0 ||
+      scalingParameters.rescaleSlope % 1 !== 0;
+
     const {
       BitsAllocated,
       PixelRepresentation,
@@ -180,7 +184,7 @@ function cornerstoneStreamingImageVolumeLoader(
         // Temporary fix for 16 bit images to use Float32
         // until the new dicom image loader handler the conversion
         // correctly
-        if (!use16BitDataType) {
+        if (!use16BitDataType || hasFloatRescale) {
           sizeInBytes = length * 4;
           scalarData = useSharedArrayBuffer
             ? createFloat32SharedArray(length)

--- a/packages/streaming-image-volume-loader/src/cornerstoneStreamingImageVolumeLoader.ts
+++ b/packages/streaming-image-volume-loader/src/cornerstoneStreamingImageVolumeLoader.ts
@@ -110,6 +110,8 @@ function cornerstoneStreamingImageVolumeLoader(
       scalingParameters.rescaleIntercept < 0 ||
       scalingParameters.rescaleSlope < 0;
 
+    // The prescale is ALWAYS used with modality LUT, so we can assume that
+    // if the rescale slope is not an integer, we need to use Float32
     const hasFloatRescale =
       scalingParameters.rescaleIntercept % 1 !== 0 ||
       scalingParameters.rescaleSlope % 1 !== 0;


### PR DESCRIPTION


### Context

When using the `use16BitTexture` it will force every volume to be 16bit regardless of the fact that some may end up in float territory because of the scaling

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
