### PR TITLE
fix(SplineROI): future added polygon woud not trigger complete event when a polygon is out of range and  got removed

### DIFF
--- a/packages/tools/examples/splineROITools/index.ts
+++ b/packages/tools/examples/splineROITools/index.ts
@@ -266,17 +266,6 @@ async function run() {
       },
     ],
   });
-
-  toolGroup.setToolConfiguration(SplineROITool.toolName, {
-    preventHandleOutsideImage: true,
-  });
-
-  toolsNames.forEach((n) => {
-    toolGroup.setToolConfiguration(n, {
-      preventHandleOutsideImage: true,
-    });
-  });
-
   addManipulationBindings(toolGroup);
 
   // Get Cornerstone imageIds and fetch metadata into RAM

--- a/packages/tools/examples/splineROITools/index.ts
+++ b/packages/tools/examples/splineROITools/index.ts
@@ -266,6 +266,17 @@ async function run() {
       },
     ],
   });
+
+  toolGroup.setToolConfiguration(SplineROITool.toolName, {
+    preventHandleOutsideImage: true,
+  });
+
+  toolsNames.forEach((n) => {
+    toolGroup.setToolConfiguration(n, {
+      preventHandleOutsideImage: true,
+    });
+  });
+
   addManipulationBindings(toolGroup);
 
   // Get Cornerstone imageIds and fetch metadata into RAM

--- a/packages/tools/src/tools/annotation/SplineROITool.ts
+++ b/packages/tools/src/tools/annotation/SplineROITool.ts
@@ -365,13 +365,17 @@ class SplineROITool extends ContourSegmentationBaseTool {
       removeAnnotation(annotation.annotationUID);
     }
 
-    this.fireChangeOnUpdate ||= {
-      annotationUID: annotation.annotationUID,
-      changeType: newAnnotation
-        ? ChangeTypes.Completed
-        : ChangeTypes.HandlesUpdated,
-      contourHoleProcessingEnabled,
-    };
+    if (!this.fireChangeOnUpdate) {
+      this.fireChangeOnUpdate = {
+        annotationUID: annotation.annotationUID,
+        changeType: newAnnotation
+          ? ChangeTypes.Completed
+          : ChangeTypes.HandlesUpdated,
+        contourHoleProcessingEnabled,
+      };
+    } else {
+      this.fireChangeOnUpdate.annotationUID = annotation.annotationUID;
+    }
 
     triggerAnnotationRenderForViewportIds(renderingEngine, viewportIdsToRender);
 
@@ -591,6 +595,8 @@ class SplineROITool extends ContourSegmentationBaseTool {
     changeType = ChangeTypes.StatsUpdated,
     contourHoleProcessingEnabled
   ): void => {
+    console.log('triggerChangeEvent: ', changeType);
+
     if (changeType === ChangeTypes.Completed) {
       this.triggerAnnotationCompleted(annotation, contourHoleProcessingEnabled);
     } else {

--- a/packages/tools/src/tools/annotation/SplineROITool.ts
+++ b/packages/tools/src/tools/annotation/SplineROITool.ts
@@ -365,16 +365,18 @@ class SplineROITool extends ContourSegmentationBaseTool {
       removeAnnotation(annotation.annotationUID);
     }
 
+    const changeType = newAnnotation
+      ? ChangeTypes.Completed
+      : ChangeTypes.HandlesUpdated;
     if (!this.fireChangeOnUpdate) {
       this.fireChangeOnUpdate = {
         annotationUID: annotation.annotationUID,
-        changeType: newAnnotation
-          ? ChangeTypes.Completed
-          : ChangeTypes.HandlesUpdated,
+        changeType,
         contourHoleProcessingEnabled,
       };
     } else {
       this.fireChangeOnUpdate.annotationUID = annotation.annotationUID;
+      this.fireChangeOnUpdate.changeType = changeType;
     }
 
     triggerAnnotationRenderForViewportIds(renderingEngine, viewportIdsToRender);

--- a/packages/tools/src/tools/annotation/SplineROITool.ts
+++ b/packages/tools/src/tools/annotation/SplineROITool.ts
@@ -595,8 +595,6 @@ class SplineROITool extends ContourSegmentationBaseTool {
     changeType = ChangeTypes.StatsUpdated,
     contourHoleProcessingEnabled
   ): void => {
-    console.log('triggerChangeEvent: ', changeType);
-
     if (changeType === ChangeTypes.Completed) {
       this.triggerAnnotationCompleted(annotation, contourHoleProcessingEnabled);
     } else {


### PR DESCRIPTION
### Context

When a new added polygon is out of range and the `preventHandleOutsideImage` is true. The new added polygon would be auto removed. After that, all the future add polygons would not trigger the complete event, like this:
![spline-before-fix](https://github.com/cornerstonejs/cornerstone3D/assets/41723543/322355f3-5488-4208-9587-89910ca653ed)

This PR fix it.

### Changes & Results

The cause is `this.fireChangeOnUpdate` would not be reassign after the new added out of range annotation is removed. 
As a result the annotation complete event would never be fired.
This PR add code to update `annotationUID` and `changeType` field in `this.fireChangeOnUpdate`

### Testing

![spline-after-fix](https://github.com/cornerstonejs/cornerstone3D/assets/41723543/ec7a12f3-164c-4102-b319-bc405067639f)

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Window 10
- [x] Node version: 20.10.0
- [x] Browser: Chrome 121.0.6167.141