### PR TITLE
fix: Refactor image splitting logic for 4D datasets

### DIFF
--- a/packages/streaming-image-volume-loader/src/helpers/splitImageIdsBy4DTags.ts
+++ b/packages/streaming-image-volume-loader/src/helpers/splitImageIdsBy4DTags.ts
@@ -1,21 +1,20 @@
 import { metaData } from '@cornerstonejs/core';
 
-// TODO: add support for other 4D tags as listed below
+// TODO: Test remaining implemented tags
 // Supported 4D Tags
-//   (0018,1060) Trigger Time                   [NOK]
-//   (0018,0081) Echo Time                      [NOK]
-//   (0018,0086) Echo Number                    [NOK]
+//   (0018,1060) Trigger Time                   [Implemented, not tested]
+//   (0018,0081) Echo Time                      [Implemented, not tested]
+//   (0018,0086) Echo Number                    [Implemented, not tested]
 //   (0020,0100) Temporal Position Identifier   [OK]
 //   (0054,1300) FrameReferenceTime             [OK]
+//   (0018,9087) Diffusion B Value              [OK]
+//   (2001,1003) Philips Diffusion B-factor     [OK]
+//   (0019,100c) Siemens Diffusion B Value      [Implemented, not tested]
+//   (0043,1039) GE Diffusion B Value           [OK]
 
-interface MappedFrameReferenceTime {
+interface MappedIPP {
   imageId: string;
-  frameReferenceTime: number;
-}
-
-interface MappedTemporalPositionIdentifier {
-  imageId: string;
-  temporalPositionIdentifier: number;
+  imagePositionPatient;
 }
 
 const groupBy = (array, key) => {
@@ -25,32 +24,148 @@ const groupBy = (array, key) => {
   }, {});
 };
 
-function splitFramesByMetadata(
-  imageIds: string[],
-  metadataField: string,
-  property: string
-): string[][] {
-  const framesMetadata: Array<any> = imageIds.map((imageId: string) => {
-    const moduleInfo = metaData.get(metadataField, imageId);
-    const propInfo = moduleInfo ? moduleInfo[property] : 0;
-    return { imageId, [property]: propInfo };
+function getIPPGroups(imageIds: string[]): { [id: string]: Array<MappedIPP> } {
+  const ippMetadata: Array<MappedIPP> = imageIds.map((imageId) => {
+    const imagePositionPatient = metaData.get('ImagePositionPatient', imageId);
+    return { imageId, imagePositionPatient };
   });
 
-  if (!framesMetadata.every((item) => item[property])) {
-    // some frames do not have the metadataField
+  if (!ippMetadata.every((item) => item.imagePositionPatient)) {
+    // Fail if any instances don't provide a position
     return null;
   }
 
-  const framesGroups = groupBy(framesMetadata, property);
-  const sortedKeys = Object.keys(framesGroups)
-    .map(Number.parseFloat)
-    .sort((a, b) => a - b);
-
-  const imageIdsGroups = sortedKeys.map((key) =>
-    framesGroups[key].map((item) => item.imageId)
+  const positionGroups = groupBy(ippMetadata, 'imagePositionPatient');
+  const positions = Object.keys(positionGroups);
+  const frame_count = positionGroups[positions[0]].length;
+  if (frame_count === 1) {
+    // Single frame indicates 3D volume
+    return null;
+  }
+  const frame_count_equal = positions.every(
+    (k) => positionGroups[k].length === frame_count
   );
+  if (!frame_count_equal) {
+    // Differences in number of frames per position group --> not a valid MV
+    return null;
+  }
+  return positionGroups;
+}
 
-  return imageIdsGroups;
+function test4DTag(
+  IPPGroups: { [id: string]: Array<MappedIPP> },
+  value_getter: (imageId: string) => number
+) {
+  const frame_groups = {};
+  let first_frame_value_set: number[] = [];
+
+  const positions = Object.keys(IPPGroups);
+  for (let i = 0; i < positions.length; i++) {
+    const frame_value_set: Set<number> = new Set<number>();
+    const frames = IPPGroups[positions[i]];
+
+    for (let j = 0; j < frames.length; j++) {
+      const frame_value = value_getter(frames[j].imageId) || 0;
+
+      frame_groups[frame_value] = frame_groups[frame_value] || [];
+      frame_groups[frame_value].push({ imageId: frames[j].imageId });
+
+      frame_value_set.add(frame_value);
+      if (frame_value_set.size - 1 < j) {
+        return undefined;
+      }
+    }
+
+    if (i == 0) {
+      first_frame_value_set = Array.from(frame_value_set);
+    } else if (!setEquals(first_frame_value_set, frame_value_set)) {
+      return undefined;
+    }
+  }
+  return frame_groups;
+}
+
+function getTagValue(imageId: string, tag: string): number {
+  const value = metaData.get(tag, imageId);
+  try {
+    return parseFloat(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function getPhilipsPrivateBValue(imageId: string) {
+  // Philips Private Diffusion B-factor tag (2001, 1003)
+  // Private creator: Philips Imaging DD 001, VR=FL, VM=1
+  const value = metaData.get('20011003', imageId);
+  try {
+    const { InlineBinary } = value;
+    if (InlineBinary) {
+      const value_bytes = atob(InlineBinary);
+      const ary_buf = new ArrayBuffer(value_bytes.length);
+      const dv = new DataView(ary_buf);
+      for (let i = 0; i < value_bytes.length; i++) {
+        dv.setUint8(i, value_bytes.charCodeAt(i));
+      }
+      //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      // For WebGL Buffers, can skip Float32Array,
+      // just return ArrayBuffer is all that's needed.
+      return new Float32Array(ary_buf)[0];
+    }
+
+    return parseFloat(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function getSiemensPrivateBValue(imageId: string) {
+  // Siemens Private Diffusion B-factor tag (0019, 100c)
+  // Private creator: SIEMENS MR HEADER, VR=IS, VM=1
+  let value = metaData.get('0019100c', imageId);
+
+  try {
+    const { InlineBinary } = value;
+    if (InlineBinary) {
+      value = atob(InlineBinary);
+    }
+    return parseFloat(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function getGEPrivateBValue(imageId: string) {
+  // GE Private Diffusion B-factor tag (0043, 1039)
+  // Private creator: GEMS_PARM_01, VR=IS, VM=4
+  let value = metaData.get('00431039', imageId);
+
+  try {
+    const { InlineBinary } = value;
+    if (InlineBinary) {
+      value = atob(InlineBinary).split('//');
+    }
+    return parseFloat(value[0]) % 100000;
+  } catch {
+    return undefined;
+  }
+}
+
+function setEquals(set_a: number[], set_b: Set<number>): boolean {
+  if (set_a.length != set_b.size) {
+    return false;
+  }
+  for (let i = 0; i < set_a.length; i++) {
+    if (!set_b.has(set_a[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function getPetFrameReferenceTime(imageId) {
+  const moduleInfo = metaData.get('petImageModule', imageId);
+  return moduleInfo ? moduleInfo['frameReferenceTime'] : 0;
 }
 
 /**
@@ -60,32 +175,34 @@ function splitFramesByMetadata(
  * @returns imageIds grouped by 4D tags
  */
 function splitImageIdsBy4DTags(imageIds: string[]): string[][] {
-  const fncList = [
-    (imageIds) =>
-      splitFramesByMetadata(imageIds, 'petImageModule', 'frameReferenceTime'),
-    (imageIds) =>
-      splitFramesByMetadata(
-        imageIds,
-        'temporalPositionIdentifier',
-        'temporalPositionIdentifier'
-      ),
+  const positionGroups = getIPPGroups(imageIds);
+  if (!positionGroups) {
+    return [imageIds];
+  }
+
+  const fncList2 = [
+    (imageId) => getTagValue(imageId, 'TemporalPositionIdentifier'),
+    (imageId) => getTagValue(imageId, 'DiffusionBValue'),
+    (imageId) => getTagValue(imageId, 'TriggerTime'),
+    (imageId) => getTagValue(imageId, 'EchoTime'),
+    (imageId) => getTagValue(imageId, 'EchoNumber'),
+    getPhilipsPrivateBValue,
+    getSiemensPrivateBValue,
+    getGEPrivateBValue,
+    getPetFrameReferenceTime,
   ];
 
-  for (let i = 0; i < fncList.length; i++) {
-    const framesGroups = fncList[i](imageIds);
+  for (let i = 0; i < fncList2.length; i++) {
+    const frame_groups = test4DTag(positionGroups, fncList2[i]);
+    if (frame_groups) {
+      const sortedKeys = Object.keys(frame_groups)
+        .map(Number.parseFloat)
+        .sort((a, b) => a - b);
 
-    if (!framesGroups || framesGroups.length <= 1) {
-      // imageIds could not be split into groups
-      continue;
-    }
-
-    const framesPerGroup = framesGroups[0].length;
-    const groupsHaveSameLength = framesGroups.every(
-      (g) => g.length === framesPerGroup
-    );
-
-    if (groupsHaveSameLength) {
-      return framesGroups;
+      const imageIdsGroups = sortedKeys.map((key) =>
+        frame_groups[key].map((item) => item.imageId)
+      );
+      return imageIdsGroups;
     }
   }
 

--- a/packages/streaming-image-volume-loader/src/helpers/splitImageIdsBy4DTags.ts
+++ b/packages/streaming-image-volume-loader/src/helpers/splitImageIdsBy4DTags.ts
@@ -26,7 +26,7 @@ const groupBy = (array, key) => {
 
 function getIPPGroups(imageIds: string[]): { [id: string]: Array<MappedIPP> } {
   const ippMetadata: Array<MappedIPP> = imageIds.map((imageId) => {
-    const imagePositionPatient = metaData.get('ImagePositionPatient', imageId);
+    const { imagePositionPatient } = metaData.get('imagePlaneModule', imageId);
     return { imageId, imagePositionPatient };
   });
 


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->
Related to #1048 and OHIF PR [#3664](https://github.com/OHIF/Viewers/pull/3664). Both deal with the issue of adding support for 4D datasets to OHIF Viewer.


### Changes & Results

Refactor splitting datasets in `packages/streaming-image-volume-loader/helpers/splitImageIdsBy4dTags`.
- First group by imagePositionPatient. Allows checking whether the dataset is potentially a multi-stack (4D) dataset (i.e. equal and > 1 number of frames for each position)
- Check ability of predefined tags to split the dataset (i.e. unique values within 1 position, but corresponding instances for any one value in all positions).
- By checking tags on the position-grouped instances, early stopping is possible (e.g. when duplicate values are encountered, or when a set of values does not match the first such set).
- Add custom functions for parsing DWI b values stored in private tags for Philips, Siemens and GE datasets.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

ToDo:
- [ ] Frame timepoint values are currently not provided, only used to sort the array of arrays. Therefore, the timepoints cannot be displayed downstream.
- [ ] Certain tags are implemented and should potentially work, but have not been tested.
- [ ] There exist use cases where a series with a single SeriesInstanceUID contains multiple 4D stacks identified by different ImageType values. To correctly display them, they would need to be grouped by both ImageType and a Frame timepoint identifier tag.

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [ ] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Linux 22.04.3 <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [x] "Node version: 20.11.0 <!--[e.g. 16.14.0]"-->
- [x] "Browser:
  - Chrome 121.0.6167.85
  - Firefox 122.0
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
