### PR TITLE
fix: Add getTargetId method to viewports

### DIFF
--- a/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
@@ -35,6 +35,7 @@ import type {
   VOIRange,
   EventTypes,
   VolumeViewportProperties,
+  TargetSpecifier,
 } from '../types';
 import { VoiModifiedEventDetail } from '../types/EventTypes';
 import type { ViewportInput } from '../types/IViewport';
@@ -1382,9 +1383,27 @@ abstract class BaseVolumeViewport extends Viewport implements IVolumeViewport {
     return imageVolume.imageIds;
   };
 
-  abstract getCurrentImageIdIndex(): number;
-
   abstract getCurrentImageId(): string;
+
+  public getTargetId(specifier: TargetSpecifier = {}): string {
+    let { volumeId, sliceIndex } = specifier;
+    if (!volumeId) {
+      const actorEntries = this.getActors();
+      if (!actorEntries) {
+        return;
+      }
+      // find the first image actor of instance type vtkVolume
+      volumeId = actorEntries.find(
+        (actorEntry) => actorEntry.actor.getClassName() === 'vtkVolume'
+      )?.uid;
+    }
+
+    sliceIndex ??= this.getCurrentImageIdIndex();
+    const { viewPlaneNormal, focalPoint } = this.getCamera();
+    return `volumeId:${volumeId}?sliceIndex=${sliceIndex}&viewPlaneNormal=${viewPlaneNormal.join(
+      ','
+    )}&focalPoint=${focalPoint.join(',')}`;
+  }
 
   abstract setBlendMode(
     blendMode: BlendModes,

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -35,7 +35,7 @@ import type {
   VOIRange,
   VolumeActor,
 } from '../types';
-import { ViewportInput } from '../types/IViewport';
+import { TargetSpecifier, ViewportInput } from '../types/IViewport';
 import {
   actorIsA,
   colormap as colormapUtils,
@@ -2811,6 +2811,11 @@ class StackViewport extends Viewport implements IStackViewport, IImagesLoader {
   public getCurrentImageIdIndex = (): number => {
     return this.currentImageIdIndex;
   };
+
+  public getTargetId(specifier: TargetSpecifier = {}): string {
+    const { sliceIndex: imageIdIndex = this.currentImageIdIndex } = specifier;
+    return `imageId:${this.imageIds[imageIdIndex]}`;
+  }
 
   /**
    *

--- a/packages/core/src/RenderingEngine/Viewport.ts
+++ b/packages/core/src/RenderingEngine/Viewport.ts
@@ -30,7 +30,11 @@ import type {
   EventTypes,
   DisplayArea,
 } from '../types';
-import type { ViewportInput, IViewport } from '../types/IViewport';
+import type {
+  ViewportInput,
+  IViewport,
+  TargetSpecifier,
+} from '../types/IViewport';
 import type { vtkSlabCamera } from './vtkClasses/vtkSlabCamera';
 import { getConfiguration } from '../init';
 import IImageCalibration from '../types/IImageCalibration';
@@ -882,6 +886,14 @@ class Viewport implements IViewport {
       vec2.subtract(vec2.create(), initialCanvasFocal, currentCanvasFocal)
     );
     return result;
+  }
+
+  public getCurrentImageIdIndex(): number {
+    throw new Error('Not implemented');
+  }
+
+  public getTargetId(specifier?: TargetSpecifier): string {
+    return null;
   }
 
   /**

--- a/packages/core/src/types/IViewport.ts
+++ b/packages/core/src/types/IViewport.ts
@@ -8,6 +8,20 @@ import ViewportStatus from '../enums/ViewportStatus';
 import DisplayArea from './displayArea';
 
 /**
+ * Specifies what image to get a reference for.
+ */
+export type TargetSpecifier = {
+  /** The slice index within the current viewport camera to get a reference for */
+  sliceIndex?: number;
+  /** True to get a frame of reference UID reference instead of a regular image one */
+  forFrameOfReference?: boolean;
+  /** Set of points to get a reference for, in world space */
+  points?: Point3[];
+  /** The volumeId to reference */
+  volumeId?: string;
+};
+
+/**
  * Viewport interface for cornerstone viewports
  */
 interface IViewport {
@@ -107,6 +121,10 @@ interface IViewport {
   setCamera(cameraInterface: ICamera, storeAsInitialCamera?: boolean): void;
   /** Gets the number of slices in the current camera orientation */
   getNumberOfSlices(): number;
+  /** Gets the current slice in the current camera orientation */
+  getCurrentImageIdIndex(): number;
+  /** Gets a referenced image url of some sort - could be a real image id, or could be a URL with parameters */
+  getTargetId(forTarget?: TargetSpecifier): string;
   /** whether the viewport has custom rendering */
   customRenderViewportToCanvas: () => unknown;
   _getCorners(bounds: Array<number>): Array<number>[];

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -13,7 +13,11 @@ import type VolumeLoaderFn from './VolumeLoaderFn';
 import type IRegisterImageLoader from './IRegisterImageLoader';
 import type IStreamingVolumeProperties from './IStreamingVolumeProperties';
 import type CustomEventType from './CustomEventType';
-import type { IViewport, PublicViewportInput } from './IViewport';
+import type {
+  IViewport,
+  PublicViewportInput,
+  TargetSpecifier,
+} from './IViewport';
 import type { VolumeActor, Actor, ActorEntry, ImageActor } from './IActor';
 import type {
   IImageLoadObject,
@@ -141,6 +145,7 @@ export type {
   IRegisterImageLoader,
   IStreamingVolumeProperties,
   IViewport,
+  TargetSpecifier,
   StackViewportProperties,
   VolumeViewportProperties,
   ViewportProperties,

--- a/packages/tools/src/tools/base/BaseTool.ts
+++ b/packages/tools/src/tools/base/BaseTool.ts
@@ -206,7 +206,10 @@ abstract class BaseTool implements IBaseTool {
 
       return viewports[0].getImageData();
     } else if (targetId.startsWith('volumeId:')) {
-      const volumeId = targetId.split('volumeId:')[1];
+      const query = targetId.indexOf('?');
+      const volumeId = targetId
+        .substring(0, query === -1 ? undefined : query)
+        .split('volumeId:')[1];
       const viewports = utilities.getViewportsWithVolumeId(
         volumeId,
         renderingEngine.id
@@ -248,17 +251,14 @@ abstract class BaseTool implements IBaseTool {
    * @returns targetId
    */
   protected getTargetId(viewport: Types.IViewport): string | undefined {
-    if (viewport instanceof StackViewport) {
-      return `imageId:${viewport.getCurrentImageId()}`;
-    } else if (viewport instanceof BaseVolumeViewport) {
-      return `volumeId:${this.getTargetVolumeId(viewport)}`;
-    } else if (viewport instanceof VideoViewport) {
-      return `videoId:${viewport.getCurrentImageId()}`;
-    } else {
-      throw new Error(
-        'getTargetId: viewport must be a StackViewport or VolumeViewport'
-      );
+    const targetId = viewport.getTargetId?.();
+    if (targetId) {
+      return targetId;
     }
+    if (viewport instanceof BaseVolumeViewport) {
+      return `volumeId:${this.getTargetVolumeId(viewport)}`;
+    }
+    throw new Error('getTargetId: viewport must have a getTargetId method');
   }
 }
 


### PR DESCRIPTION

### Context
The method used to get target id's for annotations isn't very consistent, and for contour segmentations which may need target id's for viewports not currently in view, this becomes important to include a well defined target method, in particular, for video viewports with interpolation of contours, a new method is required that is consistent.

### Changes & Results

Add a getTargetId method that can optionally include a slice index and includes the viewport positioning for volumes in order to allow a single target id to be defined/used for generating contour annotations as well as regular annotations.

### Testing

Test annotations on several frames of viewports.  The annotation should remain on the correct frame.
video
stack
volume

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
