### PR TITLE
fix(AnnotationTool): fix NaN verbiage in angle tool on incomplete angle

### DIFF
--- a/packages/tools/src/tools/annotation/AngleTool.ts
+++ b/packages/tools/src/tools/annotation/AngleTool.ts
@@ -838,6 +838,11 @@ function defaultGetTextLines(data, targetId): string[] {
     return;
   }
 
+  if (isNaN(angle)) {
+    // The verbiage for incomplete angle is set in cachedStats
+    return [`${angle}`];
+  }
+
   const textLines = [`${roundNumber(angle)} ${String.fromCharCode(176)}`];
 
   return textLines;


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

Fixes #1144 

The incomplete angle created with just one line has the verbiage NaN as the angle - this should not appear on the image

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

Before:
![image](https://github.com/cornerstonejs/cornerstone3D/assets/161482421/c8092521-6798-47c3-bfa2-cbe6e412264a)

After:
![image](https://github.com/cornerstonejs/cornerstone3D/assets/161482421/4bc8fda2-b489-4d49-9bd4-bd4fa17dc1ae)


### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

1. Run `yarn example -- stackAnnotationTools`
2. Select 'Angle' annotation tool
3. Click, hold and drag the mouse to begin drawing the angle
4. When you reach the desired point of the vertex, click the mouse button twice

The measurements panel will display the verbiage 'Incomplete Angle' for any angle measurement that is incomplete (meaning the angle has only one line not, two lines)

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals. (This doesn't apply to this PR as no api changes were made)

#### Tested Environment

- [macOS 14.3.1] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [20.10.0] "Node version: <!--[e.g. 16.14.0]"-->
- [Chrome 122.0.6261.111] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
