### PR TITLE
fix(rotation): Only one CAMERA_MODIFIED event per rotation

### DIFF
--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -1017,7 +1017,7 @@ class StackViewport extends Viewport implements IStackViewport {
       ? vec3.negate(vec3.create(), this.initialViewUp)
       : this.initialViewUp;
 
-    this.setCamera({
+    this.setCameraNoEvent({
       viewUp: initialViewUp as Point3,
     });
 


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
Fixes: #819 

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

When setting the camera in StackViewport.setRotationGPU, do not fire a CAMERA_MODIFIED event because it is already being done so in setRotation.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

See #819. However, here are some brief details here...

1. Launch the Stack API example.
2. Open the browser console and enter the following snippet of code that will log the event fired.
```
var viewport = cornerstone.getRenderingEngines()[0].getViewports()[0];
viewport.element.addEventListener(cornerstone.EVENTS.CAMERA_MODIFIED, (e) => console.log(e)); 
```
3. Click any of the rotate buttons in the example.
4. The console should log a single event for each rotation button click.
<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Windows 11<!--[e.g. Windows 10, macOS 10.15.4]"-->
- [x] "Node version: 16.14.0<!--[e.g. 16.14.0]"-->
- [x] "Browser: Chrome 117.0.5938.152 
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
