### PR TITLE
fix: remove contour segmentation holes from annotationUIDsMap (#1095)

### DIFF
--- a/packages/tools/src/eventListeners/annotations/contourSegmentation/contourSegmentationCompleted.ts
+++ b/packages/tools/src/eventListeners/annotations/contourSegmentation/contourSegmentationCompleted.ts
@@ -220,6 +220,7 @@ function createPolylineHole(
   }
 
   addChildAnnotation(targetAnnotation, holeAnnotation);
+  contourSegUtils.removeContourSegmentationAnnotation(holeAnnotation);
 
   const { element } = viewport;
   const enabledElement = getEnabledElement(element);


### PR DESCRIPTION
Remove contour segmentation annotations from `annotationUIDsMap` as soon as they are "converted" into a hole.