### PR TITLE
fix(StreamingImageLoader): allow image volume loading to work when SharedArrayBuffer is being used.

### DIFF
--- a/packages/streaming-image-volume-loader/src/BaseStreamingImageVolume.ts
+++ b/packages/streaming-image-volume-loader/src/BaseStreamingImageVolume.ts
@@ -469,7 +469,7 @@ export default class BaseStreamingImageVolume extends ImageVolume {
     }
 
     function handleArrayBufferLoad(scalarData, image, options) {
-      if (!(scalarData.buffer instanceof ArrayBuffer)) {
+      if (!scalarData.buffer) {
         return;
       }
 


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

I was investigating why my 3D stacks load normally, but all volumes are completely
grayed out.

For me, scalarData.buffer was a SharedArrayBuffer and not an ArrayBuffer here.
This was causing handleArrayBufferLoad to ignore the successful loading of
pixel data, keeping the volume scalarData all-zero, and eventually causing the
volume to display completely empty even though all images were loaded.

I suppose, at this point, the idea was to check whether there was any
scalarData to load into -- not that the type of buffer was explicitly
ArrayBuffer. By changing the check accordingly, the slice pixel data is being
loaded into the volume scalarData correctly, and the volume is rendered
normally.

### Changes & Results

Before:

<img width="844" alt="Scherm­afbeelding 2023-10-15 om 19 29 12" src="https://github.com/cornerstonejs/cornerstone3D/assets/328769/f9e9b069-2a64-4aba-963f-1ba413b0804a">

After:

<img width="965" alt="Scherm­afbeelding 2023-10-15 om 19 28 24" src="https://github.com/cornerstonejs/cornerstone3D/assets/328769/56122810-1a43-4abc-a041-bc41fe24afb4">

(The black rectangle is another issue on my end, not related to this one.)

### Testing

This bug can be triggered simply by calling `volume.load()` on the result of a `streamingImageVolumeLoader.loadVolume()` while in a scope that allows cross-origin isolation (i.e. the Cross-Origin-Opener-Policy & Cross-Origin-Embedder-Policy headers are set to 'same-origin' and 'require-corp' respectively). This will cause Cornerstone to use SharedArrayBuffer instead of ArrayBuffer.

If you'd like I can supply some code examples, but it's not zero-effort so let me know if this is wanted.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: macOS 14.0"
- [x] "Node version: v20.8.0"
- [x] "Browser: Chrome 117.0"

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
