### PR TITLE
fix(spline): spline update issue

### DIFF
--- a/packages/tools/examples/splineROITools/index.ts
+++ b/packages/tools/examples/splineROITools/index.ts
@@ -188,7 +188,7 @@ addSliderToToolbar({
         'spline'
       );
 
-      splineConfig.configuration[splineType].resolution = value;
+      splineConfig.configuration[splineType].resolution = parseInt(value);
       toolGroup.setToolConfiguration(splineToolName, { spline: splineConfig });
     });
   },
@@ -209,7 +209,7 @@ addSliderToToolbar({
       'spline'
     );
 
-    splineConfig.configuration.CARDINAL.scale = value;
+    splineConfig.configuration.CARDINAL.scale = parseFloat(value);
     toolGroup.setToolConfiguration(splineToolName, { spline: splineConfig });
   },
 });


### PR DESCRIPTION
### Context

- Splines were not updating properly after changing the resolution and/or scale.
- The position of the lines were not updating after zooming in/out breaking all mouse events.

### Changes & Results

- Changed the code to make sure the splines will be updated not only when `annotation.invalidated` is true because that flag does not change after updating the config
- Fixed an issue with string/number conversion before comparing the value from  the configuration with the current spline resolution and scale values

### Testing

- Open Spline ROI Tool example
- Draw a spline
- Change its resolution (it was broken before)
- Change its scale (it was broken before)
- Zoom in/out and try to click on the handle/spline to move it