### PR TITLE
fix(nifti): support NON-SharedArrayBuffer mode for loading nifti volumes

### DIFF
--- a/packages/nifti-volume-loader/src/helpers/convert.ts
+++ b/packages/nifti-volume-loader/src/helpers/convert.ts
@@ -1,4 +1,4 @@
-import type { Types } from '@cornerstonejs/core';
+import { getShouldUseSharedArrayBuffer, Types } from '@cornerstonejs/core';
 import { parseAffineMatrix } from './affineUtilities';
 
 /**
@@ -11,7 +11,8 @@ const invertDataPerFrame = (dimensions, imageDataArray) => {
   if (
     imageDataArray instanceof Uint8Array ||
     imageDataArray instanceof ArrayBuffer ||
-    imageDataArray instanceof SharedArrayBuffer
+    (getShouldUseSharedArrayBuffer() &&
+      imageDataArray instanceof SharedArrayBuffer)
   ) {
     TypedArrayConstructor = Uint8Array;
     bytesPerVoxel = 1;

--- a/packages/nifti-volume-loader/src/helpers/fetchAndAllocateNiftiVolume.ts
+++ b/packages/nifti-volume-loader/src/helpers/fetchAndAllocateNiftiVolume.ts
@@ -5,6 +5,7 @@ import {
   Enums,
   eventTarget,
   triggerEvent,
+  getShouldUseSharedArrayBuffer,
 } from '@cornerstonejs/core';
 import type { Types } from '@cornerstonejs/core';
 import { vec3 } from 'gl-matrix';
@@ -212,6 +213,8 @@ export default async function fetchAndAllocateNiftiVolume(
   cache.decacheIfNecessaryUntilBytesAvailable(sizeInBytes);
 
   let scalarData;
+  const useSharedArrayBuffer = getShouldUseSharedArrayBuffer();
+  const buffer_size = dimensions[0] * dimensions[1] * dimensions[2];
 
   switch (BitsAllocated) {
     case 8:
@@ -220,18 +223,18 @@ export default async function fetchAndAllocateNiftiVolume(
           '8 Bit signed images are not yet supported by this plugin.'
         );
       } else {
-        scalarData = createUint8SharedArray(
-          dimensions[0] * dimensions[1] * dimensions[2]
-        );
+        scalarData = useSharedArrayBuffer
+          ? createUint8SharedArray(buffer_size)
+          : new Uint8Array(buffer_size);
       }
 
       break;
 
     case 16:
     case 32:
-      scalarData = createFloat32SharedArray(
-        dimensions[0] * dimensions[1] * dimensions[2]
-      );
+      scalarData = useSharedArrayBuffer
+        ? createFloat32SharedArray(buffer_size)
+        : new Float32Array(buffer_size);
 
       break;
   }


### PR DESCRIPTION
This should fix: https://github.com/cornerstonejs/cornerstone3D/issues/1156

@sedghi 


<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
Using example: https://github.com/cornerstonejs/cornerstone3D/blob/main/packages/nifti-volume-loader/examples/niftiWithTools/index.ts#L130-L133
```
async function setup() {
  setUseSharedArrayBuffer(false);

  await csInit();
  await csTools3dInit();
...
}
```

Over Direct IP (non https)
![Screenshot from 2024-03-28 22-23-23](https://github.com/cornerstonejs/cornerstone3D/assets/7339051/07005f66-abbb-4427-9761-f06ef5d03e98)

Over Localhost (non https)
![Screenshot from 2024-03-28 22-23-42](https://github.com/cornerstonejs/cornerstone3D/assets/7339051/8a6fb4b8-afa9-4c31-8af2-e7b593c327be)

Https Mode
![Screenshot from 2024-03-28 22-29-12](https://github.com/cornerstonejs/cornerstone3D/assets/7339051/c8dcff7b-c371-4815-bd9a-a75f9836e2c0)


<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
