### PR TITLE
feat(nifti): NIFTI data type enhancement

### DIFF
--- a/common/reviews/api/nifti-volume-loader.api.md
+++ b/common/reviews/api/nifti-volume-loader.api.md
@@ -43,10 +43,17 @@ declare namespace helpers {
 export { helpers }
 
 // @public (undocumented)
-function makeVolumeMetadata(niftiHeader: any, orientation: any, scalarData: any): Types.Metadata;
+function makeVolumeMetadata(niftiHeader: any, orientation: any, scalarData: any, pixelRepresentation: any): {
+    volumeMetadata: Types.Metadata;
+    dimensions: Types.Point3;
+    direction: Types.Mat3;
+};
 
 // @public (undocumented)
-function modalityScaleNifti(array: Float32Array | Int16Array | Uint8Array, niftiHeader: any): void;
+function modalityScaleNifti(niftiHeader: any, niftiImageBuffer: ArrayBuffer): {
+    scalarData: PixelDataTypedArray_2;
+    pixelRepresentation: number;
+};
 
 // @public (undocumented)
 export class NiftiImageVolume extends ImageVolume {

--- a/packages/core/src/RenderingEngine/helpers/createVolumeActor.ts
+++ b/packages/core/src/RenderingEngine/helpers/createVolumeActor.ts
@@ -66,13 +66,7 @@ async function createVolumeActor(
     volumeActor.getProperty().setIndependentComponents(false);
   }
 
-  // If the volume is composed of imageIds, we can apply a default VOI based
-  // on either the metadata or the min/max of the middle slice. Example of other
-  // types of volumes which might not be composed of imageIds would be e.g., nrrd, nifti
-  // format volumes
-  if (imageVolume.imageIds?.length) {
-    await setDefaultVolumeVOI(volumeActor, imageVolume, useNativeDataType);
-  }
+  await setDefaultVolumeVOI(volumeActor, imageVolume, useNativeDataType);
 
   if (callback) {
     callback({ volumeActor, volumeId });

--- a/packages/nifti-volume-loader/examples/niftiBasic/index.ts
+++ b/packages/nifti-volume-loader/examples/niftiBasic/index.ts
@@ -9,8 +9,6 @@ import {
 import { init as csTools3dInit } from '@cornerstonejs/tools';
 import { cornerstoneNiftiImageVolumeLoader } from '@cornerstonejs/nifti-volume-loader';
 
-import { setCtTransferFunctionForVolumeActor } from '../../../../utils/demo/helpers';
-
 // This is for debugging purposes
 console.warn(
   'Click on index.ts to open source code for this example --------->'
@@ -90,7 +88,7 @@ async function setup() {
 
   setVolumesForViewports(
     renderingEngine,
-    [{ volumeId, callback: setCtTransferFunctionForVolumeActor }],
+    [{ volumeId }],
     viewportInputArray.map((v) => v.viewportId)
   );
 

--- a/packages/nifti-volume-loader/examples/niftiWithTools/index.ts
+++ b/packages/nifti-volume-loader/examples/niftiWithTools/index.ts
@@ -12,10 +12,7 @@ import {
   Enums as NiftiEnums,
 } from '@cornerstonejs/nifti-volume-loader';
 
-import {
-  addDropdownToToolbar,
-  setCtTransferFunctionForVolumeActor,
-} from '../../../../utils/demo/helpers';
+import { addDropdownToToolbar } from '../../../../utils/demo/helpers';
 
 const {
   LengthTool,
@@ -276,7 +273,7 @@ async function setup() {
 
   setVolumesForViewports(
     renderingEngine,
-    [{ volumeId, callback: setCtTransferFunctionForVolumeActor }],
+    [{ volumeId }],
     viewportInputArray.map((v) => v.viewportId)
   );
 

--- a/packages/nifti-volume-loader/src/helpers/fetchAndAllocateNiftiVolume.ts
+++ b/packages/nifti-volume-loader/src/helpers/fetchAndAllocateNiftiVolume.ts
@@ -1,23 +1,11 @@
 import * as NiftiReader from 'nifti-reader-js';
-import {
-  cache,
-  utilities,
-  Enums,
-  eventTarget,
-  triggerEvent,
-  getShouldUseSharedArrayBuffer,
-} from '@cornerstonejs/core';
-import type { Types } from '@cornerstonejs/core';
-import { vec3 } from 'gl-matrix';
-import makeVolumeMetadata from './makeVolumeMetadata';
+import { eventTarget, triggerEvent } from '@cornerstonejs/core';
 import NiftiImageVolume from '../NiftiImageVolume';
-import * as NIFTICONSTANTS from './niftiConstants';
-import { invertDataPerFrame, rasToLps } from './convert';
-import modalityScaleNifti from './modalityScaleNifti';
+import { rasToLps } from './convert';
 import Events from '../enums/Events';
 import { NIFTI_LOADER_SCHEME } from '../constants';
-
-const { createUint8SharedArray, createFloat32SharedArray } = utilities;
+import makeVolumeMetadata from './makeVolumeMetadata';
+import modalityScaleNifti from './modalityScaleNifti';
 
 export const urlsMap = new Map();
 
@@ -68,19 +56,6 @@ function fetchArrayBuffer(url, onProgress, signal, onload) {
   });
 }
 
-export const getTypedNiftiArray = (datatypeCode, niftiImageBuffer) => {
-  switch (datatypeCode) {
-    case NIFTICONSTANTS.NIFTI_TYPE_UINT8:
-      return new Uint8Array(niftiImageBuffer);
-    case NIFTICONSTANTS.NIFTI_TYPE_FLOAT32:
-      return new Float32Array(niftiImageBuffer);
-    case NIFTICONSTANTS.NIFTI_TYPE_INT16:
-      return new Int16Array(niftiImageBuffer);
-    default:
-      throw new Error(`datatypeCode ${datatypeCode} is not yet supported`);
-  }
-};
-
 export default async function fetchAndAllocateNiftiVolume(
   volumeId: string
 ): Promise<NiftiImageVolume> {
@@ -127,122 +102,25 @@ export default async function fetchAndAllocateNiftiVolume(
     niftiImage = NiftiReader.readImage(niftiHeader, niftiBuffer);
   }
 
-  const typedNiftiArray = getTypedNiftiArray(
-    niftiHeader.datatypeCode,
+  console.time('answer time');
+  const { scalarData, pixelRepresentation } = modalityScaleNifti(
+    niftiHeader,
     niftiImage
   );
-
-  // Convert to LPS for display in OHIF.
+  // TODO: Comment it as no need invert data of each frame
+  // invertDataPerFrame(niftiHeader.dims.slice(1, 4), scalarData);
 
   const { orientation, origin, spacing } = rasToLps(niftiHeader);
-  invertDataPerFrame(niftiHeader.dims.slice(1, 4), typedNiftiArray);
-
-  modalityScaleNifti(typedNiftiArray, niftiHeader);
-
-  const volumeMetadata = makeVolumeMetadata(
+  const { volumeMetadata, dimensions, direction } = makeVolumeMetadata(
     niftiHeader,
     orientation,
-    typedNiftiArray
+    scalarData,
+    pixelRepresentation
   );
 
-  const scanAxisNormal = vec3.create();
-  vec3.set(scanAxisNormal, orientation[6], orientation[7], orientation[8]);
+  console.timeEnd('answer time');
 
-  const {
-    BitsAllocated,
-    PixelRepresentation,
-    PhotometricInterpretation,
-    ImageOrientationPatient,
-    Columns,
-    Rows,
-  } = volumeMetadata;
-
-  const rowCosineVec = vec3.fromValues(
-    ImageOrientationPatient[0],
-    ImageOrientationPatient[1],
-    ImageOrientationPatient[2]
-  );
-  const colCosineVec = vec3.fromValues(
-    ImageOrientationPatient[3],
-    ImageOrientationPatient[4],
-    ImageOrientationPatient[5]
-  );
-
-  const { dims } = niftiHeader;
-
-  const numFrames = dims[3];
-
-  // Spacing goes [1] then [0], as [1] is column spacing (x) and [0] is row spacing (y)
-  const dimensions = <Types.Point3>[Columns, Rows, numFrames];
-  const direction = new Float32Array([
-    rowCosineVec[0],
-    rowCosineVec[1],
-    rowCosineVec[2],
-    colCosineVec[0],
-    colCosineVec[1],
-    colCosineVec[2],
-    scanAxisNormal[0],
-    scanAxisNormal[1],
-    scanAxisNormal[2],
-  ]) as Types.Mat3;
-  const signed = PixelRepresentation === 1;
-
-  // Check if it fits in the cache before we allocate data
-  // TODO Improve this when we have support for more types
-  // NOTE: We use 4 bytes per voxel as we are using Float32.
-  let bytesPerVoxel = 1;
-  if (BitsAllocated === 16 || BitsAllocated === 32) {
-    bytesPerVoxel = 4;
-  }
-  const sizeInBytesPerComponent =
-    bytesPerVoxel * dimensions[0] * dimensions[1] * dimensions[2];
-
-  let numComponents = 1;
-  if (PhotometricInterpretation === 'RGB') {
-    numComponents = 3;
-  }
-
-  const sizeInBytes = sizeInBytesPerComponent * numComponents;
-
-  // check if there is enough space in unallocated + image Cache
-  const isCacheable = cache.isCacheable(sizeInBytes);
-  if (!isCacheable) {
-    throw new Error(Enums.Events.CACHE_SIZE_EXCEEDED);
-  }
-
-  cache.decacheIfNecessaryUntilBytesAvailable(sizeInBytes);
-
-  let scalarData;
-  const useSharedArrayBuffer = getShouldUseSharedArrayBuffer();
-  const buffer_size = dimensions[0] * dimensions[1] * dimensions[2];
-
-  switch (BitsAllocated) {
-    case 8:
-      if (signed) {
-        throw new Error(
-          '8 Bit signed images are not yet supported by this plugin.'
-        );
-      } else {
-        scalarData = useSharedArrayBuffer
-          ? createUint8SharedArray(buffer_size)
-          : new Uint8Array(buffer_size);
-      }
-
-      break;
-
-    case 16:
-    case 32:
-      scalarData = useSharedArrayBuffer
-        ? createFloat32SharedArray(buffer_size)
-        : new Float32Array(buffer_size);
-
-      break;
-  }
-
-  // Set the scalar data from the nifti typed view into the SAB
-  scalarData.set(typedNiftiArray);
-
-  const niftiImageVolume = new NiftiImageVolume(
+  return new NiftiImageVolume(
     // ImageVolume properties
     {
       volumeId,
@@ -252,7 +130,7 @@ export default async function fetchAndAllocateNiftiVolume(
       origin,
       direction,
       scalarData,
-      sizeInBytes,
+      sizeInBytes: scalarData.byteLength,
       imageIds: [],
     },
     // Streaming properties
@@ -265,6 +143,4 @@ export default async function fetchAndAllocateNiftiVolume(
       controller,
     }
   );
-
-  return niftiImageVolume;
 }

--- a/packages/nifti-volume-loader/src/helpers/makeVolumeMetadata.ts
+++ b/packages/nifti-volume-loader/src/helpers/makeVolumeMetadata.ts
@@ -1,40 +1,31 @@
-import { Types } from '@cornerstonejs/core';
+import { Types, utilities } from '@cornerstonejs/core';
 import { vec3 } from 'gl-matrix';
+
+const { windowLevel } = utilities;
 
 // everything here is LPS
 export default function makeVolumeMetadata(
   niftiHeader,
   orientation,
-  scalarData
-): Types.Metadata {
+  scalarData,
+  pixelRepresentation
+): {
+  volumeMetadata: Types.Metadata;
+  dimensions: Types.Point3;
+  direction: Types.Mat3;
+} {
   const { numBitsPerVoxel, littleEndian, pixDims, dims } = niftiHeader;
-
-  const rowCosines = vec3.create();
-  const columnCosines = vec3.create();
-
-  vec3.set(rowCosines, orientation[0], orientation[1], orientation[2]);
-  vec3.set(columnCosines, orientation[3], orientation[4], orientation[5]);
-
   let min = Infinity;
   let max = -Infinity;
-
-  const xDim = dims[1];
-  const yDim = dims[2];
-  const zDim = dims[3];
-
-  const frameLength = xDim * yDim;
-
-  const middleFrameIndex = Math.floor(zDim / 2);
-
+  const frameLength = dims[1] * dims[2];
+  const middleFrameIndex = Math.floor(dims[3] / 2);
   const offset = frameLength * middleFrameIndex;
-
   for (
     let voxelIndex = offset;
     voxelIndex < offset + frameLength;
     voxelIndex++
   ) {
     const voxelValue = scalarData[voxelIndex];
-
     if (voxelValue > max) {
       max = voxelValue;
     }
@@ -42,34 +33,53 @@ export default function makeVolumeMetadata(
       min = voxelValue;
     }
   }
+  const { windowWidth, windowCenter } = windowLevel.toWindowLevel(min, max);
 
-  const windowCenter = (max + min) / 2;
-  const windowWidth = max - min;
-
+  const rowCosines = vec3.create();
+  const columnCosines = vec3.create();
+  const scanAxisNormal = vec3.create();
+  vec3.set(rowCosines, orientation[0], orientation[1], orientation[2]);
+  vec3.set(columnCosines, orientation[3], orientation[4], orientation[5]);
+  vec3.set(scanAxisNormal, orientation[6], orientation[7], orientation[8]);
   return {
-    BitsAllocated: numBitsPerVoxel,
-    BitsStored: numBitsPerVoxel,
-    SamplesPerPixel: 1,
-    HighBit: littleEndian ? numBitsPerVoxel - 1 : 1,
-    PhotometricInterpretation: 'MONOCHROME2',
-    PixelRepresentation: 1,
-    ImageOrientationPatient: [
+    volumeMetadata: {
+      BitsAllocated: numBitsPerVoxel,
+      BitsStored: numBitsPerVoxel,
+      SamplesPerPixel: 1,
+      HighBit: littleEndian ? numBitsPerVoxel - 1 : 1,
+      PhotometricInterpretation: 'MONOCHROME2',
+      PixelRepresentation: pixelRepresentation,
+      ImageOrientationPatient: [
+        rowCosines[0],
+        rowCosines[1],
+        rowCosines[2],
+        columnCosines[0],
+        columnCosines[1],
+        columnCosines[2],
+      ],
+      PixelSpacing: [pixDims[1], pixDims[2]],
+      Columns: dims[1],
+      Rows: dims[2],
+      // This is a reshaped object and not a dicom tag:
+      voiLut: [{ windowCenter, windowWidth }],
+      // Todo: we should grab this from somewhere but it doesn't really
+      // prevent us from rendering the volume so we'll just hardcode it for now.
+      FrameOfReferenceUID: '1.2.3',
+      Modality: 'MR',
+      VOILUTFunction: 'LINEAR',
+    },
+    // Spacing goes [1] then [0], as [1] is column spacing (x) and [0] is row spacing (y)
+    dimensions: [dims[1], dims[2], dims[3]],
+    direction: new Float32Array([
       rowCosines[0],
       rowCosines[1],
       rowCosines[2],
       columnCosines[0],
       columnCosines[1],
       columnCosines[2],
-    ],
-    PixelSpacing: [pixDims[1], pixDims[2]],
-    Columns: xDim,
-    Rows: yDim,
-    // This is a reshaped object and not a dicom tag:
-    voiLut: [{ windowCenter, windowWidth }],
-    // Todo: we should grab this from somewhere but it doesn't really
-    // prevent us from rendering the volume so we'll just hardcode it for now.
-    FrameOfReferenceUID: '1.2.3',
-    Modality: 'MR',
-    VOILUTFunction: 'LINEAR',
+      scanAxisNormal[0],
+      scanAxisNormal[1],
+      scanAxisNormal[2],
+    ]) as Types.Mat3,
   };
 }

--- a/packages/nifti-volume-loader/src/helpers/modalityScaleNifti.ts
+++ b/packages/nifti-volume-loader/src/helpers/modalityScaleNifti.ts
@@ -1,25 +1,185 @@
+import {
+  cache,
+  Enums,
+  getShouldUseSharedArrayBuffer,
+  utilities,
+} from '@cornerstonejs/core';
+import * as NIFTICONSTANTS from './niftiConstants';
+import {
+  PixelDataTypedArray,
+  PixelDataTypedArrayString,
+} from '@cornerstonejs/core/src/types';
+
+const {
+  createFloat32SharedArray,
+  createInt16SharedArray,
+  createUint8SharedArray,
+  createUint16SharedArray,
+} = utilities;
 /**
  * Given a pixel array, rescale the pixel values using the rescale slope and
  * intercept
  *
  * Todo: add the scaling of PT and SUV
- * @param array - The array to be scaled.
- * @param scalingParameters - The scaling parameters
- * @returns The array being scaled
+ * @param niftiHeader - The header of nifti file
+ * @param niftiImageBuffer - The array buffer of nifti file
+ * @returns The array being scaled and pixelRepresentation
  */
 export default function modalityScaleNifti(
-  array: Float32Array | Int16Array | Uint8Array,
-  niftiHeader
-): void {
-  const arrayLength = array.length;
-  const { scl_slope, scl_inter } = niftiHeader;
+  niftiHeader,
+  niftiImageBuffer: ArrayBuffer
+): {
+  scalarData: PixelDataTypedArray;
+  pixelRepresentation: number;
+} {
+  const { datatypeCode, scl_slope, scl_inter } = niftiHeader;
 
+  let slope = scl_slope;
+  let inter = scl_inter;
   if (!scl_slope || scl_slope === 0 || Number.isNaN(scl_slope)) {
-    // No scaling encoded in NIFTI header
-    return;
+    slope = 1;
   }
+  if (!scl_inter || Number.isNaN(scl_inter)) {
+    inter = 0;
+  }
+  const hasNegativeRescale = inter < 0 || slope < 0;
+  const hasFloatRescale = inter % 1 !== 0 || slope % 1 !== 0;
+  let niiBuffer;
+  let scalarData;
+  let pixelRepresentation = 1;
+  switch (datatypeCode) {
+    case NIFTICONSTANTS.NIFTI_TYPE_UINT8:
+      niiBuffer = new Uint8Array(niftiImageBuffer);
+      if (hasFloatRescale) {
+        scalarData = allocateScalarData('Float32Array', niiBuffer);
+      } else if (hasNegativeRescale) {
+        scalarData = allocateScalarData('Int16Array', niiBuffer);
+      } else {
+        pixelRepresentation = 0;
+        scalarData = allocateScalarData('Uint8Array', niiBuffer);
+      }
+      break;
+    case NIFTICONSTANTS.NIFTI_TYPE_INT16:
+      niiBuffer = new Int16Array(niftiImageBuffer);
+      if (hasFloatRescale) {
+        scalarData = allocateScalarData('Float32Array', niiBuffer);
+      } else {
+        scalarData = allocateScalarData('Int16Array', niiBuffer);
+      }
+      break;
+    case NIFTICONSTANTS.NIFTI_TYPE_INT32:
+      niiBuffer = new Int32Array(niftiImageBuffer);
+      scalarData = allocateScalarData('Float32Array', niiBuffer);
+      break;
+    case NIFTICONSTANTS.NIFTI_TYPE_FLOAT32: {
+      niiBuffer = new Float32Array(niftiImageBuffer);
+      scalarData = allocateScalarData('Float32Array', niiBuffer);
+      break;
+    }
+    case NIFTICONSTANTS.NIFTI_TYPE_INT8:
+      niiBuffer = new Int8Array(niftiImageBuffer);
+      if (hasFloatRescale) {
+        scalarData = allocateScalarData('Float32Array', niiBuffer);
+      } else {
+        scalarData = allocateScalarData('Int8Array', niiBuffer);
+      }
+      break;
+    case NIFTICONSTANTS.NIFTI_TYPE_UINT16:
+      niiBuffer = new Uint16Array(niftiImageBuffer);
+      if (hasFloatRescale || hasNegativeRescale) {
+        scalarData = allocateScalarData('Float32Array', niiBuffer);
+      } else {
+        pixelRepresentation = 0;
+        scalarData = allocateScalarData('Uint16Array', niiBuffer);
+      }
+      break;
+    case NIFTICONSTANTS.NIFTI_TYPE_UINT32:
+      niiBuffer = new Uint32Array(niftiImageBuffer);
+      scalarData = allocateScalarData('Float32Array', niiBuffer);
+      break;
+    default:
+      throw new Error(
+        `NIFTI datatypeCode ${datatypeCode} is not yet supported`
+      );
+  }
+  const nVox = scalarData.length;
+  if (slope !== 1 && inter !== 0) {
+    for (let i = 0; i < nVox; i++) {
+      scalarData[i] = intensityRaw2Scaled(scalarData[i], slope, inter);
+    }
+  }
+  niftiHeader.numBitsPerVoxel = (scalarData.byteLength / scalarData.length) * 8;
+  return {
+    scalarData,
+    pixelRepresentation,
+  };
+}
 
-  for (let i = 0; i < arrayLength; i++) {
-    array[i] = array[i] * scl_slope + scl_inter;
+function intensityRaw2Scaled(
+  raw: number,
+  scl_slope: number,
+  scl_inter: number
+): number {
+  return raw * scl_slope + scl_inter;
+}
+
+function checkCacheAvailable(bitsAllocated: number, length: number): number {
+  const sizeInBytes: number = (bitsAllocated / 8) * length;
+  const isCacheable = cache.isCacheable(sizeInBytes);
+  if (!isCacheable) {
+    throw new Error(Enums.Events.CACHE_SIZE_EXCEEDED);
   }
+  cache.decacheIfNecessaryUntilBytesAvailable(sizeInBytes);
+  return sizeInBytes;
+}
+
+function allocateScalarData(
+  types: PixelDataTypedArrayString,
+  niiBuffer: PixelDataTypedArray
+): PixelDataTypedArray {
+  let bitsAllocated;
+  let scalarData;
+  const useSharedArrayBuffer = getShouldUseSharedArrayBuffer();
+  const nVox = niiBuffer.length;
+  switch (types) {
+    case 'Float32Array':
+      bitsAllocated = 32;
+      checkCacheAvailable(bitsAllocated, nVox);
+      scalarData = useSharedArrayBuffer
+        ? createFloat32SharedArray(nVox)
+        : new Float32Array(nVox);
+      break;
+    case 'Int16Array':
+      bitsAllocated = 16;
+      checkCacheAvailable(bitsAllocated, nVox);
+      scalarData = useSharedArrayBuffer
+        ? createInt16SharedArray(nVox)
+        : new Int16Array(nVox);
+      break;
+    case 'Int8Array':
+      bitsAllocated = 8;
+      checkCacheAvailable(bitsAllocated, nVox);
+      scalarData = useSharedArrayBuffer
+        ? createInt16SharedArray(nVox)
+        : new Int16Array(nVox);
+      break;
+    case 'Uint16Array':
+      bitsAllocated = 16;
+      checkCacheAvailable(bitsAllocated, nVox);
+      scalarData = useSharedArrayBuffer
+        ? createUint16SharedArray(nVox)
+        : new Uint16Array(nVox);
+      break;
+    case 'Uint8Array':
+      bitsAllocated = 8;
+      checkCacheAvailable(bitsAllocated, nVox);
+      scalarData = useSharedArrayBuffer
+        ? createUint8SharedArray(nVox)
+        : new Uint8Array(nVox);
+      break;
+    default:
+      throw new Error(`TypedArray ${types} is not yet supported`);
+  }
+  scalarData.set(niiBuffer);
+  return scalarData;
 }


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

- Support NIFTI file which code type(2, 4, 8, 16, 256, 512, 768) is uint8, int8, uint16, int16, uint32, int32, float32 (#964, #791).
- RGB is not supported yet
- Set default VOI for NIFTI image which imageIds array is empty.
- Support typed array convertation when NIFTI scale result is negetive and float. It may cause precision of loss. 
- Skip scale if slope is 1 and inter is 0
- NIFTI examples and api docs are updated too

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
The test data is provided by #791(pull request #1033) and #964 
https://raw.githubusercontent.com/alfnie/conn/master/utils/surf/referenceT1.nii
https://drive.google.com/file/d/1sLOBm3PGT2XOAWdPRdcyMLZ7tOB9fCcT/view?usp=drive_link

Following is the compare results with NiiVue(RAS) and ITK-SNAP(LPS)

<img width="1428" alt="nifti-compare-int16 (2)" src="https://github.com/cornerstonejs/cornerstone3D/assets/4962574/83f3259f-a5ce-4aca-96f9-48a798190c88">
<img width="1317" alt="nifti-compare-uint8 (2)" src="https://github.com/cornerstonejs/cornerstone3D/assets/4962574/a7924d9c-a788-45e7-9163-433226711209">

<img width="1381" alt="nifti-compare" src="https://github.com/cornerstonejs/cornerstone3D/assets/4962574/78e98ec0-0260-4fc0-8cda-e5d53d316859">



<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [X] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Windows 10
- [x] "Node version: 18.20.1
- [x] "Browser:  Chrome 83.0.4103.116

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
