### PR TITLE
fix(annotations): Ensure viewports re-render for annotation drawing

### DIFF
--- a/packages/tools/src/utilities/triggerAnnotationRender.ts
+++ b/packages/tools/src/utilities/triggerAnnotationRender.ts
@@ -98,12 +98,20 @@ class AnnotationRenderingEngine {
         // If there is nothing left that is flagged for rendering, stop here
         // and allow RAF to be called again
         if (this._needsRender.size === 0) {
-          this._animationFrameSet = false;
-          this._animationFrameHandle = null;
-          return;
+          break;
         }
       }
     }
+
+    this._animationFrameSet = false;
+    this._animationFrameHandle = null;
+
+    // Call render again which will use RAF to call this function asynchronously
+    // if there is any viewport that needs to be rendered because when
+    // `triggerRender` is called inside the render loop a listener can flag new
+    // viewports that need to be rendered and some of the viewports that were
+    // already rendered can be added back to `_needsRender`.
+    this._render();
   };
 
   private _setAllViewportsToBeRenderedNextFrame() {


### PR DESCRIPTION
### Context

In some cases the viewports are not re-rendered making it impossible to draw annotations.

### Changes & Results

Updated `triggerAnnotationRender` responsible for "scheduling" a render call using RAF to make sure that even when an event listener adds a viewport back to the `needsRender` list it can reschedule a new render call instead of getting blocked.

### Testing

Just open some examples such as [Spline Contour Segmentation Advanced](https://www.cornerstonejs.org/live-examples/splinecontoursegmentationtoolsadvanced) or [Livewire Contour Segmentation](https://www.cornerstonejs.org/live-examples/livewirecontoursegmentation) and try to add annotations to coronal or sagittal viewpots.