### PR TITLE
Fix: package exports

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,6 +14,13 @@
     "test": "test"
   },
   "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts"
+    }
+  },
   "scripts": {
     "build:cjs": "tsc --project ./tsconfig.cjs.json",
     "build:esm": "tsc --project ./tsconfig.esm.json",

--- a/packages/nifti-volume-loader/package.json
+++ b/packages/nifti-volume-loader/package.json
@@ -16,6 +16,13 @@
     "access": "public"
   },
   "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/umd/index.js",
+      "types": "./dist/types/index.d.ts"
+    }
+  },
   "scripts": {
     "build:esm": "tsc --project ./tsconfig.esm.json",
     "build:umd": "cross-env NODE_ENV=production webpack --config .webpack/webpack.prod.js",

--- a/packages/streaming-image-volume-loader/package.json
+++ b/packages/streaming-image-volume-loader/package.json
@@ -14,6 +14,13 @@
     "test": "test"
   },
   "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts"
+    }
+  },
   "scripts": {
     "api-check": "api-extractor --debug run",
     "build:cjs": "tsc --project ./tsconfig.cjs.json",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -14,6 +14,13 @@
     "test": "test"
   },
   "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts"
+    }
+  },
   "scripts": {
     "build:cjs": "tsc --project ./tsconfig.cjs.json",
     "build:esm": "tsc --project ./tsconfig.esm.json",


### PR DESCRIPTION
### Context

The current `main` field in package.json would cause app fail to import @cornerstone/xxx packages

### Changes & Results

Add `exports` field in package.json in these packages to distinguish cjs and mjs usage
* @cornerstonejs/core
* @cornerstonejs/tools package
* @cornerstonejs/nifti-volume-loader
* @cornerstonejs/streaming-image-volume-loader

### Testing

None

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)

#### Public Documentation Updates

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [x] "Node version: <!--[e.g. 16.14.0]"-->
- [x] "Browser: