### PR TITLE
fix: Inclusion of this build in OHIF was causing an import loop

### DIFF
--- a/packages/tools/src/tools/base/BaseTool.ts
+++ b/packages/tools/src/tools/base/BaseTool.ts
@@ -5,7 +5,7 @@ import {
   VideoViewport,
 } from '@cornerstonejs/core';
 import { Types } from '@cornerstonejs/core';
-import { ToolModes } from '../../enums';
+import ToolModes from '../../enums/ToolModes';
 import { InteractionTypes, ToolProps, PublicToolProps } from '../../types';
 
 export interface IBaseTool {

--- a/packages/tools/src/utilities/planar/filterAnnotationsForDisplay.ts
+++ b/packages/tools/src/utilities/planar/filterAnnotationsForDisplay.ts
@@ -7,8 +7,8 @@ import {
 } from '@cornerstonejs/core';
 
 import filterAnnotationsWithinSlice from './filterAnnotationsWithinSlice';
-import { Annotations } from '../../types';
-import { annotationFrameRange } from '..';
+import type { Annotations } from '../../types';
+import annotationFrameRange from '../annotationFrameRange';
 
 const baseUrlExtractor = /(videoId:|imageId:|volumeId:)([a-zA-Z]*:)/;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17393,7 +17393,7 @@ pkg-up@^3.1.0:
   version "1.1.0"
   resolved "https://codeload.github.com/ataft/plugin-image-zoom/tar.gz/8e1b866c79ed6d42cefc4c52f851f1dfd1d0c7de"
   dependencies:
-    medium-zoom "^1.0.4"
+    medium-zoom "^1.0.8"
 
 posix-character-classes@^0.1.0:
   version "0.1.1"


### PR DESCRIPTION
### Context

There was an import that ended up importing itself and trying to resolve all the imports along the way, introduced in the video code.

### Changes & Results

Use direct import instead of import via the group/namespace files.

### Testing

Link core/tools into OHIF.  Start OHIF - if it starts, the fix worked.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
