### PR TITLE
fix(colorbar): don't change colorbar color if volume id doesn't match

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -284,6 +284,7 @@ type ColormapModifiedEvent = CustomEvent_2<ColormapModifiedEventDetail>;
 type ColormapModifiedEventDetail = {
     viewportId: string;
     colormap: ColormapPublic;
+    volumeId?: string;
 };
 
 // @public (undocumented)

--- a/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
@@ -287,7 +287,8 @@ abstract class BaseVolumeViewport extends Viewport implements IVolumeViewport {
     if (!suppressEvents) {
       const eventDetail = {
           viewportId: this.id,
-          colormap
+          colormap,
+          volumeId
       };
       triggerEvent(this.element, Events.COLORMAP_MODIFIED, eventDetail);
     }

--- a/packages/core/src/types/EventTypes.ts
+++ b/packages/core/src/types/EventTypes.ts
@@ -54,6 +54,8 @@ type ColormapModifiedEventDetail = {
   viewportId: string;
   /** The new colormap */
   colormap: ColormapPublic;
+  /** Unique ID for the volume in the cache */
+  volumeId?: string;
 }
 
 /**

--- a/packages/tools/src/utilities/voi/colorbar/ViewportColorbar.ts
+++ b/packages/tools/src/utilities/voi/colorbar/ViewportColorbar.ts
@@ -174,10 +174,10 @@ class ViewportColorbar extends Colorbar {
   private _viewportColormapModifiedCallback = (
     evt: Types.EventTypes.ColormapModifiedEvent
   ) => {
-    const { viewportId, colormap } = evt.detail;
+    const { viewportId, colormap, volumeId  } = evt.detail;
     const { viewport } = this.enabledElement;
 
-    if (viewportId !== viewport.id) {
+    if (viewportId !== viewport.id || volumeId !== this._volumeId) {
       return;
     }
 


### PR DESCRIPTION

### Context

If there's two colorbars on the same viewport, and the colormap is modified, it's not enough to only check the viewport id, we need to make sure the volumeId also matches, otherwise both colorbars will change color.


### Changes & Results

pass volumeId in the event for volume viewport.