### PR TITLE
fix: wrong param passed to setLabelOutlineThickness

### DIFF
--- a/packages/tools/src/tools/displayTools/Labelmap/labelmapDisplay.ts
+++ b/packages/tools/src/tools/displayTools/Labelmap/labelmapDisplay.ts
@@ -332,7 +332,7 @@ function _setLabelmapColorAndOpacity(
         : outlineWidth;
   }
 
-  actor.getProperty().setLabelOutlineThickness(outlineWidths);
+  actor.getProperty().setLabelOutlineThickness(outlineWidth);
 
   // Set visibility based on whether actor visibility is specifically asked
   // to be turned on/off (on by default) AND whether is is in active but


### PR DESCRIPTION
### Context

Fix wrong param passed to `actor.getProperty().setLabelOutlineThickness`
The `setLabelOutlineThickness` accept `number` type not `Array<number>`, the current code would cause tsc build error.
And according to the comment context, it should be `outlineWidth` instead of `outlineWidths`

### Changes & Results

```diff
- actor.getProperty().setLabelOutlineThickness(outlineWidths);
+ actor.getProperty().setLabelOutlineThickness(outlineWidth);
```

### Testing

None

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Ubutnu 23.10
- [x] "Node version: 20.10.0
- [x] "Browser: Chrome 120.0.6099.225
