### PR TITLE
fix(dicom-image-loader): add rgba condition interception for canvas createImageData API

### DIFF
--- a/packages/dicomImageLoader/src/imageLoader/createImage.ts
+++ b/packages/dicomImageLoader/src/imageLoader/createImage.ts
@@ -238,11 +238,18 @@ function createImage(
           canvas.height = imageFrame.rows;
           canvas.width = imageFrame.columns;
           const context = canvas.getContext('2d');
-          const imageData = context.createImageData(
+          let imageData = context.createImageData(
             imageFrame.columns,
             imageFrame.rows
           );
-
+          if (!useRGBA) {
+            imageData = {
+              ...imageData,
+              data: new Uint8ClampedArray(
+                3 * imageFrame.columns * imageFrame.rows
+              ),
+            };
+          }
           convertColorSpace(imageFrame, imageData.data, useRGBA);
           imageFrame.imageData = imageData;
           imageFrame.pixelData = imageData.data;

--- a/packages/dicomImageLoader/src/imageLoader/createImage.ts
+++ b/packages/dicomImageLoader/src/imageLoader/createImage.ts
@@ -246,7 +246,9 @@ function createImage(
             imageData = {
               ...imageData,
               data: new Uint8ClampedArray(
-                3 * imageFrame.columns * imageFrame.rows
+                imageFrame.samplesPerPixel *
+                  imageFrame.columns *
+                  imageFrame.rows
               ),
             };
           }


### PR DESCRIPTION
### Context

The canvas context API `createImageData ` would always return a `ImageData `. And its `data` field is always a rgba color mode `Uint8ClampedArray `, like this:
![image](https://github.com/cornerstonejs/cornerstone3D/assets/41723543/3d4c36a4-84b6-4fbb-a7fe-e216dad26def)

In the newest vtk package which has already been upragded in cornserstone repo would throw a error like this:
![image](https://github.com/cornerstonejs/cornerstone3D/assets/41723543/a6ad00a6-e2f7-4b29-9a88-a4241ad2a7cc)

As a result, the image would not render.

This PR fix it.

### Changes & Results

Add a condition, if not using rgba, then replace the data with a new Uint8ClampedArray with  `imageFrame.samplesPerPixel * columns * rows`  length

### Testing
I've tested on my private project. I'm sorry I can't share it with others because the image 
 belongs to company.

Sorr for the inconvenience.

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Ubuntu 23.10
- [x] Node version: 20.10.0
- [x] Browser: Chrome 120.0.6099.227

