### PR TITLE
fix(slabScroll): spacing calculation in getTargetVolumeAndSpacingInNormalDir function

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -873,7 +873,7 @@ function getSpacingInNormalDirection(imageVolume: IImageVolume | {
 }, viewPlaneNormal: Point3): number;
 
 // @public (undocumented)
-function getTargetVolumeAndSpacingInNormalDir(viewport: IVolumeViewport, camera: ICamera, targetVolumeId?: string): {
+function getTargetVolumeAndSpacingInNormalDir(viewport: IVolumeViewport, camera: ICamera, targetVolumeId?: string, useSlabThickness?: boolean): {
     imageVolume: IImageVolume;
     spacingInNormalDirection: number;
     actorUID: string;
@@ -904,7 +904,7 @@ function getVolumeActorCorners(volumeActor: any): Array<Point3>;
 function getVolumeLoaderSchemes(): string[];
 
 // @public (undocumented)
-function getVolumeSliceRangeInfo(viewport: IVolumeViewport, volumeId: string): {
+function getVolumeSliceRangeInfo(viewport: IVolumeViewport, volumeId: string, useSlabThickness?: boolean): {
     sliceRange: ActorSliceRange;
     spacingInNormalDirection: number;
     camera: ICamera;
@@ -914,7 +914,7 @@ function getVolumeSliceRangeInfo(viewport: IVolumeViewport, volumeId: string): {
 function getVolumeViewportsContainingSameVolumes(targetViewport: IVolumeViewport, renderingEngineId?: string): Array<IVolumeViewport>;
 
 // @public (undocumented)
-function getVolumeViewportScrollInfo(viewport: IVolumeViewport, volumeId: string): {
+function getVolumeViewportScrollInfo(viewport: IVolumeViewport, volumeId: string, useSlabThickness?: boolean): {
     numScrollSteps: number;
     currentStepIndex: number;
     sliceRangeInfo: {

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -3557,6 +3557,7 @@ type ScrollOptions_2 = {
     volumeId?: string;
     debounceLoading?: boolean;
     loop?: boolean;
+    scrollSlabs?: boolean;
 };
 
 // @public (undocumented)
@@ -3904,6 +3905,7 @@ export class StackScrollMouseWheelTool extends BaseTool {
             invert: boolean;
             debounceIfNotLoaded: boolean;
             loop: boolean;
+            scrollSlabs: boolean;
         };
     });
     // (undocumented)

--- a/packages/core/src/utilities/getTargetVolumeAndSpacingInNormalDir.ts
+++ b/packages/core/src/utilities/getTargetVolumeAndSpacingInNormalDir.ts
@@ -30,9 +30,8 @@ const isPrimaryVolume = (volume): boolean =>
  * @param camera - current camera
  * @param targetVolumeId - If a target volumeId is given that volume
  * is forced to be used.
- * @param useSlabThickness - If true, the spacing in the normal direction
- * will be calculated based on the slab thickness instead of the spacing in the
- *
+ * @param useSlabThickness - If true, the number of steps will be calculated
+ * based on the slab thickness instead of the spacing in the normal direction
  * @returns An object containing the imageVolume and spacingInNormalDirection.
  *
  */

--- a/packages/core/src/utilities/getTargetVolumeAndSpacingInNormalDir.ts
+++ b/packages/core/src/utilities/getTargetVolumeAndSpacingInNormalDir.ts
@@ -30,6 +30,8 @@ const isPrimaryVolume = (volume): boolean =>
  * @param camera - current camera
  * @param targetVolumeId - If a target volumeId is given that volume
  * is forced to be used.
+ * @param useSlabThickness - If true, the spacing in the normal direction
+ * will be calculated based on the slab thickness instead of the spacing in the
  *
  * @returns An object containing the imageVolume and spacingInNormalDirection.
  *
@@ -37,7 +39,8 @@ const isPrimaryVolume = (volume): boolean =>
 export default function getTargetVolumeAndSpacingInNormalDir(
   viewport: IVolumeViewport,
   camera: ICamera,
-  targetVolumeId?: string
+  targetVolumeId?: string,
+  useSlabThickness = false
 ): {
   imageVolume: IImageVolume;
   spacingInNormalDirection: number;
@@ -75,7 +78,8 @@ export default function getTargetVolumeAndSpacingInNormalDir(
     const spacingInNormalDirection = getSpacingInNormal(
       imageVolume,
       viewPlaneNormal,
-      viewport
+      viewport,
+      useSlabThickness
     );
 
     return { imageVolume, spacingInNormalDirection, actorUID };
@@ -131,11 +135,12 @@ export default function getTargetVolumeAndSpacingInNormalDir(
 function getSpacingInNormal(
   imageVolume: IImageVolume,
   viewPlaneNormal: Point3,
-  viewport: IVolumeViewport
+  viewport: IVolumeViewport,
+  useSlabThickness = false
 ): number {
   const { slabThickness } = viewport.getProperties();
   let spacingInNormalDirection = slabThickness;
-  if (!slabThickness) {
+  if (!slabThickness || useSlabThickness === false) {
     spacingInNormalDirection = getSpacingInNormalDirection(
       imageVolume,
       viewPlaneNormal

--- a/packages/core/src/utilities/getVolumeSliceRangeInfo.ts
+++ b/packages/core/src/utilities/getVolumeSliceRangeInfo.ts
@@ -11,11 +11,14 @@ import {
  * Calculates the slice range for the given volume based on its orientation
  * @param viewport - Volume viewport
  * @param volumeId - Id of one of the volumes loaded on the given viewport
+ * @param useSlabThickness - If true, the slice range will be calculated
+ * based on the slab thickness instead of the spacing in the normal direction
  * @returns slice range information
  */
 function getVolumeSliceRangeInfo(
   viewport: IVolumeViewport,
-  volumeId: string
+  volumeId: string,
+  useSlabThickness = false
 ): {
   sliceRange: ActorSliceRange;
   spacingInNormalDirection: number;
@@ -24,7 +27,12 @@ function getVolumeSliceRangeInfo(
   const camera = viewport.getCamera();
   const { focalPoint, viewPlaneNormal } = camera;
   const { spacingInNormalDirection, actorUID } =
-    getTargetVolumeAndSpacingInNormalDir(viewport, camera, volumeId);
+    getTargetVolumeAndSpacingInNormalDir(
+      viewport,
+      camera,
+      volumeId,
+      useSlabThickness
+    );
 
   if (!actorUID) {
     throw new Error(

--- a/packages/core/src/utilities/getVolumeViewportScrollInfo.ts
+++ b/packages/core/src/utilities/getVolumeViewportScrollInfo.ts
@@ -5,14 +5,17 @@ import getVolumeSliceRangeInfo from './getVolumeSliceRangeInfo';
  * Calculates the number os steps the volume can scroll based on its orientation
  * @param viewport - Volume viewport
  * @param volumeId - Id of one of the volumes loaded on the given viewport
+ * @param useSlabThickness - If true, the number of steps will be calculated
+ * based on the slab thickness instead of the spacing in the normal direction
  * @returns number of steps the volume can scroll and its current position
  */
 function getVolumeViewportScrollInfo(
   viewport: IVolumeViewport,
-  volumeId: string
+  volumeId: string,
+  useSlabThickness = false
 ) {
   const { sliceRange, spacingInNormalDirection, camera } =
-    getVolumeSliceRangeInfo(viewport, volumeId);
+    getVolumeSliceRangeInfo(viewport, volumeId, useSlabThickness);
 
   const { min, max, current } = sliceRange;
 

--- a/packages/tools/examples/volumeSlabScroll/index.ts
+++ b/packages/tools/examples/volumeSlabScroll/index.ts
@@ -149,10 +149,7 @@ addToggleButtonToToolbar({
   title: 'Toggle Slab Scroll',
   defaultToggle: false,
   onClick: (toggle) => {
-    let scrollSlabs = false;
-    if (toggle) {
-      scrollSlabs = true;
-    }
+    const scrollSlabs = !!toggle;
     toolGroup.setToolConfiguration(StackScrollMouseWheelTool.toolName, {
       scrollSlabs,
     });

--- a/packages/tools/examples/volumeSlabScroll/index.ts
+++ b/packages/tools/examples/volumeSlabScroll/index.ts
@@ -10,6 +10,7 @@ import {
   createImageIdsAndCacheMetaData,
   setTitleAndDescription,
   addButtonToToolbar,
+  addToggleButtonToToolbar,
 } from '../../../../utils/demo/helpers';
 import * as cornerstoneTools from '@cornerstonejs/tools';
 import addDropDownToToolbar from '../../../../utils/demo/helpers/addDropdownToToolbar';
@@ -140,6 +141,21 @@ addButtonToToolbar({
 
     viewport.resetProperties();
     viewport.render();
+  },
+});
+
+addToggleButtonToToolbar({
+  id: 'slabScroll',
+  title: 'Toggle Slab Scroll',
+  defaultToggle: false,
+  onClick: (toggle) => {
+    let scrollSlabs = false;
+    if (toggle) {
+      scrollSlabs = true;
+    }
+    toolGroup.setToolConfiguration(StackScrollMouseWheelTool.toolName, {
+      scrollSlabs,
+    });
   },
 });
 

--- a/packages/tools/src/tools/StackScrollToolMouseWheelTool.ts
+++ b/packages/tools/src/tools/StackScrollToolMouseWheelTool.ts
@@ -20,6 +20,7 @@ class StackScrollMouseWheelTool extends BaseTool {
         invert: false,
         debounceIfNotLoaded: true,
         loop: false,
+        scrollSlabs: false,
       },
     }
   ) {
@@ -41,6 +42,7 @@ class StackScrollMouseWheelTool extends BaseTool {
       debounceLoading: this.configuration.debounceIfNotLoaded,
       loop: this.configuration.loop,
       volumeId,
+      scrollSlabs: this.configuration.scrollSlabs,
     });
   }
 }

--- a/packages/tools/src/types/ScrollOptions.ts
+++ b/packages/tools/src/types/ScrollOptions.ts
@@ -4,6 +4,7 @@ type ScrollOptions = {
   volumeId?: string;
   debounceLoading?: boolean;
   loop?: boolean;
+  scrollSlabs?: boolean;
 };
 
 export default ScrollOptions;

--- a/packages/tools/src/utilities/scroll.ts
+++ b/packages/tools/src/utilities/scroll.ts
@@ -38,12 +38,12 @@ export default function scroll(
   }
 
   const { type: viewportType } = viewport;
-  const { volumeId, delta } = options;
+  const { volumeId, delta, scrollSlabs } = options;
 
   if (viewport instanceof StackViewport) {
     viewport.scroll(delta, options.debounceLoading, options.loop);
   } else if (viewport instanceof VolumeViewport) {
-    scrollVolume(viewport, volumeId, delta);
+    scrollVolume(viewport, volumeId, delta, scrollSlabs);
   } else if (viewport instanceof VideoViewport) {
     viewport.scroll(delta);
   } else {
@@ -54,10 +54,13 @@ export default function scroll(
 export function scrollVolume(
   viewport: VolumeViewport,
   volumeId: string,
-  delta: number
+  delta: number,
+  scrollSlabs = false
 ) {
+  const useSlabThickness = scrollSlabs;
+
   const { numScrollSteps, currentStepIndex, sliceRangeInfo } =
-    csUtils.getVolumeViewportScrollInfo(viewport, volumeId);
+    csUtils.getVolumeViewportScrollInfo(viewport, volumeId, useSlabThickness);
 
   if (!sliceRangeInfo) {
     return;


### PR DESCRIPTION

### Context

Seems like scrolling with slab thickness accommodated is not always a desired behavior, so I'm adding it as an option.

### Changes & Results


### Testing

Should work like before, just adding an option. Try `volumeSlabScroll` example


### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
