### PR TITLE
pixel normalization

### DIFF
--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -157,6 +157,7 @@ class StackViewport extends Viewport implements IStackViewport, IImagesLoader {
   private voiUpdatedWithSetProperties = false;
   private VOILUTFunction: VOILUTFunctionType;
   //
+  private outOfRange = false;
   private invert = false;
   // The initial invert of the image loaded as opposed to the invert status of the viewport itself (see above).
   private initialInvert = false;
@@ -1386,7 +1387,8 @@ class StackViewport extends Viewport implements IStackViewport, IImagesLoader {
 
     let voiRangeToUse = voiRange;
 
-    if (typeof voiRangeToUse === 'undefined') {
+    if (typeof voiRangeToUse === 'undefined' || this.outOfRange) {
+      this.outOfRange = false;
       const imageData = imageActor.getMapper().getInputData();
       const range = imageData.getPointData().getScalars().getRange();
       const maxVoiRange = { lower: range[0], upper: range[1] };
@@ -1782,7 +1784,10 @@ class StackViewport extends Viewport implements IStackViewport, IImagesLoader {
 
     // Update the pixel data in the vtkImageData object with the pixelData
     // from the loaded Cornerstone image
-    updateVTKImageDataWithCornerstoneImage(this._imageData, image);
+    this.outOfRange = updateVTKImageDataWithCornerstoneImage(
+      this._imageData,
+      image
+    );
   }
 
   /**
@@ -3047,7 +3052,6 @@ class StackViewport extends Viewport implements IStackViewport, IImagesLoader {
     };
 
     triggerEvent(this.element, Events.COLORMAP_MODIFIED, eventDetail);
-
   }
 
   private unsetColormapGPU() {

--- a/packages/core/src/RenderingEngine/helpers/normalizePixels.ts
+++ b/packages/core/src/RenderingEngine/helpers/normalizePixels.ts
@@ -1,0 +1,51 @@
+import { IImage } from '../../types';
+import vtkDataArray from '@kitware/vtk.js/Common/Core/DataArray';
+import vtkImageData from '@kitware/vtk.js/Common/DataModel/ImageData';
+import generateLut from './cpuFallback/rendering/generateLut';
+
+export function normalizePixels(vtkImage: vtkImageData, image: IImage): any {
+  const { windowCenter, windowWidth } = image;
+  const width = Array.isArray(windowWidth) ? windowWidth[0] : windowWidth;
+  const center = Array.isArray(windowCenter) ? windowCenter[0] : windowCenter;
+
+  const lut = generateLut(image, width, center, false, undefined, undefined);
+  const pixelData = image.getPixelData();
+
+  const numPixels = pixelData.length;
+  const minPixelValue = image.minPixelValue;
+  let storedPixelDataIndex = 0;
+
+  const numComp = vtkImage.getPointData().getNumberOfComponents();
+  const textureData = new Float32Array(numPixels);
+  for (let i = 0; i < numPixels; i++) {
+    textureData[i * numComp] = 255; // Red
+    textureData[i * numComp + 1] = 255; // Green
+    textureData[i * numComp + 2] = 255; // Blue
+    textureData[i * numComp + 3] = 255; // Alpha
+  }
+
+  if (pixelData instanceof Float32Array) {
+    while (storedPixelDataIndex < numPixels) {
+      if (minPixelValue < 0) {
+        textureData[storedPixelDataIndex * numComp + 3] =
+          lut[pixelData[storedPixelDataIndex++] + -minPixelValue]; // Alpha
+      } else {
+        textureData[storedPixelDataIndex * numComp + 3] =
+          lut[pixelData[storedPixelDataIndex++]]; // Alpha
+      }
+    }
+  } else {
+    while (storedPixelDataIndex < numPixels) {
+      textureData[storedPixelDataIndex * numComp + 3] =
+        lut[pixelData[storedPixelDataIndex++]]; // Alpha
+    }
+  }
+
+  const dataArray = vtkDataArray.newInstance({
+    name: 'Pixels',
+    numberOfComponents: numComp,
+    values: textureData,
+  });
+
+  return dataArray;
+}


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
### Describe the Bug

In case if we are using CPU rendering it works fine, but in case GPU this image inverted.
Please see attached anonimized file
[DICOM sample Issue with Invertion.zip](https://github.com/cornerstonejs/cornerstone3D/files/13840630/DICOM.sample.Issue.with.Invertion.zip)


### Steps to Reproduce


run GPU rendering
![image](https://github.com/cornerstonejs/cornerstone3D/assets/124146469/2b4f9647-7ca2-4762-a430-74d60b11bb11)

run CPU rendering
![image](https://github.com/cornerstonejs/cornerstone3D/assets/124146469/b4275442-32f5-4833-86c6-c7081124a7d7)



### The current behavior

Image inverted and not rendered in proper way

### The expected behavior

Image should be rendered in the correct way and the result should not depend on the rendering type.

### OS

Windows 10, Mac os

### Node version

v18.14.1

### Browser

Chrome 120.0.6099.131

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
Such images have a pixel range of [negative, negative]. Therefore, we are modifying the pixels per LUT to normal values [0, 255]. After these manipulations, everything renders fine.



### Testing
Try to open stackViewport with this series using GPU rendering:
[DICOM.sample.Issue.with.Invertion (1).zip](https://github.com/cornerstonejs/cornerstone3D/files/14971080/DICOM.sample.Issue.with.Invertion.1.zip)

