### PR TITLE
fix(livewire): issue when closing a path

### DIFF
--- a/packages/tools/src/tools/annotation/LivewireContourTool.ts
+++ b/packages/tools/src/tools/annotation/LivewireContourTool.ts
@@ -402,7 +402,6 @@ class LivewireContourTool extends AnnotationTool {
     const { viewport, renderingEngine } = enabledElement;
     const controlPoints = this.editData.currentPath.getControlPoints();
     let closePath = controlPoints.length >= 2 && doubleClick;
-    let addNewPoint = true;
 
     // Check if user clicked on the first point to close the curve
     if (controlPoints.length >= 2) {
@@ -432,24 +431,20 @@ class LivewireContourTool extends AnnotationTool {
       }
 
       if (closestHandlePoint.index === 0) {
-        addNewPoint = false;
         closePath = true;
       }
     }
 
     this.editData.closed = this.editData.closed || closePath;
+    this.editData.confirmedPath = this.editData.currentPath;
 
-    if (addNewPoint) {
-      this.editData.confirmedPath = this.editData.currentPath;
+    // Add the current cursor position as a new control point after clicking
+    this.editData.confirmedPath.addControlPoint(
+      this.editData.currentPath.getLastPoint()
+    );
 
-      // Add the current cursor position as a new control point after clicking
-      this.editData.confirmedPath.addControlPoint(
-        this.editData.currentPath.getLastPoint()
-      );
-
-      // Start a new search starting at the last control point
-      this.scissors.startSearch(worldToSlice(worldPos));
-    }
+    // Start a new search starting at the last control point
+    this.scissors.startSearch(worldToSlice(worldPos));
 
     annotation.invalidated = true;
     triggerAnnotationRenderForViewportIds(renderingEngine, viewportIdsToRender);


### PR DESCRIPTION
After making changes to support double clicks to close a path a new issue was introduced as shown in the video below where you can see a straight line after closing a path. The issue is because a new control point is added after closing the path.

https://github.com/cornerstonejs/cornerstone3D/assets/931820/fa83b8c1-f78f-421f-9905-287e462d6504

