### PR TITLE
Fix: rotate resolution decreasing on click

### DIFF
--- a/packages/tools/examples/orientationMarker/index.ts
+++ b/packages/tools/examples/orientationMarker/index.ts
@@ -92,8 +92,8 @@ const toolGroupId = 'MY_TOOLGROUP_ID';
 
 // ======== Set up page ======== //
 setTitleAndDescription(
-  'OverlayGrid',
-  'Here we demonstrate overlay grid tool working. The reference lines for all the images in axial series is displayed in the sagittal and coronal series.'
+  'Orientation Marker',
+  'Here we demonstrate Orientation marker tool working .'
 );
 
 const size = '500px';

--- a/packages/tools/src/tools/TrackballRotateTool.ts
+++ b/packages/tools/src/tools/TrackballRotateTool.ts
@@ -20,6 +20,8 @@ import vtkVolumeMapper from '@kitware/vtk.js/Rendering/Core/VolumeMapper';
 class TrackballRotateTool extends BaseTool {
   static toolName;
   originalSampleDistance = null;
+  preMouseDownCallback: (evt: EventTypes.InteractionEventType) => void;
+  mouseUpCallback: (evt: EventTypes.InteractionEventType) => void;
   touchDragCallback: (evt: EventTypes.InteractionEventType) => void;
   mouseDragCallback: (evt: EventTypes.InteractionEventType) => void;
   cleanUp: () => void;
@@ -39,6 +41,8 @@ class TrackballRotateTool extends BaseTool {
 
     this.touchDragCallback = this._dragCallback.bind(this);
     this.mouseDragCallback = this._dragCallback.bind(this);
+    this.preMouseDownCallback = this._preMouseDownCallback.bind(this);
+    this.mouseUpCallback = this._mouseUpCallback.bind(this);
   }
 
   _getMapperFromViewport = (
@@ -161,6 +165,22 @@ class TrackballRotateTool extends BaseTool {
     });
   };
 
+  _preMouseDownCallback(evt: EventTypes.InteractionEventType): void {
+    console.log('premousedown');
+    const { element } = evt.detail;
+    const enabledElement = getEnabledElement(element);
+    const { viewport } = enabledElement;
+    this._reduceSampleDistance(viewport);
+  }
+
+  _mouseUpCallback(evt: EventTypes.InteractionEventType): void {
+    console.log('mouseup');
+    const { element } = evt.detail;
+    const enabledElement = getEnabledElement(element);
+    const { viewport } = enabledElement;
+    this._restoreSampleDistance(viewport);
+  }
+
   // pseudocode inspired from
   // https://github.com/kitware/vtk-js/blob/HEAD/Sources/Interaction/Manipulators/MouseCameraUnicamRotateManipulator/index.js
   _dragCallback(evt: EventTypes.InteractionEventType): void {
@@ -170,7 +190,6 @@ class TrackballRotateTool extends BaseTool {
     const { rotateIncrementDegrees } = this.configuration;
     const enabledElement = getEnabledElement(element);
     const { viewport } = enabledElement;
-    this._reduceSampleDistance(viewport);
 
     const camera = viewport.getCamera();
     const width = element.clientWidth;
@@ -234,7 +253,6 @@ class TrackballRotateTool extends BaseTool {
 
       this.rotateCamera(viewport, centerWorld, rightV, angleY);
 
-      this._restoreSampleDistance(viewport);
       viewport.render();
     }
   }

--- a/packages/tools/src/tools/TrackballRotateTool.ts
+++ b/packages/tools/src/tools/TrackballRotateTool.ts
@@ -66,7 +66,6 @@ class TrackballRotateTool extends BaseTool {
 
   _getViewportsInfo = () => {
     const viewports = getToolGroup(this.toolGroupId).viewportsInfo;
-
     return viewports;
   };
 


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
As discussed yesterday if Office hours, the click with the TrackballRotateTool was causing a permanent and additive resolution decrease

### Changes & Results

Reworked listener to do resolution decrease at drag callback.
However, this mean resolution is changed everytime a drag event occurs, it might have performance impact, as resolution decrease / reincrease could have computation cost.

### Testing

Go to Ortientation Maker Tool, click on the 3D viewport and drag, resolution doesn't decrease anymore

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
