### PR TITLE
fix(WindowLevelTool): attempt to set zero width color range

### DIFF
--- a/packages/tools/src/tools/WindowLevelTool.ts
+++ b/packages/tools/src/tools/WindowLevelTool.ts
@@ -98,6 +98,11 @@ class WindowLevelTool extends BaseTool {
       });
     }
 
+    // If the range is not valid. Do nothing
+    if (newRange.lower >= newRange.upper) {
+      return;
+    }
+
     viewport.setProperties({
       voiRange: newRange,
     });


### PR DESCRIPTION
### Context

When using mouse with `WindowLevelTool`. When the `voiRange.upper` is equal to or less than `voiRange.lower`, would cause `attempt to set zero width color range` in the console.

### Changes & Results

Add a condition to ensure `voiRange.upper` is larger than `voiRange.lower`

### Testing

* Before
![cs-window-level-before-fix](https://github.com/cornerstonejs/cornerstone3D/assets/41723543/5e82c33e-b988-4882-ac97-b6c9e6cbf772)
* After
![cs-window-level-after-fix](https://github.com/cornerstonejs/cornerstone3D/assets/41723543/4f060649-fd1b-4908-9c57-f940ba99ae19)


### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Ubuntu 23.10
- [x] Node version: 20.10.0
- [x] Browser: Chrome 120.0.6099.225
