### PR TITLE
fix: wrong closed status value in SplineROI tool

### DIFF
--- a/packages/tools/src/tools/annotation/SplineROITool.ts
+++ b/packages/tools/src/tools/annotation/SplineROITool.ts
@@ -813,7 +813,7 @@ class SplineROITool extends ContourSegmentationBaseTool {
     const data = annotation.data;
     const targetId = this.getTargetId(viewport);
 
-    if (!data.spline.closed || !textboxStyle.visibility) {
+    if (!data.spline.instance.closed || !textboxStyle.visibility) {
       return;
     }
 


### PR DESCRIPTION
### Context

The current `SplineROI` has a closed status value for every annotaion. And it is stored in the `annotation.data.spline.instance.closed`. But the current code is getting it from `annotation.data.spline.closed` which is always `undefined`
As a result it would cause losing the spline from calling `getTextlines` function. So the text part is missing in the final rendered svg



### Changes & Results

```diff
- if (!data.spline.closed || !textboxStyle.visibility) {
+ if (!data.spline.instance.closed || !textboxStyle.visibility) {
```

### Testing

* Before
![cs-spline-before-fix-text-show](https://github.com/cornerstonejs/cornerstone3D/assets/41723543/34a215e4-1b07-4f33-b06b-26c643594bcd)
* After
![cs-spline-after-fix-text-show](https://github.com/cornerstonejs/cornerstone3D/assets/41723543/74c5091e-b0d1-4d87-86d7-888b098030ac)

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS": Ubuntu 23.10
- [x] "Node version: 20.10.0
- [x] "Browser: Chrome 120.0.6099.225
