### PR TITLE
fix: Add degree to rad conversion for rotate mouse wheel

### DIFF
--- a/packages/tools/src/tools/VolumeRotateMouseWheelTool.ts
+++ b/packages/tools/src/tools/VolumeRotateMouseWheelTool.ts
@@ -29,7 +29,7 @@ class VolumeRotateMouseWheelTool extends BaseTool {
       supportedInteractionTypes: ['Mouse', 'Touch'],
       configuration: {
         direction: DIRECTIONS.Z,
-        rotateIncrementDegrees: 0.5,
+        rotateIncrementDegrees: 2,
       },
     }
   ) {
@@ -51,7 +51,8 @@ class VolumeRotateMouseWheelTool extends BaseTool {
     const [cx, cy, cz] = focalPoint;
     const [ax, ay, az] = direction;
 
-    const angle = deltaY * rotateIncrementDegrees;
+    //Calculate angle in radian as glmatrix rotate is in radian
+    const angle = (deltaY * (rotateIncrementDegrees * Math.PI)) / 180;
 
     // position[3] = 1.0
     // focalPoint[3] = 1.0

--- a/packages/tools/src/tools/VolumeRotateMouseWheelTool.ts
+++ b/packages/tools/src/tools/VolumeRotateMouseWheelTool.ts
@@ -29,7 +29,7 @@ class VolumeRotateMouseWheelTool extends BaseTool {
       supportedInteractionTypes: ['Mouse', 'Touch'],
       configuration: {
         direction: DIRECTIONS.Z,
-        rotateIncrementDegrees: 2,
+        rotateIncrementDegrees: 30,
       },
     }
   ) {


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

RotateMouseWheel as a configuration unit in degree (which is fine)
The probleme is that the value in degree was passed to glmatrix which is using radian rotation unit

### Changes & Results
Convert degree to radian before application

### Testing

N/A

### Checklist

#### PR

#### Code


#### Public Documentation Updates

No modification needed

#### Tested Environment



<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
