### PR TITLE
fix: Lockup in request pool when returning non promise result

### DIFF
--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -3479,6 +3479,9 @@ function pointInEllipse(ellipse: any, pointLPS: any, inverts?: Inverts): boolean
 function pointInShapeCallback(imageData: vtkImageData | Types_2.CPUImageData, pointInShapeFn: ShapeFnCriteria, callback?: PointInShapeCallback, boundsIJK?: BoundsIJK_2): Array<PointInShape>;
 
 // @public (undocumented)
+function pointInSurroundingSphereCallback(imageData: vtkImageData, circlePoints: [Types_2.Point3, Types_2.Point3], callback: PointInShapeCallback, viewport?: Types_2.IVolumeViewport): void;
+
+// @public (undocumented)
 const pointsAreWithinCloseContourProximity: (p1: Types_2.Point2, p2: Types_2.Point2, closeContourProximity: number) => boolean;
 
 // @public (undocumented)
@@ -5361,6 +5364,7 @@ declare namespace utilities {
         getAnnotationNearPoint,
         getAnnotationNearPointOnEnabledElement,
         jumpToSlice,
+        pointInSurroundingSphereCallback,
         viewport,
         cine,
         clip_2 as clip,

--- a/packages/core/src/requestPool/requestPoolManager.ts
+++ b/packages/core/src/requestPool/requestPoolManager.ts
@@ -239,10 +239,17 @@ class RequestPoolManager {
         this.numRequests[type]++;
         this.awake = true;
 
-        requestDetails.requestFn()?.finally(() => {
+        const requestResult = requestDetails.requestFn();
+        if (requestResult?.finally) {
+          requestResult.finally(() => {
+            this.numRequests[type]--;
+            this.startAgain();
+          });
+        } else {
+          // Handle non-async request functions too - typically just short circuit ones
           this.numRequests[type]--;
-          this.startAgain();
-        });
+          i--;
+        }
       }
     }
 

--- a/packages/dicomImageLoader/src/imageLoader/wadouri/loadImage.ts
+++ b/packages/dicomImageLoader/src/imageLoader/wadouri/loadImage.ts
@@ -126,12 +126,7 @@ function loadImageFromDataSet(
         const pixelData = getPixelData(dataSet, frame);
         const transferSyntax = dataSet.string('x00020010');
 
-        imagePromise = createImage(
-          imageId,
-          pixelData,
-          transferSyntax,
-          options
-        );
+        imagePromise = createImage(imageId, pixelData, transferSyntax, options);
       } catch (error) {
         // Reject the error, and the dataSet
         reject({
@@ -177,13 +172,10 @@ function loadImage(
   const parsedImageId = parseImageId(imageId);
 
   options = Object.assign({}, options);
-  let loader = options.loader;
-
-  if (loader === undefined) {
-    loader = getLoaderForScheme(parsedImageId.scheme);
-  } else {
-    delete options.loader;
-  }
+  // The options might have a loader, but it is a loader into the cache, so not
+  // the scheme loader, which is separate
+  delete options.loader;
+  const schemeLoader = getLoaderForScheme(parsedImageId.scheme);
 
   // if the dataset for this url is already loaded, use it, in case of multiframe
   // images, we need to extract the frame pixelData from the dataset although the
@@ -194,7 +186,7 @@ function loadImage(
      */
     const dataSet: DataSet = (dataSetCacheManager as any).get(
       parsedImageId.url,
-      loader,
+      schemeLoader,
       imageId
     );
 
@@ -210,7 +202,7 @@ function loadImage(
   // load the dataSet via the dataSetCacheManager
   const dataSetPromise = dataSetCacheManager.load(
     parsedImageId.url,
-    loader,
+    schemeLoader,
     imageId
   );
 

--- a/packages/streaming-image-volume-loader/src/BaseStreamingImageVolume.ts
+++ b/packages/streaming-image-volume-loader/src/BaseStreamingImageVolume.ts
@@ -453,6 +453,7 @@ export default class BaseStreamingImageVolume
     const { cachedFrames } = this;
 
     if (cachedFrames[imageIdIndex] === ImageQualityStatus.FULL_RESOLUTION) {
+      // The request framework handles non-promise returns, so just return here
       return;
     }
 

--- a/packages/tools/src/utilities/index.ts
+++ b/packages/tools/src/utilities/index.ts
@@ -25,6 +25,7 @@ import { getSphereBoundsInfo } from './getSphereBoundsInfo';
 import scroll from './scroll';
 import { pointToString } from './pointToString';
 import annotationFrameRange from './annotationFrameRange';
+import pointInSurroundingSphereCallback from './pointInSurroundingSphereCallback';
 
 // name spaces
 import * as contours from './contours';
@@ -75,6 +76,7 @@ export {
   getAnnotationNearPoint,
   getAnnotationNearPointOnEnabledElement,
   jumpToSlice,
+  pointInSurroundingSphereCallback,
   viewport,
   cine,
   clip,

--- a/yarn.lock
+++ b/yarn.lock
@@ -17399,7 +17399,7 @@ pkg-up@^3.1.0:
   version "1.1.0"
   resolved "https://codeload.github.com/ataft/plugin-image-zoom/tar.gz/8e1b866c79ed6d42cefc4c52f851f1dfd1d0c7de"
   dependencies:
-    medium-zoom "^1.0.4"
+    medium-zoom "^1.0.8"
 
 posix-character-classes@^0.1.0:
   version "0.1.1"


### PR DESCRIPTION
### Context

The wrong loader was being used in the URI loadImage call, and there was a bug in the request pool manager that failed to start requests when the request returned an empty result instead of a promise (eg short circuit)

### Changes & Results

Fix the request pool manager to ensure the counts are decremented even on no response
Fix the loadImage to use the original scheme loader (the options loader was never specified, so it wasn't relevant, and was slightly different in the newer version, so wasn't working)

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
