### PR TITLE
fix(Magnify): add flag to jump error and unnecessary logic

### DIFF
--- a/packages/tools/src/tools/MagnifyTool.ts
+++ b/packages/tools/src/tools/MagnifyTool.ts
@@ -42,6 +42,8 @@ class MagnifyTool extends BaseTool {
     super(toolProps, defaultToolProps);
   }
 
+  private _hasBeenRemoved = false;
+
   _getReferencedImageId(
     viewport: Types.IStackViewport | Types.IVolumeViewport
   ): string {
@@ -155,8 +157,10 @@ class MagnifyTool extends BaseTool {
     const magnifyViewport = renderingEngine.getViewport(
       MAGNIFY_VIEWPORT_ID
     ) as Types.IStackViewport;
-
     magnifyViewport.setStack([referencedImageId]).then(() => {
+      if (this._hasBeenRemoved) {
+        return;
+      }
       // match the original viewport voi range
       magnifyViewport.setProperties(viewportProperties);
 
@@ -261,10 +265,12 @@ class MagnifyTool extends BaseTool {
 
     this._deactivateDraw(element);
     resetElementCursor(element);
+    this._hasBeenRemoved = true;
   };
 
   _activateDraw = (element: HTMLDivElement) => {
     state.isInteractingWithTool = true;
+    this._hasBeenRemoved = false;
 
     element.addEventListener(
       Events.MOUSE_UP,


### PR DESCRIPTION
### Context
The current Magnify tool would cause an error when just single clicked on the canvas.
![magnify-before-fix](https://github.com/cornerstonejs/cornerstone3D/assets/41723543/558be49a-43e7-404a-804e-1116e99cf334)

The reason is `setStack` is an async function. In the `then` callback, the magnify element has already been removed from the dom tree. So the `setProperties` function would cause this error.

This PR fix #866 

### Changes & Results

And a flag `_hasBeenRemoved` to determine whether the current magnify element has been removed from dom tree. Change its status to `true` in the `_dragEndCallback`. Restore to `false` in the `_activateDraw`.  Use it in the `setStack` callback, if `true`, then do nothing.

### Testing
![magnify-after-fix](https://github.com/cornerstonejs/cornerstone3D/assets/41723543/93918e18-1f1f-4aa9-854f-b355bed9587e)

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Ubuntu 23.10
- [x] Node version: 20.10.0
- [x] Browser: Chrome 121.0.6167.86