### PR TITLE
fix(calibration tool): fix calibration type not being rendered on measurements

### DIFF
--- a/packages/tools/src/utilities/getCalibratedUnits.ts
+++ b/packages/tools/src/utilities/getCalibratedUnits.ts
@@ -173,6 +173,7 @@ const getCalibratedLengthUnitsAndScale = (image, handles) => {
     }
   } else if (calibration.scale) {
     scale = calibration.scale;
+    calibrationType = calibration?.type;
   }
 
   return {


### PR DESCRIPTION

### Context

The calibration type was not being returned so it was not being rendered.

### Changes & Results

Fixed above issue
