### PR TITLE
fix(AnnotationEraserTool): check length of annotation on eraser _deleteNearbyAnnotations

### DIFF
--- a/packages/tools/src/tools/AnnotationEraserTool.ts
+++ b/packages/tools/src/tools/AnnotationEraserTool.ts
@@ -56,7 +56,7 @@ class AnnotationEraserTool extends BaseTool {
 
       const annotations = getAnnotations(toolName, element);
 
-      if (!annotations) {
+      if (!annotations.length) {
         continue;
       }
 


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

- Fixes issue number [1218](https://github.com/cornerstonejs/cornerstone3D/issues/1218). 
- Annotations being checked for every added Tool were continuing based on annotations truthiness, an empty array is always returned at a minimum. 
- PR changes the check to the length of the annotations array returned (which is 0 when there are no annotations for a tool). This terminates the iteration in question and removes the the error in issue [1218], of looping through an empty array of annotation objects.


<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
- .length added to annotation if statement in ` packages/tools/src/tools/AnnotationEraserTool.ts ` on Line 58
- Eraser tool removes annotation selected on without the `Uncaught TypeError: interactableAnnotations is not iterable` error
<img width="939" alt="Screenshot 2024-04-23 at 4 04 14 PM" src="https://github.com/cornerstonejs/cornerstone3D/assets/122240522/87bc417a-f0d4-4979-a1c9-c7efcbe06f72">


<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
- run `yarn run example stackAnnotationTools`
- create an annotation (using any tool)
- select the eraser tool 
- select an annotation to remove it
- annotation should be removed and no error in the console

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: MacOS 14.4.1  <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [x] Node version: 20.12.1 <!--[e.g. 16.14.0]"-->
- [x] Browser: Brave 1.65.114]

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
