### PR TITLE
feat(contourSeg): polyline performance improvements

### DIFF
--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -1647,6 +1647,9 @@ function debounce(func: Function, wait?: number, options?: {
 }): Function;
 
 // @public (undocumented)
+function decimate(polyline: Types_2.Point2[], epsilon?: number): Types_2.Point2[];
+
+// @public (undocumented)
 const _default: {
     filterAnnotationsWithinSlice: typeof filterAnnotationsWithinSlice;
     getWorldWidthAndHeightFromCorners: typeof getWorldWidthAndHeightFromCorners;
@@ -3745,7 +3748,7 @@ declare namespace polyline {
         getNormal3,
         getNormal2,
         intersectPolyline,
-        simplify,
+        decimate,
         getFirstLineSegmentIntersectionIndexes,
         getLineSegmentIntersectionsIndexes,
         getLineSegmentIntersectionsCoordinates,
@@ -4696,9 +4699,6 @@ function setToolGroupSpecificConfig_2(toolGroupId: string, segmentationRepresent
 function showAllAnnotations(): void;
 
 // @public (undocumented)
-function simplify(polyline: Types_2.Point2[], epsilon?: number): Types_2.Point2[];
-
-// @public (undocumented)
 function smoothAnnotation(enabledElement: Types_2.IEnabledElement, annotation: PlanarFreehandROIAnnotation, knotsRatioPercentage: number): boolean;
 
 // @public (undocumented)
@@ -5627,7 +5627,7 @@ function updateContourPolyline(annotation: ContourAnnotation, polylineData: {
 }, transforms: {
     canvasToWorld: (point: Types_2.Point2) => Types_2.Point3;
 }, options?: {
-    simplify?: {
+    decimate?: {
         enabled?: boolean;
         epsilon?: number;
     };

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -3745,6 +3745,7 @@ declare namespace polyline {
         getNormal3,
         getNormal2,
         intersectPolyline,
+        simplify,
         getFirstLineSegmentIntersectionIndexes,
         getLineSegmentIntersectionsIndexes,
         getLineSegmentIntersectionsCoordinates,
@@ -4695,6 +4696,9 @@ function setToolGroupSpecificConfig_2(toolGroupId: string, segmentationRepresent
 function showAllAnnotations(): void;
 
 // @public (undocumented)
+function simplify(polyline: Types_2.Point2[], epsilon?: number): Types_2.Point2[];
+
+// @public (undocumented)
 function smoothAnnotation(enabledElement: Types_2.IEnabledElement, annotation: PlanarFreehandROIAnnotation, knotsRatioPercentage: number): boolean;
 
 // @public (undocumented)
@@ -5622,6 +5626,11 @@ function updateContourPolyline(annotation: ContourAnnotation, polylineData: {
     targetWindingDirection?: ContourWindingDirection;
 }, transforms: {
     canvasToWorld: (point: Types_2.Point2) => Types_2.Point3;
+}, options?: {
+    simplify?: {
+        enabled?: boolean;
+        epsilon?: number;
+    };
 }): void;
 
 declare namespace utilities {

--- a/packages/tools/src/eventListeners/annotations/contourSegmentation/contourSegmentationCompleted.ts
+++ b/packages/tools/src/eventListeners/annotations/contourSegmentation/contourSegmentationCompleted.ts
@@ -249,7 +249,7 @@ function getContourHolesData(
   });
 }
 
-async function combinePolylines(
+function combinePolylines(
   viewport: Types.IViewport,
   targetAnnotation: ContourSegmentationAnnotation,
   targetPolyline: Types.Point2[],

--- a/packages/tools/src/tools/annotation/LivewireContourTool.ts
+++ b/packages/tools/src/tools/annotation/LivewireContourTool.ts
@@ -113,7 +113,7 @@ class LivewireContourTool extends ContourSegmentationBaseTool {
          * for better performance and storage.
          */
         decimate: {
-          enabled: true,
+          enabled: false,
           /** A maximum given distance 'epsilon' to decide if a point should or
            * shouldn't be added the resulting polyline which will have a lower
            * number of points for higher `epsilon` values.

--- a/packages/tools/src/tools/annotation/LivewireContourTool.ts
+++ b/packages/tools/src/tools/annotation/LivewireContourTool.ts
@@ -32,7 +32,6 @@ import { LivewireScissors } from '../../utilities/livewire/LivewireScissors';
 import { LivewirePath } from '../../utilities/livewire/LiveWirePath';
 import { getViewportIdsWithToolToRender } from '../../utilities/viewportFilters';
 import ContourSegmentationBaseTool from '../base/ContourSegmentationBaseTool';
-import updateContourPolyline from '../../utilities/contours/updateContourPolyline';
 
 const CLICK_CLOSE_CURVE_SQR_DIST = 10 ** 2; // px
 
@@ -108,6 +107,20 @@ class LivewireContourTool extends ContourSegmentationBaseTool {
            */
           showInterpolationPolyline: false,
         },
+
+        /**
+         * The polyline may get processed in order to reduce the number of points
+         * for better performance and storage.
+         */
+        decimate: {
+          enabled: true,
+          /** A maximum given distance 'epsilon' to decide if a point should or
+           * shouldn't be added the resulting polyline which will have a lower
+           * number of points for higher `epsilon` values.
+           */
+          epsilon: 0.1,
+        },
+
         actions: {
           undo: {
             method: 'undo',
@@ -922,7 +935,7 @@ class LivewireContourTool extends ContourSegmentationBaseTool {
       imagePoints = [...imagePoints, imagePoints[0]];
     }
 
-    updateContourPolyline(
+    this.updateContourPolyline(
       annotation,
       {
         points: imagePoints,

--- a/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
+++ b/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
@@ -231,6 +231,18 @@ class PlanarFreehandROITool extends ContourSegmentationBaseTool {
           // interpolation is complete.
           onInterpolationComplete: null,
         },
+        /**
+         * The polyline may get processed in order to reduce the number of points
+         * for better performance and storage.
+         */
+        decimate: {
+          enabled: true,
+          /** A maximum given distance 'epsilon' to decide if a point should or
+           * shouldn't be added the resulting polyline which will have a lower
+           * number of points for higher `epsilon` values.
+           */
+          epsilon: 0.1,
+        },
         calculateStats: false,
         getTextLines: defaultGetTextLines,
         statsCalculator: BasicStatsCalculator,

--- a/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
+++ b/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
@@ -236,7 +236,7 @@ class PlanarFreehandROITool extends ContourSegmentationBaseTool {
          * for better performance and storage.
          */
         decimate: {
-          enabled: true,
+          enabled: false,
           /** A maximum given distance 'epsilon' to decide if a point should or
            * shouldn't be added the resulting polyline which will have a lower
            * number of points for higher `epsilon` values.

--- a/packages/tools/src/tools/annotation/SplineROITool.ts
+++ b/packages/tools/src/tools/annotation/SplineROITool.ts
@@ -56,7 +56,6 @@ import { LinearSpline } from './splines/LinearSpline';
 import { CatmullRomSpline } from './splines/CatmullRomSpline';
 import { BSpline } from './splines/BSpline';
 import ContourSegmentationBaseTool from '../base/ContourSegmentationBaseTool';
-import updateContourPolyline from '../../utilities/contours/updateContourPolyline';
 
 const SPLINE_MIN_POINTS = 3;
 const SPLINE_CLICK_CLOSE_CURVE_DIST = 10;
@@ -121,6 +120,18 @@ class SplineROITool extends ContourSegmentationBaseTool {
          * modifier must be pressed when the first point of a new contour is added.
          */
         contourHoleAdditionModifierKey: KeyboardBindings.Shift,
+        /**
+         * The polyline may get processed in order to reduce the number of points
+         * for better performance and storage.
+         */
+        decimate: {
+          enabled: true,
+          /** A maximum given distance 'epsilon' to decide if a point should or
+           * shouldn't be added the resulting polyline which will have a lower
+           * number of points for higher `epsilon` values.
+           */
+          epsilon: 0.1,
+        },
         spline: {
           configuration: {
             [SplineTypesEnum.Cardinal]: {
@@ -693,7 +704,7 @@ class SplineROITool extends ContourSegmentationBaseTool {
         const spline = this._updateSplineInstance(element, annotation);
         const splinePolylineCanvas = spline.getPolylinePoints();
 
-        updateContourPolyline(
+        this.updateContourPolyline(
           annotation,
           {
             points: splinePolylineCanvas,

--- a/packages/tools/src/tools/annotation/SplineROITool.ts
+++ b/packages/tools/src/tools/annotation/SplineROITool.ts
@@ -125,7 +125,7 @@ class SplineROITool extends ContourSegmentationBaseTool {
          * for better performance and storage.
          */
         decimate: {
-          enabled: true,
+          enabled: false,
           /** A maximum given distance 'epsilon' to decide if a point should or
            * shouldn't be added the resulting polyline which will have a lower
            * number of points for higher `epsilon` values.

--- a/packages/tools/src/tools/annotation/planarFreehandROITool/drawLoop.ts
+++ b/packages/tools/src/tools/annotation/planarFreehandROITool/drawLoop.ts
@@ -18,7 +18,6 @@ import { PlanarFreehandROIAnnotation } from '../../../types/ToolSpecificAnnotati
 import findOpenUShapedContourVectorToPeak from './findOpenUShapedContourVectorToPeak';
 import { polyline } from '../../../utilities/math';
 import { removeAnnotation } from '../../../stateManagement/annotation/annotationState';
-import { updateContourPolyline } from '../../../utilities/contours/';
 import reverseIfAntiClockwise from '../../../utilities/contours/reverseIfAntiClockwise';
 
 const {
@@ -238,7 +237,7 @@ function completeDrawClosedContour(
   // contours. A future optimisation if we use this for segmentation is to re-do
   // this rendering with the GPU rather than SVG.
 
-  updateContourPolyline(
+  this.updateContourPolyline(
     annotation,
     {
       points: updatedPoints,
@@ -315,7 +314,7 @@ function completeDrawOpenContour(
   // contours. A future optimisation if we use this for segmentation is to re-do
   // this rendering with the GPU rather than SVG.
 
-  updateContourPolyline(
+  this.updateContourPolyline(
     annotation,
     {
       points: updatedPoints,

--- a/packages/tools/src/tools/base/ContourBaseTool.ts
+++ b/packages/tools/src/tools/base/ContourBaseTool.ts
@@ -224,10 +224,6 @@ abstract class ContourBaseTool extends AnnotationTool {
     }
   ) {
     const decimateConfig = this.configuration?.decimate || {};
-    console.log('>>>>> decimate', {
-      enabled: !!decimateConfig.enabled,
-      epsilon: decimateConfig.epsilon,
-    });
 
     updateContourPolyline(annotation, polylineData, transforms, {
       decimate: {

--- a/packages/tools/src/tools/base/ContourBaseTool.ts
+++ b/packages/tools/src/tools/base/ContourBaseTool.ts
@@ -17,7 +17,9 @@ import type {
 import { drawPath as drawPathSvg } from '../../drawingSvg';
 import { StyleSpecifier } from '../../types/AnnotationStyle';
 import AnnotationTool from './AnnotationTool';
+import { updateContourPolyline } from '../../utilities/contours/';
 import { getContourHolesDataCanvas } from '../../utilities/contours';
+import { ContourWindingDirection } from '../../types/ContourAnnotation';
 
 /**
  * A contour base class responsible for rendering contour instances such as
@@ -208,6 +210,31 @@ abstract class ContourBaseTool extends AnnotationTool {
     getChildAnnotations(annotation).forEach((childAnnotation) =>
       this.moveAnnotation(childAnnotation, worldPosDelta)
     );
+  }
+
+  protected updateContourPolyline(
+    annotation: ContourAnnotation,
+    polylineData: {
+      points: Types.Point2[];
+      closed?: boolean;
+      targetWindingDirection?: ContourWindingDirection;
+    },
+    transforms: {
+      canvasToWorld: (point: Types.Point2) => Types.Point3;
+    }
+  ) {
+    const decimateConfig = this.configuration?.decimate || {};
+    console.log('>>>>> decimate', {
+      enabled: !!decimateConfig.enabled,
+      epsilon: decimateConfig.epsilon,
+    });
+
+    updateContourPolyline(annotation, polylineData, transforms, {
+      decimate: {
+        enabled: !!decimateConfig.enabled,
+        epsilon: decimateConfig.epsilon,
+      },
+    });
   }
 
   /**

--- a/packages/tools/src/utilities/contours/updateContourPolyline.ts
+++ b/packages/tools/src/utilities/contours/updateContourPolyline.ts
@@ -28,7 +28,8 @@ export default function updateContourPolyline(
 ) {
   const { canvasToWorld } = transforms;
   const { data } = annotation;
-  const { points: polyline, targetWindingDirection } = polylineData;
+  const { targetWindingDirection } = polylineData;
+  const polyline = math.polyline.simplify(polylineData.points);
   let { closed } = polylineData;
   const numPoints = polyline.length;
   const polylineWorldPoints = new Array(numPoints);

--- a/packages/tools/src/utilities/contours/updateContourPolyline.ts
+++ b/packages/tools/src/utilities/contours/updateContourPolyline.ts
@@ -15,11 +15,11 @@ import {
  * @param polylineData - Polyline data (points, winding direction and closed)
  * @param transforms - Methods to convert points to/from canvas and world spaces
  * @param options - Options
- *   - simplify: allow to set some parameters to simplify the polyline reducing
+ *   - decimate: allow to set some parameters to decimate the polyline reducing
  *   the amount of points stored which also affects how fast it will draw the
  *   annotation in a viewport, compute the winding direction, append/remove
- *   contours and create holes. A higher `epsilon` value results in a more
- *   simplified polyline version with less points.
+ *   contours and create holes. A higher `epsilon` value results in a polyline
+ *   with less points.
  */
 export default function updateContourPolyline(
   annotation: ContourAnnotation,
@@ -32,7 +32,7 @@ export default function updateContourPolyline(
     canvasToWorld: (point: Types.Point2) => Types.Point3;
   },
   options?: {
-    simplify?: {
+    decimate?: {
       enabled?: boolean;
       epsilon?: number;
     };
@@ -43,11 +43,11 @@ export default function updateContourPolyline(
   const { targetWindingDirection } = polylineData;
   let { points: polyline } = polylineData;
 
-  // Simplify the polyline by default to reduce tha amount of points
-  if (options?.simplify?.enabled !== false) {
-    polyline = math.polyline.simplify(
+  // Decimate the polyline to reduce tha amount of points
+  if (options?.decimate?.enabled) {
+    polyline = math.polyline.decimate(
       polylineData.points,
-      options?.simplify?.epsilon
+      options?.decimate?.epsilon
     );
   }
 

--- a/packages/tools/src/utilities/contours/updateContourPolyline.ts
+++ b/packages/tools/src/utilities/contours/updateContourPolyline.ts
@@ -14,6 +14,12 @@ import {
  * @param viewport - Viewport
  * @param polylineData - Polyline data (points, winding direction and closed)
  * @param transforms - Methods to convert points to/from canvas and world spaces
+ * @param options - Options
+ *   - simplify: allow to set some parameters to simplify the polyline reducing
+ *   the amount of points stored which also affects how fast it will draw the
+ *   annotation in a viewport, compute the winding direction, append/remove
+ *   contours and create holes. A higher `epsilon` value results in a more
+ *   simplified polyline version with less points.
  */
 export default function updateContourPolyline(
   annotation: ContourAnnotation,
@@ -24,12 +30,27 @@ export default function updateContourPolyline(
   },
   transforms: {
     canvasToWorld: (point: Types.Point2) => Types.Point3;
+  },
+  options?: {
+    simplify?: {
+      enabled?: boolean;
+      epsilon?: number;
+    };
   }
 ) {
   const { canvasToWorld } = transforms;
   const { data } = annotation;
   const { targetWindingDirection } = polylineData;
-  const polyline = math.polyline.simplify(polylineData.points);
+  let { points: polyline } = polylineData;
+
+  // Simplify the polyline by default to reduce tha amount of points
+  if (options?.simplify?.enabled !== false) {
+    polyline = math.polyline.simplify(
+      polylineData.points,
+      options?.simplify?.epsilon
+    );
+  }
+
   let { closed } = polylineData;
   const numPoints = polyline.length;
   const polylineWorldPoints = new Array(numPoints);

--- a/packages/tools/src/utilities/math/line/distanceToPointSquaredInfo.ts
+++ b/packages/tools/src/utilities/math/line/distanceToPointSquaredInfo.ts
@@ -24,7 +24,8 @@ export default function distanceToPointSquaredInfo(
   let closestPoint: Types.Point2;
   const distanceSquared = math.point.distanceToPointSquared(lineStart, lineEnd);
 
-  // Check if lineStart is the same as lineEnd which means
+  // Check if lineStart equal to the lineEnd which means the closest point
+  // is any of these two points
   if (lineStart[0] === lineEnd[0] && lineStart[1] === lineEnd[1]) {
     closestPoint = lineStart;
   }

--- a/packages/tools/src/utilities/math/polyline/decimate.ts
+++ b/packages/tools/src/utilities/math/polyline/decimate.ts
@@ -11,15 +11,15 @@ const DEFAULT_EPSILON = 0.1;
  * https://rosettacode.org/wiki/Ramer-Douglas-Peucker_line_simplification
  * https://karthaus.nl/rdp/
  *
- * @param polyline - Polyline to simplify
+ * @param polyline - Polyline to decimate
  * @param epsilon - A maximum given distance 'epsilon' to decide if a point
- * should or shouldn't be added the the simplified polyline version. In each
+ * should or shouldn't be added the decimated polyline version. In each
  * iteration the polyline is split into two polylines and the distance of each
  * point from those new polylines are checked against the line that connects
  * the first and last points.
- * @returns Simplified polyline
+ * @returns Decimated polyline
  */
-export default function simplify(
+export default function decimate(
   polyline: Types.Point2[],
   epsilon = DEFAULT_EPSILON
 ) {
@@ -33,15 +33,15 @@ export default function simplify(
   const epsilonSquared = epsilon * epsilon;
   const partitionQueue = [[0, numPoints - 1]];
 
-  // Used a boolean array to set each point that will be in the simplified polyline
+  // Used a boolean array to set each point that will be in the decimated polyline
   // because pre-allocated arrays are 3-4x faster than thousands of push() calls
   // to add all points to a new array.
   const polylinePointFlags = new Array(numPoints).fill(false);
 
-  // Start and end points are always added to the simplified polyline
-  let numSimplifiedPoints = 2;
+  // Start and end points are always added to the decimated polyline
+  let numDecimatedPoints = 2;
 
-  // Add start and end points to the simplified polyline
+  // Add start and end points to the decimated polyline
   polylinePointFlags[0] = true;
   polylinePointFlags[numPoints - 1] = true;
 
@@ -82,9 +82,9 @@ export default function simplify(
     }
 
     // Update the flag for the furthest point because it will be added to the
-    // simplified polyline
+    // decimated polyline
     polylinePointFlags[maxDistIndex] = true;
-    numSimplifiedPoints++;
+    numDecimatedPoints++;
 
     // Partition the points into two parts using maxDistIndex as the pivot point
     // and process both sides
@@ -93,13 +93,13 @@ export default function simplify(
   }
 
   // A pre-allocated array is 3-4x faster then multiple push() calls
-  const simplifiedPolyline: Types.Point2[] = new Array(numSimplifiedPoints);
+  const decimatedPolyline: Types.Point2[] = new Array(numDecimatedPoints);
 
   for (let srcIndex = 0, dstIndex = 0; srcIndex < numPoints; srcIndex++) {
     if (polylinePointFlags[srcIndex]) {
-      simplifiedPolyline[dstIndex++] = polyline[srcIndex];
+      decimatedPolyline[dstIndex++] = polyline[srcIndex];
     }
   }
 
-  return simplifiedPolyline;
+  return decimatedPolyline;
 }

--- a/packages/tools/src/utilities/math/polyline/index.ts
+++ b/packages/tools/src/utilities/math/polyline/index.ts
@@ -9,7 +9,7 @@ import getNormal3 from './getNormal3';
 import getNormal2 from './getNormal2';
 import { mergePolylines, subtractPolylines } from './combinePolyline';
 import intersectPolyline from './intersectPolyline';
-import simplify from './simplify';
+import decimate from './decimate';
 import getFirstLineSegmentIntersectionIndexes from './getFirstLineSegmentIntersectionIndexes';
 import getLineSegmentIntersectionsIndexes from './getLineSegmentIntersectionsIndexes';
 import getLineSegmentIntersectionsCoordinates from './getLineSegmentIntersectionsCoordinates';
@@ -30,7 +30,7 @@ export {
   getNormal3,
   getNormal2,
   intersectPolyline,
-  simplify,
+  decimate,
   getFirstLineSegmentIntersectionIndexes,
   getLineSegmentIntersectionsIndexes,
   getLineSegmentIntersectionsCoordinates,

--- a/packages/tools/src/utilities/math/polyline/index.ts
+++ b/packages/tools/src/utilities/math/polyline/index.ts
@@ -9,6 +9,7 @@ import getNormal3 from './getNormal3';
 import getNormal2 from './getNormal2';
 import { mergePolylines, subtractPolylines } from './combinePolyline';
 import intersectPolyline from './intersectPolyline';
+import simplify from './simplify';
 import getFirstLineSegmentIntersectionIndexes from './getFirstLineSegmentIntersectionIndexes';
 import getLineSegmentIntersectionsIndexes from './getLineSegmentIntersectionsIndexes';
 import getLineSegmentIntersectionsCoordinates from './getLineSegmentIntersectionsCoordinates';
@@ -29,6 +30,7 @@ export {
   getNormal3,
   getNormal2,
   intersectPolyline,
+  simplify,
   getFirstLineSegmentIntersectionIndexes,
   getLineSegmentIntersectionsIndexes,
   getLineSegmentIntersectionsCoordinates,

--- a/packages/tools/src/utilities/math/polyline/simplify.ts
+++ b/packages/tools/src/utilities/math/polyline/simplify.ts
@@ -1,0 +1,93 @@
+import type { Types } from '@cornerstonejs/core';
+import * as mathLine from '../line';
+
+const EPSILON = 0.1;
+const EPSILON_SQUARED = EPSILON * EPSILON;
+
+/**
+ * Ramer–Douglas–Peucker algorithm implementation to decimate a polyline
+ * to a similar polyline with fewer points
+ *
+ * https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm
+ * https://rosettacode.org/wiki/Ramer-Douglas-Peucker_line_simplification
+ * https://karthaus.nl/rdp/
+ *
+ * @param polyline - Polyline to simplify
+ * @returns Simplified polyline
+ */
+export default function simplify(polyline: Types.Point2[]) {
+  const numPoints = polyline.length;
+
+  // There are no points in a triangle that can be removed
+  if (numPoints < 3) {
+    return polyline;
+  }
+
+  const polylinePointFlags = new Array(numPoints).fill(false);
+  const partitionQueue = [[0, numPoints - 1]];
+
+  // Start and end points are always added to the simplified polyline
+  let numSimplifiedPoints = 2;
+
+  // Add start and end points to the simplified polyline
+  polylinePointFlags[0] = true;
+  polylinePointFlags[numPoints - 1] = true;
+
+  // Using a loop+queue instead of recursion to avoid up to numPoints*2 function calls
+  while (partitionQueue.length) {
+    const [startIndex, endIndex] = partitionQueue.pop();
+
+    // Return if there is no point between the start and end points
+    if (endIndex - startIndex === 1) {
+      continue;
+    }
+
+    const startPoint = polyline[startIndex];
+    const endPoint = polyline[endIndex];
+    let maxDistSquared = -Infinity;
+    let maxDistIndex = -1;
+
+    // Search for the furthest point
+    for (let i = startIndex + 1; i < endIndex; i++) {
+      const currentPoint = polyline[i];
+
+      const distSquared = mathLine.distanceToPointSquared(
+        startPoint,
+        endPoint,
+        currentPoint
+      );
+
+      if (distSquared > maxDistSquared) {
+        maxDistSquared = distSquared;
+        maxDistIndex = i;
+      }
+    }
+
+    // Do not add any of the points because the fursthest one is very close to
+    // the line based on the epsilon value
+    if (maxDistSquared < EPSILON_SQUARED) {
+      continue;
+    }
+
+    // Update the flag for the furthest point because it will be added to the
+    // simplified polyline
+    polylinePointFlags[maxDistIndex] = true;
+    numSimplifiedPoints++;
+
+    // Partition the points into two parts using maxDistIndex as the pivot point
+    // and process both sides
+    partitionQueue.push([maxDistIndex, endIndex]);
+    partitionQueue.push([startIndex, maxDistIndex]);
+  }
+
+  // Use a pre-allocated array is much faster then multiple push() calls
+  const simplifiedPolyline: Types.Point2[] = new Array(numSimplifiedPoints);
+
+  for (let srcIndex = 0, dstIndex = 0; srcIndex < numPoints; srcIndex++) {
+    if (polylinePointFlags[srcIndex]) {
+      simplifiedPolyline[dstIndex++] = polyline[srcIndex];
+    }
+  }
+
+  return simplifiedPolyline;
+}

--- a/packages/tools/src/utilities/math/polyline/simplify.ts
+++ b/packages/tools/src/utilities/math/polyline/simplify.ts
@@ -1,8 +1,7 @@
 import type { Types } from '@cornerstonejs/core';
 import * as mathLine from '../line';
 
-const EPSILON = 0.1;
-const EPSILON_SQUARED = EPSILON * EPSILON;
+const DEFAULT_EPSILON = 0.1;
 
 /**
  * Ramer–Douglas–Peucker algorithm implementation to decimate a polyline
@@ -13,18 +12,31 @@ const EPSILON_SQUARED = EPSILON * EPSILON;
  * https://karthaus.nl/rdp/
  *
  * @param polyline - Polyline to simplify
+ * @param epsilon - A maximum given distance 'epsilon' to decide if a point
+ * should or shouldn't be added the the simplified polyline version. In each
+ * iteration the polyline is split into two polylines and the distance of each
+ * point from those new polylines are checked against the line that connects
+ * the first and last points.
  * @returns Simplified polyline
  */
-export default function simplify(polyline: Types.Point2[]) {
+export default function simplify(
+  polyline: Types.Point2[],
+  epsilon = DEFAULT_EPSILON
+) {
   const numPoints = polyline.length;
 
-  // There are no points in a triangle that can be removed
+  // The polyline must have at least a start and end points
   if (numPoints < 3) {
     return polyline;
   }
 
-  const polylinePointFlags = new Array(numPoints).fill(false);
+  const epsilonSquared = epsilon * epsilon;
   const partitionQueue = [[0, numPoints - 1]];
+
+  // Used a boolean array to set each point that will be in the simplified polyline
+  // because pre-allocated arrays are 3-4x faster than thousands of push() calls
+  // to add all points to a new array.
+  const polylinePointFlags = new Array(numPoints).fill(false);
 
   // Start and end points are always added to the simplified polyline
   let numSimplifiedPoints = 2;
@@ -33,7 +45,8 @@ export default function simplify(polyline: Types.Point2[]) {
   polylinePointFlags[0] = true;
   polylinePointFlags[numPoints - 1] = true;
 
-  // Using a loop+queue instead of recursion to avoid up to numPoints*2 function calls
+  // Iterative approach using a queue instead of recursion to reduce the number
+  // of function calls (performance)
   while (partitionQueue.length) {
     const [startIndex, endIndex] = partitionQueue.pop();
 
@@ -50,7 +63,6 @@ export default function simplify(polyline: Types.Point2[]) {
     // Search for the furthest point
     for (let i = startIndex + 1; i < endIndex; i++) {
       const currentPoint = polyline[i];
-
       const distSquared = mathLine.distanceToPointSquared(
         startPoint,
         endPoint,
@@ -65,7 +77,7 @@ export default function simplify(polyline: Types.Point2[]) {
 
     // Do not add any of the points because the fursthest one is very close to
     // the line based on the epsilon value
-    if (maxDistSquared < EPSILON_SQUARED) {
+    if (maxDistSquared < epsilonSquared) {
       continue;
     }
 
@@ -80,7 +92,7 @@ export default function simplify(polyline: Types.Point2[]) {
     partitionQueue.push([startIndex, maxDistIndex]);
   }
 
-  // Use a pre-allocated array is much faster then multiple push() calls
+  // A pre-allocated array is 3-4x faster then multiple push() calls
   const simplifiedPolyline: Types.Point2[] = new Array(numSimplifiedPoints);
 
   for (let srcIndex = 0, dstIndex = 0; srcIndex < numPoints; srcIndex++) {


### PR DESCRIPTION
### Context

Adding contour annotations may result in polylines with thousands of points making the viewer much slower to render the annotations and also process them (append, remove, create holes, interpolate, etc.). 

### Changes & Results

Implemented the Ramer–Douglas–Peucker algorithm that simplifies polylines based on an a given distance `epsilon` reducing the amount of points in a polyline.

Two polylines with 6k (source) and 7k (target) points were used on the test below to measure the time it would take to merge them before and after simplifying the polylines.

![perf_polyline-simplification_merge](https://github.com/cornerstonejs/cornerstone3D/assets/931820/c70d510a-3295-4a40-aee0-564786431774)

A good way to generate contours with +50k points is zooming all the way out before creating a freehand segmentation contour. Both polylines got simplified to new polylines with ~200 points or less each with no visual changes on the viewport. I know this is not a real example but that helped to measure the time it would take to process the contours.

https://github.com/cornerstonejs/cornerstone3D/assets/931820/ce4e68b5-d714-479a-8113-52aaaefd6612


### Testing

Draw contours (spline, freehand, livewire) and make sure they are rendered and processed (append, remove, hole, interpolation, etc) correctly. A performance improvement is very noticeable when drawing multiple freehand ROIs.