### PR TITLE
fix: final htj2k transfer syntaxes

### DIFF
--- a/packages/dicomImageLoader/docs/TransferSyntaxes.md
+++ b/packages/dicomImageLoader/docs/TransferSyntaxes.md
@@ -20,7 +20,8 @@ Compressed (requires codec, see below)
 * 1.2.840.10008.1.2.4.81 JPEG-LS Lossy (Near-Lossless) Image Compression
 * 1.2.840.10008.1.2.4.90 JPEG 2000 Image Compression (Lossless Only)
 * 1.2.840.10008.1.2.4.91 JPEG 2000 Image Compression
-* 3.2.840.10008.1.2.4.96 HTJ2K (experimental TSUID)
+* 3.2.840.10008.1.2.4.96 HTJ2K (private TSUID for HTJ2K)
+* 1.2.840.10008.1.2.4.202 High Throughput JPEG 2000 (HTJ2K with RPCL)
 * 1.2.840.10008.1.2.1.99 Deflate Transfer Syntax
 
 Photometric Interpretations
@@ -32,4 +33,4 @@ Photometric Interpretations
 * YBR_FULL
 * YBR_FULL_422
 * YBR_RCT
-* YBR_ICT 
+* YBR_ICT

--- a/packages/dicomImageLoader/src/imageLoader/decodeImageFrame.ts
+++ b/packages/dicomImageLoader/src/imageLoader/decodeImageFrame.ts
@@ -182,6 +182,9 @@ function decodeImageFrame(
       );
 
     case '3.2.840.10008.1.2.4.96':
+    case '1.2.840.10008.1.2.4.201':
+    case '1.2.840.10008.1.2.4.202':
+    case '1.2.840.10008.1.2.4.203':
       // HTJ2K
       return processDecodeTask(
         imageFrame,

--- a/packages/dicomImageLoader/src/imageLoader/wadors/loadImage.ts
+++ b/packages/dicomImageLoader/src/imageLoader/wadors/loadImage.ts
@@ -8,7 +8,15 @@ import { DICOMLoaderIImage, DICOMLoaderImageOptions } from '../../types';
 
 const { ProgressiveIterator } = utilities;
 const { ImageQualityStatus } = Enums;
-const streamableTransferSyntaxes = new Set<string>(['3.2.840.10008.1.2.4.96']);
+const streamableTransferSyntaxes = new Set<string>([
+  // Private HTJ2K
+  '3.2.840.10008.1.2.4.96',
+  // Released HTJ2K - only the RPCL one is definitely streamable.
+  '1.2.840.10008.1.2.4.202',
+  // HTJ2K lossy might be streamable, so try it.  If it fails it is ok as it will
+  // proceed and eventually work.
+  '1.2.840.10008.1.2.4.203',
+]);
 
 /**
  * Helper method to extract the transfer-syntax from the response of the server.

--- a/packages/dicomImageLoader/src/shared/decodeImageFrame.ts
+++ b/packages/dicomImageLoader/src/shared/decodeImageFrame.ts
@@ -128,6 +128,9 @@ async function decodeImageFrame(
       decodePromise = decodeJPEG2000(pixelData, opts);
       break;
     case '3.2.840.10008.1.2.4.96':
+    case '1.2.840.10008.1.2.4.201':
+    case '1.2.840.10008.1.2.4.202':
+    case '1.2.840.10008.1.2.4.203':
       // HTJ2K
       opts = {
         ...imageFrame,

--- a/packages/streaming-image-volume-loader/src/BaseStreamingImageVolume.ts
+++ b/packages/streaming-image-volume-loader/src/BaseStreamingImageVolume.ts
@@ -411,9 +411,12 @@ export default class BaseStreamingImageVolume
    */
   public load = (callback: (...args: unknown[]) => void): void => {
     const { imageIds, loadStatus, numFrames } = this;
+    const { transferSyntaxUID } =
+      metaData.get('transferSyntax', imageIds[0]) || {};
     const imageRetrieveConfiguration = metaData.get(
       imageRetrieveMetadataProvider.IMAGE_RETRIEVE_CONFIGURATION,
       this.volumeId,
+      transferSyntaxUID,
       'volume'
     );
 


### PR DESCRIPTION
### Context

The transfer syntax UID's for HTJ2K were finally released today, so this PR updates them to use the new ones.

### Changes & Results

Just add the new transfer syntaxes.

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
