### PR TITLE
fix(spline): spline ROI/Seg broken

### DIFF
--- a/packages/tools/src/tools/annotation/SplineROITool.ts
+++ b/packages/tools/src/tools/annotation/SplineROITool.ts
@@ -785,7 +785,7 @@ class SplineROITool extends ContourSegmentationBaseTool {
     // Add an action to create a new spline data on creating an interpolated
     // instance.
     let postInterpolateAction;
-    if (this.configuration.interpolation.enabled) {
+    if (this.configuration.interpolation?.enabled) {
       postInterpolateAction = (annotation) => {
         annotation.data.spline ||= createSpline();
         this.createInterpolatedSplineControl(annotation);


### PR DESCRIPTION
### Context

Spline ROI/Segmentation examples are broken because it SplineROITool class expects to have `configuration.interpolation.enabled` configuration and it fails when it is undefined.

### Changes & Results

Changed `configuration.interpolation.enabled` to `configuration.interpolation?.enabled` to make sure it will not fail when `interpolation` configuration is not available.

### Testing

Check Spline ROI Tools, Spline Segmentation Tools and Advanced Spline Segmentaion Tools examples.