### PR TITLE
Pr/feat/more datatype

### DIFF
--- a/common/reviews/api/nifti-volume-loader.api.md
+++ b/common/reviews/api/nifti-volume-loader.api.md
@@ -46,7 +46,7 @@ export { helpers }
 function makeVolumeMetadata(niftiHeader: any, orientation: any, scalarData: any): Types.Metadata;
 
 // @public (undocumented)
-function modalityScaleNifti(array: Float32Array | Int16Array | Uint8Array, niftiHeader: any): void;
+function modalityScaleNifti(array: Uint8Array | Int16Array | Int32Array | Float32Array | Float64Array | Int8Array | Uint16Array | Uint32Array, niftiHeader: any): void;
 
 // @public (undocumented)
 export class NiftiImageVolume extends ImageVolume {

--- a/packages/nifti-volume-loader/src/helpers/convert.ts
+++ b/packages/nifti-volume-loader/src/helpers/convert.ts
@@ -44,7 +44,7 @@ const invertDataPerFrame = (dimensions, imageDataArray) => {
 
   // Make a copy of the data first using the browser native fast TypedArray.set().
   const newImageDataArray = new TypedArrayConstructor(
-    imageDataArray.byteLength
+    imageDataArray.byteLength / bytesPerVoxel
   );
 
   const view = new TypedArrayConstructor(imageDataArray);

--- a/packages/nifti-volume-loader/src/helpers/convert.ts
+++ b/packages/nifti-volume-loader/src/helpers/convert.ts
@@ -18,8 +18,23 @@ const invertDataPerFrame = (dimensions, imageDataArray) => {
   } else if (imageDataArray instanceof Int16Array) {
     TypedArrayConstructor = Int16Array;
     bytesPerVoxel = 2;
+  } else if (imageDataArray instanceof Int32Array) {
+    TypedArrayConstructor = Int32Array;
+    bytesPerVoxel = 4;
   } else if (imageDataArray instanceof Float32Array) {
     TypedArrayConstructor = Float32Array;
+    bytesPerVoxel = 4;
+  } else if (imageDataArray instanceof Float64Array) {
+    TypedArrayConstructor = Float64Array;
+    bytesPerVoxel = 8;
+  } else if (imageDataArray instanceof Int8Array) {
+    TypedArrayConstructor = Int8Array;
+    bytesPerVoxel = 1;
+  } else if (imageDataArray instanceof Uint16Array) {
+    TypedArrayConstructor = Uint16Array;
+    bytesPerVoxel = 2;
+  } else if (imageDataArray instanceof Uint32Array) {
+    TypedArrayConstructor = Uint32Array;
     bytesPerVoxel = 4;
   } else {
     throw new Error(

--- a/packages/nifti-volume-loader/src/helpers/convert.ts
+++ b/packages/nifti-volume-loader/src/helpers/convert.ts
@@ -38,7 +38,7 @@ const invertDataPerFrame = (dimensions, imageDataArray) => {
     bytesPerVoxel = 4;
   } else {
     throw new Error(
-      'imageDataArray needs to be a Uint8Array, Int16Array or Float32Array.'
+      'imageDataArray needs to be a Uint8Array, Int16Array, Int32Array, Float32Array, Float64Array, Int8Array, Uint16Array or Uint32Array.'
     );
   }
 

--- a/packages/nifti-volume-loader/src/helpers/fetchAndAllocateNiftiVolume.ts
+++ b/packages/nifti-volume-loader/src/helpers/fetchAndAllocateNiftiVolume.ts
@@ -159,7 +159,6 @@ export default async function fetchAndAllocateNiftiVolume(
 
   const {
     BitsAllocated,
-    PixelRepresentation,
     PhotometricInterpretation,
     ImageOrientationPatient,
     Columns,
@@ -194,7 +193,6 @@ export default async function fetchAndAllocateNiftiVolume(
     scanAxisNormal[1],
     scanAxisNormal[2],
   ]) as Types.Mat3;
-  const signed = PixelRepresentation === 1;
 
   // Check if it fits in the cache before we allocate data
   // TODO Improve this when we have support for more types
@@ -223,17 +221,11 @@ export default async function fetchAndAllocateNiftiVolume(
 
   let scalarData;
 
-  switch (BitsAllocated) {
-    case 8:
-      if (signed) {
-        throw new Error(
-          '8 Bit signed images are not yet supported by this plugin.'
-        );
-      } else {
-        scalarData = createUint8SharedArray(
-          dimensions[0] * dimensions[1] * dimensions[2]
-        );
-      }
+  switch (niftiHeader.datatypeCode) {
+    case NIFTICONSTANTS.NIFTI_TYPE_UINT8:
+      scalarData = createUint8SharedArray(
+        dimensions[0] * dimensions[1] * dimensions[2]
+      );
 
       break;
 

--- a/packages/nifti-volume-loader/src/helpers/fetchAndAllocateNiftiVolume.ts
+++ b/packages/nifti-volume-loader/src/helpers/fetchAndAllocateNiftiVolume.ts
@@ -237,8 +237,7 @@ export default async function fetchAndAllocateNiftiVolume(
 
       break;
 
-    case 16:
-    case 32:
+    default:
       scalarData = createFloat32SharedArray(
         dimensions[0] * dimensions[1] * dimensions[2]
       );

--- a/packages/nifti-volume-loader/src/helpers/fetchAndAllocateNiftiVolume.ts
+++ b/packages/nifti-volume-loader/src/helpers/fetchAndAllocateNiftiVolume.ts
@@ -71,10 +71,20 @@ export const getTypedNiftiArray = (datatypeCode, niftiImageBuffer) => {
   switch (datatypeCode) {
     case NIFTICONSTANTS.NIFTI_TYPE_UINT8:
       return new Uint8Array(niftiImageBuffer);
-    case NIFTICONSTANTS.NIFTI_TYPE_FLOAT32:
-      return new Float32Array(niftiImageBuffer);
     case NIFTICONSTANTS.NIFTI_TYPE_INT16:
       return new Int16Array(niftiImageBuffer);
+    case NIFTICONSTANTS.NIFTI_TYPE_INT32:
+      return new Int32Array(niftiImageBuffer);
+    case NIFTICONSTANTS.NIFTI_TYPE_FLOAT32:
+      return new Float32Array(niftiImageBuffer);
+    case NIFTICONSTANTS.NIFTI_TYPE_FLOAT64:
+      return new Float64Array(niftiImageBuffer);
+    case NIFTICONSTANTS.NIFTI_TYPE_INT8:
+      return new Int8Array(niftiImageBuffer);
+    case NIFTICONSTANTS.NIFTI_TYPE_UINT16:
+      return new Uint16Array(niftiImageBuffer);
+    case NIFTICONSTANTS.NIFTI_TYPE_UINT32:
+      return new Uint32Array(niftiImageBuffer);
     default:
       throw new Error(`datatypeCode ${datatypeCode} is not yet supported`);
   }

--- a/packages/nifti-volume-loader/src/helpers/modalityScaleNifti.ts
+++ b/packages/nifti-volume-loader/src/helpers/modalityScaleNifti.ts
@@ -8,7 +8,15 @@
  * @returns The array being scaled
  */
 export default function modalityScaleNifti(
-  array: Float32Array | Int16Array | Uint8Array,
+  array:
+    | Uint8Array
+    | Int16Array
+    | Int32Array
+    | Float32Array
+    | Float64Array
+    | Int8Array
+    | Uint16Array
+    | Uint32Array,
   niftiHeader
 ): void {
   const arrayLength = array.length;


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
[Feature Request] #964
<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
Before: The nifti-volume-loader can not read nifti file with datatype such as int32, float64, int8, uint16 and uint32, so the cornerstone3D cannot render them.
After: The nifti-volume-loader can read nifti file with datatype such as int32, float64, int8, uint16 and uint32.
<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
Use the nifti-volume-loader component to load nifti file with datatype such as int32, float64, int8, uint16 and uint32.
<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"--> Ubuntu 18.04, macOS 14.2.1
- [] "Node version: <!--[e.g. 16.14.0]"--> v16.14.0
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"--> Chrome 120.0.6099.234

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->



Title
feat(NiftiVolumeLoader): enable the nifti-volume-loader to read nifti file with datatype such as int32, float64, int8, uint16 and uint32. Because there is something wrong with function ‘createInt16SharedArray’ and ‘createUint16SharedArray’(window.crossOriginIsolated is false), Float32SharedArray is used for representing datatypes except for uint8.