### PR TITLE
feat(OrientationMarker): clean up orientation marker

### DIFF
--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -3975,6 +3975,8 @@ export class OrientationMarkerTool extends BaseTool {
     // (undocumented)
     onSetToolActive: () => void;
     // (undocumented)
+    onSetToolDisabled: () => void;
+    // (undocumented)
     onSetToolEnabled: () => void;
     // (undocumented)
     orientationMarkers: any;

--- a/packages/tools/src/tools/OrientationMarkerTool.ts
+++ b/packages/tools/src/tools/OrientationMarkerTool.ts
@@ -94,6 +94,38 @@ class OrientationMarkerTool extends BaseTool {
     this.initViewports();
   };
 
+  onSetToolDisabled = (): void => {
+    this.cleanUpData();
+  };
+
+  private cleanUpData() {
+    const renderingEngines = getRenderingEngines();
+    const renderingEngine = renderingEngines[0];
+    const viewports = renderingEngine.getViewports();
+
+    viewports.forEach((viewport) => {
+      const orientationMarker = this.orientationMarkers[viewport.id];
+      if (!orientationMarker) {
+        return;
+      }
+
+      const { actor, orientationWidget } = orientationMarker;
+      orientationWidget?.setEnabled(false);
+      orientationWidget?.delete();
+      actor?.delete();
+
+      const renderer = viewport.getRenderer();
+      const renderWindow = viewport
+        .getRenderingEngine()
+        .offscreenMultiRenderWindow.getRenderWindow();
+      renderer.resetCamera();
+      renderWindow.render();
+      viewport.getRenderingEngine().render();
+
+      delete this.orientationMarkers[viewport.id];
+    });
+  }
+
   private initViewports() {
     const renderingEngines = getRenderingEngines();
     const renderingEngine = renderingEngines[0];

--- a/packages/tools/src/tools/OrientationMarkerTool.ts
+++ b/packages/tools/src/tools/OrientationMarkerTool.ts
@@ -114,11 +114,9 @@ class OrientationMarkerTool extends BaseTool {
       orientationWidget?.delete();
       actor?.delete();
 
-      const renderer = viewport.getRenderer();
       const renderWindow = viewport
         .getRenderingEngine()
         .offscreenMultiRenderWindow.getRenderWindow();
-      renderer.resetCamera();
       renderWindow.render();
       viewport.getRenderingEngine().render();
 


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

Currently, the OrientationMarker tool drawings will remain on screen after the tool is disabled. These changes will remove the drawings after the tool is disabled.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

Before:

https://github.com/cornerstonejs/cornerstone3D/assets/22822446/ca7dd5c8-206f-4913-a78d-99fa74172ad4


After:

https://github.com/cornerstonejs/cornerstone3D/assets/22822446/82acc4a1-6baf-4769-9b36-b7ae2f093874



<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies



- [X] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Tested Environment

- [X] "OS: macOS 14.0 <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [X] "Node version: v18.17.1
- [X] "Browser: Chrome 118.0.5993.88
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
