### PR TITLE
fix: Eraser Tool Error with LengthTool and PlanarFreehandROITool Loaded

### DIFF
--- a/packages/tools/src/tools/AnnotationEraserTool.ts
+++ b/packages/tools/src/tools/AnnotationEraserTool.ts
@@ -60,12 +60,11 @@ class AnnotationEraserTool extends BaseTool {
         continue;
       }
 
-      const interactableAnnotations = toolInstance.filterInteractableAnnotationsForElement
-        ? toolInstance.filterInteractableAnnotationsForElement(
-            element,
-            annotations
-          )
-        : [];
+      const interactableAnnotations =
+        toolInstance.filterInteractableAnnotationsForElement(
+          element,
+          annotations
+        ) || [];
 
       for (const annotation of interactableAnnotations) {
         if (

--- a/packages/tools/src/tools/AnnotationEraserTool.ts
+++ b/packages/tools/src/tools/AnnotationEraserTool.ts
@@ -60,11 +60,12 @@ class AnnotationEraserTool extends BaseTool {
         continue;
       }
 
-      const interactableAnnotations =
-        toolInstance.filterInteractableAnnotationsForElement(
-          element,
-          annotations
-        );
+      const interactableAnnotations = toolInstance.filterInteractableAnnotationsForElement
+        ? toolInstance.filterInteractableAnnotationsForElement(
+            element,
+            annotations
+          )
+        : [];
 
       for (const annotation of interactableAnnotations) {
         if (


### PR DESCRIPTION
Related to #1218

Fixes the 'not iterable' error in the `AnnotationEraserTool` when using the Eraser Tool with both LengthTool and PlanarFreehandROITool loaded.

- Adds a conditional check to ensure `filterInteractableAnnotationsForElement` does not return `undefined` before attempting to iterate over its result. This prevents the 'not iterable' error by ensuring `interactableAnnotations` is always an array, even if it's empty.
- Modifies the `_deleteNearbyAnnotations` method to gracefully handle cases where `filterInteractableAnnotationsForElement` might return `undefined`, ensuring the Eraser Tool functions correctly regardless of the combination of tools loaded.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/cornerstonejs/cornerstone3D/issues/1218?shareId=85160633-8878-43bd-9954-70e5959faf52).