### PR TITLE
fix(voiSyncCallback): added VOI Sync Support for Non-Fused Images

### DIFF
--- a/packages/tools/src/synchronizers/callbacks/voiSyncCallback.ts
+++ b/packages/tools/src/synchronizers/callbacks/voiSyncCallback.ts
@@ -47,7 +47,12 @@ export default function voiSyncCallback(
   }
 
   if (tViewport instanceof BaseVolumeViewport) {
-    tViewport.setProperties(tProperties, volumeId);
+    const isFusion = tViewport._actors && tViewport._actors.size > 1;
+    if (isFusion) {
+      tViewport.setProperties(tProperties, volumeId);
+    } else {
+      tViewport.setProperties(tProperties);
+    }
   } else if (tViewport instanceof StackViewport) {
     tViewport.setProperties(tProperties);
   } else {


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: macOS Sonoma 14.0
- [x] Node version: v20.10.0
- [x] Browser: Chrome Version 119.0.6045.199

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->

Description:
This pull request introduces enhancements to the window leveling functionality in non-fused image scenarios. Previously, the window leveling synchronization feature did not work correctly across viewports with different volumes when a volumeId was specified. This was particularly noticeable in non-fused imaging scenarios, leading to inconsistent visualization across viewports.

Changes:
- Implemented a check to determine if the viewport is displaying a fused image by examining the number of actors. If only one actor is present, it's considered a non-fused image scenario.
- In cases of non-fused images, the `setProperties` method is now called without specifying a `volumeId`, allowing for correct window leveling synchronization across different volumes.
- For fused images (where multiple actors are present), the existing behavior is maintained by specifying the `volumeId` in the `setProperties` method.

Impact:
These changes ensure that window leveling synchronization works seamlessly across viewports, regardless of whether they display fused or non-fused images. This enhancement makes the tool more versatile and reliable in diverse clinical and research settings.

Testing:
- Conducted testing with both fused and non-fused image examples; petCt and VolumeViewportSynchronization examples, where in the second I introduced a new volume in the third viewport.
- Verified that window leveling synchronization behaves as expected in single-modality scenarios as well as in PT-CT fusion scenarios.
