### PR TITLE
fix: add auto remove when outside image for AngleTool

### DIFF
--- a/packages/tools/src/tools/annotation/AngleTool.ts
+++ b/packages/tools/src/tools/annotation/AngleTool.ts
@@ -3,6 +3,7 @@ import {
   getEnabledElement,
   triggerEvent,
   eventTarget,
+  utilities as csUtils,
 } from '@cornerstonejs/core';
 import type { Types } from '@cornerstonejs/core';
 
@@ -823,7 +824,15 @@ class AngleTool extends AnnotationTool {
         [worldPos1, worldPos2],
         [worldPos2, worldPos3]
       );
+      const { dimensions, imageData } = this.getTargetIdImage(
+        targetId,
+        renderingEngine
+      );
 
+      // Decide if there's at least one handle is outside of image
+      this.isHandleOutsideImage = [worldPos1, worldPos2, worldPos3]
+        .map((worldPos) => csUtils.transformWorldToIndex(imageData, worldPos))
+        .some((index) => !csUtils.indexWithinDimensions(index, dimensions));
       cachedStats[targetId] = {
         angle: isNaN(angle) ? 'Incomplete Angle' : angle,
       };


### PR DESCRIPTION
### Context
The Angle tool does not support for auto removing when outside image. 

### Changes & Results
Use the `transformWorldToIndex` and `indexWithinDimensions` in `utilities` module in @cornerstonejs/core package to decide whether all the handles are within image. If not, make the `isHandleOutsideImage` value become `true`

### Testing
![cs-angle-remove-when-outside-image](https://github.com/cornerstonejs/cornerstone3D/assets/41723543/98f2f26e-c4f6-4d2b-b253-58c53a3b3f72)

### Checklist

#### PR
- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)

#### Public Documentation Updates

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [x] "Node version: 20.10.0
- [x] "Browser: 120.0.6099.225
