### PR TITLE
feat(volumeviewport): return volume specific colormap information

### DIFF
--- a/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
@@ -62,8 +62,6 @@ import type { vtkSlabCamera as vtkSlabCameraType } from './vtkClasses/vtkSlabCam
 import vtkSlabCamera from './vtkClasses/vtkSlabCamera';
 import transformWorldToIndex from '../utilities/transformWorldToIndex';
 import { getTransferFunctionNodes } from '../utilities/transferFunctionUtils';
-import isEqual from '../utilities/isEqual'
-
 /**
  * Abstract base class for volume viewports. VolumeViewports are used to render
  * 3D volumes from which various orientations can be viewed. Since VolumeViewports

--- a/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
@@ -62,6 +62,7 @@ import type { vtkSlabCamera as vtkSlabCameraType } from './vtkClasses/vtkSlabCam
 import vtkSlabCamera from './vtkClasses/vtkSlabCamera';
 import transformWorldToIndex from '../utilities/transformWorldToIndex';
 import { getTransferFunctionNodes } from '../utilities/transferFunctionUtils';
+import isEqual from '../utilities/isEqual'
 
 /**
  * Abstract base class for volume viewports. VolumeViewports are used to render
@@ -871,11 +872,10 @@ abstract class BaseVolumeViewport extends Viewport implements IVolumeViewport {
         if (presetRGBPoints.length !== RGBPoints.length) {
             return false;
         }
+
         for (let i = 0; i < presetRGBPoints.length; i += 4) {
             if (
-                presetRGBPoints[i + 1] !== RGBPoints[i + 1] ||
-                presetRGBPoints[i + 2] !== RGBPoints[i + 2] ||
-                presetRGBPoints[i + 3] !== RGBPoints[i + 3]
+              !isEqual(presetRGBPoints.slice(i + 1, i + 4), RGBPoints.slice(i + 1, i + 4))
             ) {
                 return false;
             }


### PR DESCRIPTION
### Context

We need to return the correct colormap information if there's more than 1 volume on the viewport

### Changes & Results

- Added getColormap function that attempts to identify the currently set colormap on the volume.


### Comments

i’m not sure if we should say “attempts” as from my testing this seems to return the correct opacity and colormap 100% of the time. but I’m not a vtk expert, so I can’t say for certain that this is 100% accurate.

