### PR TITLE
fix(stackContextPrefetch): fix disable function, reduce duplicated fetching of images

### DIFF
--- a/packages/tools/src/utilities/stackPrefetch/stackContextPrefetch.ts
+++ b/packages/tools/src/utilities/stackPrefetch/stackContextPrefetch.ts
@@ -164,7 +164,7 @@ function prefetch(element) {
     imageLoadPoolManager.filterRequests(clearFromImageIds(stack));
   }
 
-  function doneCallback(imageId) {
+  function doneCallback(imageId: string) {
     const imageIdIndex = stack.imageIds.indexOf(imageId);
 
     removeFromList(imageIdIndex);
@@ -222,7 +222,7 @@ function prefetch(element) {
 
   const useNativeDataType = useNorm16Texture || preferSizeOverAccuracy;
 
-  indicesToRequestCopy.forEach((imageIdIndex) => {
+  stackPrefetch.indicesToRequest.forEach((imageIdIndex) => {
     const imageId = stack.imageIds[imageIdIndex];
     // IMPORTANT: Request type should be passed if not the 'interaction'
     // highest priority will be used for the request type in the imageRetrievalPool
@@ -360,7 +360,7 @@ function disable(element) {
   const stackPrefetchData = getToolState(element);
   // If there is actually something to disable, disable it
 
-  if (stackPrefetchData && stackPrefetchData.data.length) {
+  if (stackPrefetchData) {
     stackPrefetchData.enabled = false;
     // Don't worry about clearing the requests - there aren't that many too be bothersome
   }

--- a/packages/tools/test/utilities/stackPrefetch/stackContextPrefetch_test.js
+++ b/packages/tools/test/utilities/stackPrefetch/stackContextPrefetch_test.js
@@ -1,0 +1,79 @@
+import * as cornerstone3D from '@cornerstonejs/core';
+import * as csTools3d from '@cornerstonejs/tools';
+import {
+  fakeImageLoader,
+  fakeMetaDataProvider,
+} from '../../../../../utils/test/testUtils';
+
+const { cache, RenderingEngine, Enums, metaData, imageLoader } = cornerstone3D;
+
+const viewportId = 'VIEWPORT';
+
+function createViewport(renderingEngine, viewportId, width, height) {
+  const element = document.createElement('div');
+
+  element.style.width = `${width}px`;
+  element.style.height = `${height}px`;
+  document.body.appendChild(element);
+
+  renderingEngine.setViewports([
+    {
+      viewportId: viewportId,
+      type: Enums.ViewportType.STACK,
+      element,
+      defaultOptions: {
+        background: [1, 0, 1], // pinkish background
+      },
+    },
+  ]);
+  return element;
+}
+
+describe('stackContextPrefetch:', () => {
+  beforeAll(() => {
+    cornerstone3D.setUseCPURendering(false);
+  });
+
+  beforeEach(function () {
+    cache.purgeCache();
+    this.DOMElements = [];
+    this.renderingEngine = new RenderingEngine();
+    imageLoader.registerImageLoader('fakeImageLoader', fakeImageLoader);
+    metaData.addProvider(fakeMetaDataProvider, 10000);
+  });
+
+  afterEach(function () {
+    this.DOMElements.forEach((el) => {
+      if (el.parentNode) {
+        csTools3d.utilities.stackContextPrefetch.disable(el);
+      }
+    });
+    cache.purgeCache();
+    this.renderingEngine.destroy();
+    metaData.removeProvider(fakeMetaDataProvider);
+    imageLoader.unregisterAllImageLoaders();
+    this.DOMElements.forEach((el) => {
+      if (el.parentNode) {
+        el.parentNode.removeChild(el);
+      }
+    });
+  });
+
+  it('can be disabled without error', function (done) {
+    const element = createViewport(this.renderingEngine, viewportId, 128, 128);
+    this.DOMElements.push(element);
+    const vp = this.renderingEngine.getViewport(viewportId);
+
+    const imageId1 = 'fakeImageLoader:imageURI_64_64_0_10_5_5_0';
+
+    try {
+      vp.setStack([imageId1]).then(() => {
+        csTools3d.utilities.stackContextPrefetch.enable(element);
+        csTools3d.utilities.stackContextPrefetch.disable(element);
+        done();
+      });
+    } catch (e) {
+      done.fail(e);
+    }
+  });
+});


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

This PR fixes the stackContextPrefetch.disable function that was always failing.
Additionally it makes sure that cached images are not fetched again.

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

stackContextPrefetch.disable: remove check of data that will never exist
stackContextPrefetch.prefetch: it is already checked, if images are already cached. Now it does not request cached images again, as it was intended

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->


I added a test for the disable function.

I tried to add a test for the duplicated fetching but found it difficult to test this asynchronous and open-ended behavior.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Ubuntu 22.04
- [x] "Node version: v18.18.2
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
