### PR TITLE
fix(trackball): return if element is not defined in resize observer

### DIFF
--- a/packages/tools/src/tools/TrackballRotateTool.ts
+++ b/packages/tools/src/tools/TrackballRotateTool.ts
@@ -83,10 +83,14 @@ class TrackballRotateTool extends BaseTool {
           const { element } = viewport;
 
           const resizeObserver = new ResizeObserver(() => {
-            const { viewport } = getEnabledElementByIds(
+            const element = getEnabledElementByIds(
               viewportId,
               renderingEngineId
             );
+            if (!element) {
+              return;
+            }
+            const { viewport } = element;
             viewport.resetCamera();
             viewport.render();
           });


### PR DESCRIPTION
### Context

Resize observer was throwing errors because element was not defined

### Changes

return if not defined.
