### PR TITLE
fix: wrong color convert error message

### DIFF
--- a/packages/dicomImageLoader/src/imageLoader/colorSpaceConverters/convertYBRFull422ByPixel.ts
+++ b/packages/dicomImageLoader/src/imageLoader/colorSpaceConverters/convertYBRFull422ByPixel.ts
@@ -9,7 +9,7 @@ export default function (
     throw new Error('decodeRGB: ybrBuffer must not be undefined');
   }
   if (imageFrame.length % 2 !== 0) {
-    throw new Error('decodeRGB: ybrBuffer length must be divisble by 3');
+    throw new Error('decodeRGB: ybrBuffer length must be divisble by 2');
   }
 
   const numPixels = imageFrame.length / 2;


### PR DESCRIPTION
### Context

Wrong error message. According to the code context, the message shoulde be "divisble by 2" instead of "divisble by 3"

### Changes & Results

```diff
- throw new Error('decodeRGB: ybrBuffer length must be divisble by 3');   
+ throw new Error('decodeRGB: ybrBuffer length must be divisble by 2');
```

### Testing

None

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)

#### Public Documentation Updates

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Ubuntu 23.10
- [x] "Node version: 20.10.0
- [x] "Browser: Chrome 120.0.6099.225