### PR TITLE
feat(colorbar): react to changes to the colormap

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -278,6 +278,15 @@ declare namespace colormap {
 }
 
 // @public (undocumented)
+type ColormapModifiedEvent = CustomEvent_2<ColormapModifiedEventDetail>;
+
+// @public (undocumented)
+type ColormapModifiedEventDetail = {
+    viewportId: string;
+    colormap: ColormapPublic;
+};
+
+// @public (undocumented)
 type ColormapPublic = {
     name?: string;
     opacity?: OpacityMapping[] | number;
@@ -783,6 +792,8 @@ export enum EVENTS {
     // (undocumented)
     CLIPPING_PLANES_UPDATED = "CORNERSTONE_CLIPPING_PLANES_UPDATED",
     // (undocumented)
+    COLORMAP_MODIFIED = "CORNERSTONE_COLORMAP_MODIFIED",
+    // (undocumented)
     DISPLAY_AREA_MODIFIED = "CORNERSTONE_DISPLAY_AREA_MODIFIED",
     // (undocumented)
     ELEMENT_DISABLED = "CORNERSTONE_ELEMENT_DISABLED",
@@ -850,6 +861,8 @@ declare namespace EventTypes {
         CameraModifiedEvent,
         VoiModifiedEvent,
         VoiModifiedEventDetail,
+        ColormapModifiedEvent,
+        ColormapModifiedEventDetail,
         DisplayAreaModifiedEvent,
         DisplayAreaModifiedEventDetail,
         ElementDisabledEvent,

--- a/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
@@ -283,6 +283,14 @@ abstract class BaseVolumeViewport extends Viewport implements IVolumeViewport {
     volumeActor.getProperty().setRGBTransferFunction(0, cfun);
 
     this.viewportProperties.colormap = colormap;
+
+    if (!suppressEvents) {
+      const eventDetail = {
+          viewportId: this.id,
+          colormap
+      };
+      triggerEvent(this.element, Events.COLORMAP_MODIFIED, eventDetail);
+    }
   }
 
   /**

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -3006,6 +3006,12 @@ class StackViewport extends Viewport implements IStackViewport, IImagesLoader {
     this.cpuRenderingInvalidated = true;
 
     this.render();
+
+    const eventDetail = {
+      viewportId: this.id,
+      colormap: colormapData,
+    };
+    triggerEvent(this.element, Events.COLORMAP_MODIFIED, eventDetail);
   }
 
   private setColormapGPU(colormap: ColormapPublic) {
@@ -3034,6 +3040,14 @@ class StackViewport extends Viewport implements IStackViewport, IImagesLoader {
 
     this.colormap = colormap;
     this.render();
+
+    const eventDetail = {
+      viewportId: this.id,
+      colormap,
+    };
+
+    triggerEvent(this.element, Events.COLORMAP_MODIFIED, eventDetail);
+
   }
 
   private unsetColormapGPU() {

--- a/packages/core/src/enums/Events.ts
+++ b/packages/core/src/enums/Events.ts
@@ -232,6 +232,13 @@ enum Events {
   // IMAGE_CACHE_FULL = 'CORNERSTONE_IMAGE_CACHE_FULL',
   // PRE_RENDER = 'CORNERSTONE_PRE_RENDER',
   // ELEMENT_RESIZED = 'CORNERSTONE_ELEMENT_RESIZED',
+
+  /**
+   * Triggers on the HTML element when viewport modifies its colormap
+   * Make use of {@link EventTypes.ColormapModifiedEvent | ColormapModified Event Type } for typing your event listeners for COLORMAP_MODIFIED event,
+   * and see what event detail is included in {@link EventTypes.ColormapModifiedEventDetail | ColormapModified Event Detail }
+   */
+  COLORMAP_MODIFIED = "CORNERSTONE_COLORMAP_MODIFIED"
 }
 
 export default Events;

--- a/packages/core/src/types/EventTypes.ts
+++ b/packages/core/src/types/EventTypes.ts
@@ -11,6 +11,7 @@ import VOILUTFunctionType from '../enums/VOILUTFunctionType';
 import ViewportStatus from '../enums/ViewportStatus';
 import type DisplayArea from './displayArea';
 import IImageCalibration from './IImageCalibration';
+import { ColormapPublic } from './Colormap';
 
 /**
  * CAMERA_MODIFIED Event's data
@@ -52,7 +53,7 @@ type ColormapModifiedEventDetail = {
   /** Viewport Unique ID in the renderingEngine */
   viewportId: string;
   /** The new colormap */
-  colormap: object;
+  colormap: ColormapPublic;
 }
 
 /**

--- a/packages/core/src/types/EventTypes.ts
+++ b/packages/core/src/types/EventTypes.ts
@@ -48,6 +48,13 @@ type VoiModifiedEventDetail = {
   invertStateChanged?: boolean;
 };
 
+type ColormapModifiedEventDetail = {
+  /** Viewport Unique ID in the renderingEngine */
+  viewportId: string;
+  /** The new colormap */
+  colormap: object;
+}
+
 /**
  * DISPLAY_AREA_MODIFIED Event's data
  */
@@ -288,6 +295,11 @@ type CameraModifiedEvent = CustomEventType<CameraModifiedEventDetail>;
 type VoiModifiedEvent = CustomEventType<VoiModifiedEventDetail>;
 
 /**
+ * COLORMAP_MODIFIED Event type
+ */
+type ColormapModifiedEvent = CustomEventType<ColormapModifiedEventDetail>;
+
+/**
  * DISPLAY_AREA_MODIFIED Event type
  */
 type DisplayAreaModifiedEvent = CustomEventType<DisplayAreaModifiedEventDetail>;
@@ -398,6 +410,8 @@ export type {
   CameraModifiedEvent,
   VoiModifiedEvent,
   VoiModifiedEventDetail,
+  ColormapModifiedEvent,
+  ColormapModifiedEventDetail,
   DisplayAreaModifiedEvent,
   DisplayAreaModifiedEventDetail,
   ElementDisabledEvent,

--- a/packages/tools/src/utilities/voi/colorbar/ViewportColorbar.ts
+++ b/packages/tools/src/utilities/voi/colorbar/ViewportColorbar.ts
@@ -171,6 +171,19 @@ class ViewportColorbar extends Colorbar {
     this.showAndAutoHideTicks();
   };
 
+  private _viewportColormapModifiedCallback = (
+    evt: Types.EventTypes.ColormapModifiedEvent
+  ) => {
+    const { viewportId, colormap } = evt.detail;
+    const { viewport } = this.enabledElement;
+
+    if (viewportId !== viewport.id) {
+      return;
+    }
+
+    this.activeColormapName = colormap.name;
+  };
+
   private _addCornerstoneEventListener() {
     const { _element: element } = this;
 
@@ -187,6 +200,11 @@ class ViewportColorbar extends Colorbar {
     element.addEventListener(
       Events.VOI_MODIFIED,
       this._viewportVOIModifiedCallback as EventListener
+    );
+
+    element.addEventListener(
+      Events.COLORMAP_MODIFIED,
+      this._viewportColormapModifiedCallback as EventListener
     );
   }
 }


### PR DESCRIPTION


### Context

This change makes so the Stack and Volume viewports trigger a colormap modified event, so that the colorbar can listen to the event and update it's colormap as needed.

### Changes & Results

- Added COLORMAP_MODIFIED Event
- Added new listener in ViewportColorbar.


