### PR TITLE
docs:  installation page optimization

### DIFF
--- a/packages/docs/docs/getting-started/installation.md
+++ b/packages/docs/docs/getting-started/installation.md
@@ -10,9 +10,9 @@ You can install `Cornerstone3D`, `Cornerstone3DTools`, and `StreamingImageVolume
 You can install the latest version of the packages by running:
 
 ```bash
-npm install --save @cornerstonejs/core
-npm install --save @cornerstonejs/tools
-npm install --save @cornerstonejs/streaming-image-volume-loader
+npm install @cornerstonejs/core
+npm install @cornerstonejs/tools
+npm install @cornerstonejs/streaming-image-volume-loader
 ```
 
 ## YARN

--- a/packages/docs/docs/getting-started/installation.md
+++ b/packages/docs/docs/getting-started/installation.md
@@ -10,16 +10,12 @@ You can install `Cornerstone3D`, `Cornerstone3DTools`, and `StreamingImageVolume
 You can install the latest version of the packages by running:
 
 ```bash
-npm install @cornerstonejs/core
+npm install --save @cornerstonejs/core
+npm install --save @cornerstonejs/tools
+npm install --save @cornerstonejs/streaming-image-volume-loader
 ```
 
-```bash
-npm install @cornerstonejs/tools
-```
-
-```bash
-npm install @cornerstonejs/streaming-image-volume-loader
-```
+## YARN
 
 If you are using [Yarn](https://yarnpkg.com/), you can install the packages by running:
 
@@ -27,4 +23,14 @@ If you are using [Yarn](https://yarnpkg.com/), you can install the packages by r
 yarn add @cornerstonejs/core
 yarn add @cornerstonejs/tools
 yarn add @cornerstonejs/streaming-image-volume-loader
+```
+
+## PNPM
+
+If you are using [PNPM](https://pnpm.io), you can install packages by running:
+
+```bash
+pnpm install @cornerstonejs/core
+pnpm install @cornerstonejs/tools
+pnpm install @cornerstonejs/streaming-image-volume-loader
 ```


### PR DESCRIPTION
### Context

The current installation page has these questions:
* NPM installation script is splited into three code blocks which is unnecessary
* Lack of YARN section title
* Lack of  [PNPM](https://pnpm.io) which is also a popular package manager

### Changes & Results

* Combine the splitted npm install code blocks into one
* Add YARN and PNPM section and their corresponding installation script

### Testing

None

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [x] "Node version: <!--[e.g. 16.14.0]"-->
- [x] "Browser:
