### PR TITLE
fix(scaleoverlay): account for device pixel ratio when drawing the scale annotation

### DIFF
--- a/packages/tools/src/tools/ScaleOverlayTool.ts
+++ b/packages/tools/src/tools/ScaleOverlayTool.ts
@@ -204,8 +204,8 @@ class ScaleOverlayTool extends AnnotationDisplayTool {
     };
 
     const canvasSize = {
-      width: canvas.width,
-      height: canvas.height,
+      width: canvas.width / window.devicePixelRatio || 1,
+      height: canvas.height / window.devicePixelRatio || 1,
     };
 
     const topLeft = annotation.data.handles.points[0];


### PR DESCRIPTION


### Context

scale overlay tool was broken because it wasn't taking the device pixel ratio into account.

### Changes & Results

Fixed the device pixel ratio
 

<img width="489" alt="image" src="https://github.com/cornerstonejs/cornerstone3D/assets/93064150/369e751f-510a-408f-a0d8-f3424291e5ae">
