### PR TITLE
fix(viewUp): Adjust behavior after orientation change

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -135,6 +135,8 @@ export abstract class BaseVolumeViewport extends Viewport implements IVolumeView
     // (undocumented)
     protected initialTransferFunctionNodes: any;
     // (undocumented)
+    protected initialViewUp: Point3;
+    // (undocumented)
     removeVolumeActors(actorUIDs: Array<string>, immediate?: boolean): void;
     // (undocumented)
     abstract resetProperties(volumeId?: string): void;

--- a/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
@@ -82,7 +82,7 @@ abstract class BaseVolumeViewport extends Viewport implements IVolumeViewport {
     VolumeViewportProperties
   >();
   // Camera properties
-  private initialViewUp: Point3;
+  protected initialViewUp: Point3;
   protected viewportProperties: VolumeViewportProperties = {};
 
   constructor(props: ViewportInput) {
@@ -100,16 +100,6 @@ abstract class BaseVolumeViewport extends Viewport implements IVolumeViewport {
     const renderer = this.getRenderer();
 
     const camera = vtkSlabCamera.newInstance();
-
-    this.initialViewUp = <Point3>[0, -1, 0];
-    const viewPlaneNormal = <Point3>[0, 0, -1];
-
-    camera.setDirectionOfProjection(
-      -viewPlaneNormal[0],
-      -viewPlaneNormal[1],
-      -viewPlaneNormal[2]
-    );
-    camera.setViewUp(...this.initialViewUp);
     renderer.setActiveCamera(camera);
 
     switch (this.type) {
@@ -145,6 +135,7 @@ abstract class BaseVolumeViewport extends Viewport implements IVolumeViewport {
       -viewPlaneNormal[2]
     );
     camera.setViewUpFrom(viewUp);
+    this.initialViewUp = viewUp;
 
     this.resetCamera();
   }
@@ -1029,9 +1020,12 @@ abstract class BaseVolumeViewport extends Viewport implements IVolumeViewport {
     // the viewPlaneNormal indicates a positive or negative rotation respectively.
     const normalDot = vec3.dot(initialToCurrentViewUpCross, viewPlaneNormal);
 
-    return normalDot >= 0
-      ? initialToCurrentViewUpAngle
-      : (360 - initialToCurrentViewUpAngle) % 360;
+    const value =
+      normalDot >= 0
+        ? initialToCurrentViewUpAngle
+        : (360 - initialToCurrentViewUpAngle) % 360;
+
+    return value;
   };
 
   /**

--- a/packages/core/src/RenderingEngine/VolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/VolumeViewport.ts
@@ -196,6 +196,7 @@ class VolumeViewport extends BaseVolumeViewport {
       viewUp,
     });
 
+    this.initialViewUp = viewUp;
     this.resetCamera();
   }
 


### PR DESCRIPTION

### Context

@Celian-abd FYI this was causing this issue

![CleanShot 2023-12-14 at 17 53 46](https://github.com/cornerstonejs/cornerstone3D/assets/7490180/adeafcdb-ba9c-471d-a89b-5819f63ce5ce)

I'm fixing the viewUp to be decided after orientation change 

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
