### PR TITLE
Fix weird interaction between scroll() and setImageIdIndex() in StackViewport 

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -2094,7 +2094,7 @@ interface IStackViewport extends IViewport {
     // (undocumented)
     setDefaultProperties(ViewportProperties: StackViewportProperties, imageId?: string): void;
     // (undocumented)
-    setImageIdIndex(imageIdIndex: number): Promise<string>;
+    setImageIdIndex(imageIdIndex: number, overwriteScrollIndex?: boolean): Promise<string>;
     // (undocumented)
     setProperties({ voiRange, invert, interpolationType, rotation, colormap, }: StackViewportProperties, suppressEvents?: boolean): void;
     // (undocumented)
@@ -3138,7 +3138,7 @@ export class StackViewport extends Viewport implements IStackViewport, IImagesLo
     // (undocumented)
     setDefaultProperties(ViewportProperties: StackViewportProperties, imageId?: string): void;
     // (undocumented)
-    setImageIdIndex(imageIdIndex: number): Promise<string>;
+    setImageIdIndex(imageIdIndex: number, overwriteScrollIndex?: any): Promise<string>;
     // (undocumented)
     protected setInterpolationType: (interpolationType: InterpolationType) => void;
     // (undocumented)

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -2447,7 +2447,10 @@ class StackViewport extends Viewport implements IStackViewport, IImagesLoader {
    * @param imageIdIndex - number represents imageId index
    * @param overwriteScrollIndex - can be used to also set the start position of scroll() to this index
    */
-  private async _setImageIdIndex(imageIdIndex: number, overwriteScrollIndex: boolean = false): Promise<string> {
+  private async _setImageIdIndex(
+    imageIdIndex: number,
+    overwriteScrollIndex?: boolean
+  ): Promise<string> {
     if (imageIdIndex >= this.imageIds.length) {
       throw new Error(
         `ImageIdIndex provided ${imageIdIndex} is invalid, the stack only has ${this.imageIds.length} elements`
@@ -2589,7 +2592,10 @@ class StackViewport extends Viewport implements IStackViewport, IImagesLoader {
    * provided imageIds in setStack
    * @param overwriteScrollIndex - can be used to also set the start position of scroll() to this index
    */
-  public setImageIdIndex(imageIdIndex: number, overwriteScrollIndex: boolean = false): Promise<string> {
+  public setImageIdIndex(
+    imageIdIndex: number,
+    overwriteScrollIndex?
+  ): Promise<string> {
     this._throwIfDestroyed();
 
     // If we are already on this imageId index, stop here
@@ -2598,7 +2604,10 @@ class StackViewport extends Viewport implements IStackViewport, IImagesLoader {
     }
 
     // Otherwise, get the imageId and attempt to display it
-    const imageIdPromise = this._setImageIdIndex(imageIdIndex, overwriteScrollIndex);
+    const imageIdPromise = this._setImageIdIndex(
+      imageIdIndex,
+      overwriteScrollIndex
+    );
 
     return imageIdPromise;
   }

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -2445,8 +2445,9 @@ class StackViewport extends Viewport implements IStackViewport, IImagesLoader {
   /**
    * Loads the image based on the provided imageIdIndex
    * @param imageIdIndex - number represents imageId index
+   * @param overwriteScrollIndex - can be used to also set the start position of scroll() to this index
    */
-  private async _setImageIdIndex(imageIdIndex: number): Promise<string> {
+  private async _setImageIdIndex(imageIdIndex: number, overwriteScrollIndex: boolean = false): Promise<string> {
     if (imageIdIndex >= this.imageIds.length) {
       throw new Error(
         `ImageIdIndex provided ${imageIdIndex} is invalid, the stack only has ${this.imageIds.length} elements`
@@ -2455,6 +2456,9 @@ class StackViewport extends Viewport implements IStackViewport, IImagesLoader {
 
     // Update the state of the viewport to the new imageIdIndex;
     this.currentImageIdIndex = imageIdIndex;
+    if (overwriteScrollIndex) {
+      this.targetImageIdIndex = this.currentImageIdIndex;
+    }
     this.hasPixelSpacing = true;
     this.viewportStatus = ViewportStatus.PRE_RENDER;
 
@@ -2583,8 +2587,9 @@ class StackViewport extends Viewport implements IStackViewport, IImagesLoader {
    *
    * @param imageIdIndex - number represents imageId index in the list of
    * provided imageIds in setStack
+   * @param overwriteScrollIndex - can be used to also set the start position of scroll() to this index
    */
-  public setImageIdIndex(imageIdIndex: number): Promise<string> {
+  public setImageIdIndex(imageIdIndex: number, overwriteScrollIndex: boolean = false): Promise<string> {
     this._throwIfDestroyed();
 
     // If we are already on this imageId index, stop here
@@ -2593,7 +2598,7 @@ class StackViewport extends Viewport implements IStackViewport, IImagesLoader {
     }
 
     // Otherwise, get the imageId and attempt to display it
-    const imageIdPromise = this._setImageIdIndex(imageIdIndex);
+    const imageIdPromise = this._setImageIdIndex(imageIdIndex, overwriteScrollIndex);
 
     return imageIdPromise;
   }

--- a/packages/core/src/types/IStackViewport.ts
+++ b/packages/core/src/types/IStackViewport.ts
@@ -160,7 +160,7 @@ export default interface IStackViewport extends IViewport {
    */
   setImageIdIndex(
     imageIdIndex: number,
-    overwriteScrollIndex: boolean
+    overwriteScrollIndex?: boolean
   ): Promise<string>;
   /**
    * Calibrates the image with new metadata that has been added for imageId. To calibrate

--- a/packages/core/src/types/IStackViewport.ts
+++ b/packages/core/src/types/IStackViewport.ts
@@ -158,7 +158,10 @@ export default interface IStackViewport extends IViewport {
    * Loads the image based on the provided imageIdIndex. It is an Async function which
    * returns a promise that resolves to the imageId.
    */
-  setImageIdIndex(imageIdIndex: number): Promise<string>;
+  setImageIdIndex(
+    imageIdIndex: number,
+    overwriteScrollIndex: boolean
+  ): Promise<string>;
   /**
    * Calibrates the image with new metadata that has been added for imageId. To calibrate
    * a viewport, you should add your calibration data manually to


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

I had encountered an issue in the StackViewport class, where the user would scroll, afterwards use the public method "setImageIdIndex()" to jump to a specific image and then continue scrolling. The expected behavior in this situation would be to that the viewport continues scrolling from the image that the user just jumped to. However the actual behavior was that the scrolling would pick up back where the user had last scrolled and completely ignore the "setImageIdIndex()" that had happened.

This happens because "this.targetImageIdIndex", which is used during scrolling, was never updated. My workaround was to just use the "setStack()" method instead, since it actually updates "this.targetImageIdIndex" correctly. However I believe that that is not the intended use of the method, so here is my suggested fix. It adds an optional boolean that tells the viewport to also move the scrolling position to the given index. This boolean is optional, because the method is also called from within scroll(), in which case we don't want to adjust the targetImageIdIndex. 

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: Windows
- [] "Node version: v20.12.2
- [] "Browser: Firefox

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
