### PR TITLE
fix(colormap): make syncing colormap optional

### DIFF
--- a/packages/tools/src/synchronizers/callbacks/voiSyncCallback.ts
+++ b/packages/tools/src/synchronizers/callbacks/voiSyncCallback.ts
@@ -37,11 +37,13 @@ export default function voiSyncCallback(
     | Types.VolumeViewportProperties
     | Types.StackViewportProperties = {
     voiRange: range,
-    colormap,
   };
 
   if (options?.syncInvertState && invertStateChanged) {
     tProperties.invert = invert;
+  }
+  if (options?.syncColormap && colormap) {
+    tProperties.colormap = colormap;
   }
 
   if (tViewport instanceof BaseVolumeViewport) {


### PR DESCRIPTION

### Context

This adds a configuration option that makes it optional to sync the colormaps

### Changes & Results

Added syncColormap option
