### PR TITLE
fix: windowLevel dynamic range from video viewport (#1088)

### DIFF
--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -6034,7 +6034,7 @@ export class WindowLevelTool extends BaseTool {
     // (undocumented)
     _getImageDynamicRangeFromMiddleSlice: (scalarData: any, dimensions: any) => number;
     // (undocumented)
-    _getImageDynamicRangeFromViewport(viewport: any): any;
+    _getImageDynamicRangeFromViewport(viewport: any): number;
     // (undocumented)
     _getMultiplierFromDynamicRange(viewport: any, volumeId: any): number;
     // (undocumented)

--- a/packages/tools/src/tools/WindowLevelTool.ts
+++ b/packages/tools/src/tools/WindowLevelTool.ts
@@ -204,7 +204,8 @@ class WindowLevelTool extends BaseTool {
     const dimensions = imageData.getDimensions();
 
     if (imageData.getRange) {
-      return imageData.getRange();
+      const imageDataRange = imageData.getRange();
+      return imageDataRange[1] - imageDataRange[0];
     }
     let scalarData;
     // if getScalarData is a method on imageData


### PR DESCRIPTION
fixes https://github.com/cornerstonejs/cornerstone3D/issues/1088
### Context

WindowLevel tool was using a higher multiplier resulting in much faster changes to window width and window level making it harder to adjust.

### Changes & Results

Changed the function responsible for getting the range from the viewport which was returning an array instead of a single number breaking the calculation of the ratio (`NaN`).

### Testing

- Open [videoColor](https://www.cornerstonejs.org/live-examples/videocolor) example
- Click on the viewport to change the ww/wc