### PR TITLE
fix(splines): add auto removing when outside image for SplineROITool series

### DIFF
--- a/packages/tools/src/tools/annotation/SplineROITool.ts
+++ b/packages/tools/src/tools/annotation/SplineROITool.ts
@@ -1,8 +1,8 @@
-import { utilities } from '@cornerstonejs/core';
 import {
   getEnabledElement,
   eventTarget,
   triggerEvent,
+  utilities,
 } from '@cornerstonejs/core';
 import type { Types } from '@cornerstonejs/core';
 import { vec3 } from 'gl-matrix';
@@ -304,6 +304,16 @@ class SplineROITool extends ContourSegmentationBaseTool {
 
     const enabledElement = getEnabledElement(element);
     const { renderingEngine } = enabledElement;
+
+    // Decide whether there's at least one point is outside image
+    const image = this.getTargetIdImage(
+      this.getTargetId(enabledElement.viewport),
+      enabledElement.renderingEngine
+    );
+    const { imageData, dimensions } = image;
+    this.isHandleOutsideImage = data.handles.points
+      .map((p) => utilities.transformWorldToIndex(imageData, p))
+      .some((index) => !utilities.indexWithinDimensions(index, dimensions));
 
     if (
       this.isHandleOutsideImage &&


### PR DESCRIPTION
### Context

Make `SplineROITool` auto removing when there's at least one of the  points is outside of image range.

### Changes & Results

In the `_endCallback`, determine whether to removing the annotation based on the points position is within image range or not.

### Testing
![cs-spline-remove-when-outside-image](https://github.com/cornerstonejs/cornerstone3D/assets/41723543/0917d505-2062-42c7-93df-458e67122560)

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Ubuntu 23.10
- [x] "Node version: 20.10.0
- [x] "Browser: Chrome 120.0.6099.225