### PR TITLE
Feature/threshold optional center and threshold area

### DIFF
--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -884,11 +884,11 @@ export class BrushTool extends BaseTool {
     // (undocumented)
     mouseMoveCallback: (evt: EventTypes_2.InteractionEventType) => void;
     // (undocumented)
-    onSetToolDisabled: (evt: any) => void;
+    onSetToolDisabled: () => void;
     // (undocumented)
     onSetToolEnabled: () => void;
     // (undocumented)
-    onSetToolPassive: (evt: any) => void;
+    onSetToolPassive: () => void;
     // (undocumented)
     preMouseDownCallback: (evt: EventTypes_2.MouseDownActivateEventType) => boolean;
     // (undocumented)

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -834,6 +834,16 @@ export class BrushTool extends BaseTool {
         referencedVolumeId?: undefined;
     };
     // (undocumented)
+    disableCenterIJKPreview: () => void;
+    // (undocumented)
+    disableHoverPreview: () => void;
+    // (undocumented)
+    enableCenterIJKPreview: () => void;
+    // (undocumented)
+    enableHoverPreview: () => void;
+    // (undocumented)
+    getManualPreviewMode: () => any;
+    // (undocumented)
     protected getOperationData(element?: any): {
         points: any;
         segmentIndex: number;
@@ -845,6 +855,7 @@ export class BrushTool extends BaseTool {
         viewUp: any;
         strategySpecificConfiguration: any;
         preview: unknown;
+        isCenterIJKDisabled: any;
         segmentsLocked: number[];
         imageIdReferenceMap?: Map<string, string>;
         volumeId?: string;
@@ -860,6 +871,7 @@ export class BrushTool extends BaseTool {
         viewUp: any;
         strategySpecificConfiguration: any;
         preview: unknown;
+        isCenterIJKDisabled: any;
         volumeId: string;
         referencedVolumeId: any;
         segmentsLocked: number[] | [];
@@ -867,6 +879,8 @@ export class BrushTool extends BaseTool {
     };
     // (undocumented)
     invalidateBrushCursor(): void;
+    // (undocumented)
+    manualPreview: (element: HTMLDivElement) => void;
     // (undocumented)
     mouseMoveCallback: (evt: EventTypes_2.InteractionEventType) => void;
     // (undocumented)
@@ -883,6 +897,8 @@ export class BrushTool extends BaseTool {
     rejectPreview(element?: HTMLDivElement): void;
     // (undocumented)
     renderAnnotation(enabledElement: Types_2.IEnabledElement, svgDrawingHelper: SVGDrawingHelper): void;
+    // (undocumented)
+    setManualPreviewMode: (isManualPreviewEnabled: boolean) => void;
     // (undocumented)
     static toolName: any;
     // (undocumented)

--- a/packages/tools/examples/labelmapSegmentationDynamicThreshold/index.ts
+++ b/packages/tools/examples/labelmapSegmentationDynamicThreshold/index.ts
@@ -157,6 +157,28 @@ addButtonToToolbar({
   },
 });
 
+addButtonToToolbar({
+  title: 'Manual Preview toggle',
+  onClick: () => {
+    const toolGroup = ToolGroupManager.getToolGroup(toolGroupId);
+    const activeName = toolGroup.getActivePrimaryMouseButtonTool();
+    const brush = toolGroup.getToolInstance(activeName);
+
+    if (brush.getManualPreviewMode()) {
+      brush.setManualPreviewMode(false);
+      brush.enableCenterIJKPreview();
+      brush.enableHoverPreview();
+      brush.rejectPreview?.(element1);
+    } else {
+      brush.setManualPreviewMode(true);
+      brush.disableCenterIJKPreview();
+      brush.configuration.brushSize = 1000;
+      brush.disableHoverPreview();
+      brush.manualPreview?.(element1);
+    }
+  },
+});
+
 // ============================= //
 
 async function addSegmentationsToState() {

--- a/packages/tools/examples/labelmapSegmentationDynamicThreshold/index.ts
+++ b/packages/tools/examples/labelmapSegmentationDynamicThreshold/index.ts
@@ -179,6 +179,28 @@ addButtonToToolbar({
   },
 });
 
+addButtonToToolbar({
+  title: 'Enable Center IJK preview',
+  onClick: () => {
+    const toolGroup = ToolGroupManager.getToolGroup(toolGroupId);
+    const activeName = toolGroup.getActivePrimaryMouseButtonTool();
+    const brush = toolGroup.getToolInstance(activeName);
+
+    brush.enableCenterIJKPreview();
+  },
+});
+
+addButtonToToolbar({
+  title: 'Disable Center IJK preview',
+  onClick: () => {
+    const toolGroup = ToolGroupManager.getToolGroup(toolGroupId);
+    const activeName = toolGroup.getActivePrimaryMouseButtonTool();
+    const brush = toolGroup.getToolInstance(activeName);
+
+    brush.disableCenterIJKPreview();
+  },
+});
+
 // ============================= //
 
 async function addSegmentationsToState() {

--- a/packages/tools/src/tools/segmentation/BrushTool.ts
+++ b/packages/tools/src/tools/segmentation/BrushTool.ts
@@ -386,30 +386,80 @@ class BrushTool extends BaseTool {
     }
   };
 
+  /**
+   * Sets the manual preview mode for the BrushTool.
+   * This method updates the `isManualPreviewEnabled` property of the
+   * configuration's preview object. When `isManualPreviewEnabled` is `true`,
+   * the preview mode is manually controlled.
+   *
+   * @param isManualPreviewEnabled - A boolean value to enable or disable manual
+   * preview mode.
+   */
   setManualPreviewMode = (isManualPreviewEnabled: boolean) => {
     this.configuration.preview.isManualPreviewEnabled = isManualPreviewEnabled;
   };
 
+  /**
+   * Retrieves the current state of the manual preview mode for the BrushTool.
+   * This method returns the `isManualPreviewEnabled` property of the configuration's
+   * preview object. When `isManualPreviewEnabled` is `true`, the preview mode
+   * is manually controlled.
+   *
+   * @returns {boolean} - The current state of the manual preview mode.
+   */
   getManualPreviewMode = () => {
     return this.configuration.preview.isManualPreviewEnabled;
   };
 
+  /**
+   * Enables the preview at the center of the IJK coordinate system.
+   * This method sets the `isCenterIJKDisabled` property of the configuration's
+   * preview object to `false`. When `isCenterIJKDisabled` is `false`, the preview
+   * will rely on the center of the IJK coordinate system.
+   */
   enableCenterIJKPreview = () => {
     this.configuration.preview.isCenterIJKDisabled = false;
   };
 
+  /**
+   * Disables the preview at the center of the IJK coordinate system.
+   * This method sets the `isCenterIJKDisabled` property of the configuration's
+   * preview object to `true`. When `isCenterIJKDisabled` is `true`, the preview
+   * will not rely on center of the IJK coordinate system.
+   */
   disableCenterIJKPreview = () => {
     this.configuration.preview.isCenterIJKDisabled = true;
   };
 
+  /**
+   * Enables the hover preview for the BrushTool.
+   * This method sets the `isHoverPreviewDisabled` property of the configuration's
+   * preview object to `false`. When `isHoverPreviewDisabled` is `false`, the hover
+   * preview feature is enabled (default behaviour).
+   */
   enableHoverPreview = () => {
     this.configuration.preview.isHoverPreviewDisabled = false;
   };
 
+  /**
+   * Disables the hover preview for the BrushTool.
+   * This method sets the `isHoverPreviewDisabled` property of the configuration's
+   * preview object to `true`. When `isHoverPreviewDisabled` is `true`, the hover
+   * preview feature is disabled.
+   */
   disableHoverPreview = () => {
     this.configuration.preview.isHoverPreviewDisabled = true;
   };
 
+  /**
+   * Manually triggers a preview operation for the BrushTool.
+   * This method is used to manually control the preview mode of the BrushTool.
+   * It cancels any ongoing preview operation, enables the preview mode if it's
+   * not enabled, and initiates a new preview operation at the center of the viewport.
+   *
+   * @param element - The HTMLDivElement of the viewport where the preview
+   * operation is to be performed.
+   */
   manualPreview = (element: HTMLDivElement) => {
     // If a preview operation is in progress, cancel it
     if (this._previewData.timer) {

--- a/packages/tools/src/tools/segmentation/strategies/BrushStrategy.ts
+++ b/packages/tools/src/tools/segmentation/strategies/BrushStrategy.ts
@@ -17,6 +17,7 @@ export type InitializedOperationData = LabelmapToolOperationDataAny & {
   // Additional data for performing the strategy
   enabledElement: Types.IEnabledElement;
   centerIJK?: Types.Point3;
+  isCenterIJKDisabled?: boolean;
   centerWorld: Types.Point3;
   viewport: Types.IViewport;
   imageVoxelManager:
@@ -168,7 +169,8 @@ export default class BrushStrategy {
       return;
     }
 
-    const { strategySpecificConfiguration = {}, centerIJK } = initializedData;
+    const { strategySpecificConfiguration = {}, centerIJK = [] } =
+      initializedData;
     // Store the center IJK location so that we can skip an immediate same-point update
     // TODO - move this to the BrushTool
     if (csUtils.isEqual(centerIJK, strategySpecificConfiguration.centerIJK)) {

--- a/packages/tools/src/tools/segmentation/strategies/BrushStrategy.ts
+++ b/packages/tools/src/tools/segmentation/strategies/BrushStrategy.ts
@@ -26,10 +26,9 @@ export type InitializedOperationData = LabelmapToolOperationDataAny & {
   segmentationVoxelManager: csUtils.VoxelManager<number>;
   segmentationImageData: vtkImageData;
   previewVoxelManager: csUtils.VoxelManager<number>;
-  // The index to use for the preview segment.  Currently always undefined or 255
+  // The index to use for the preview segment. Currently, always undefined or 255
   // but define it here for future expansion of LUT tables
   previewSegmentIndex?: number;
-
   brushStrategy: BrushStrategy;
   configuration?: Record<string, any>;
 };
@@ -169,8 +168,7 @@ export default class BrushStrategy {
       return;
     }
 
-    const { strategySpecificConfiguration = {}, centerIJK = [] } =
-      initializedData;
+    const { strategySpecificConfiguration = {}, centerIJK } = initializedData;
     // Store the center IJK location so that we can skip an immediate same-point update
     // TODO - move this to the BrushTool
     if (csUtils.isEqual(centerIJK, strategySpecificConfiguration.centerIJK)) {

--- a/packages/tools/src/tools/segmentation/strategies/compositions/areaFill.ts
+++ b/packages/tools/src/tools/segmentation/strategies/compositions/areaFill.ts
@@ -14,13 +14,9 @@ export default {
       segmentsLocked,
       segmentationImageData,
       segmentationVoxelManager: segmentationVoxelManager,
-      previewVoxelManager: previewVoxelManager,
       imageVoxelManager: imageVoxelManager,
       brushStrategy,
-      centerIJK,
-      isCenterIJKDisabled,
     } = operationData;
-
     const isWithinThreshold =
       brushStrategy.createIsInThreshold?.(operationData);
     const { setValue } = brushStrategy;
@@ -41,9 +37,5 @@ export default {
       callback,
       segmentationVoxelManager.boundsIJK
     );
-
-    if (!isCenterIJKDisabled) {
-      previewVoxelManager.addPoint(centerIJK);
-    }
   },
 };

--- a/packages/tools/src/tools/segmentation/strategies/compositions/index.ts
+++ b/packages/tools/src/tools/segmentation/strategies/compositions/index.ts
@@ -4,10 +4,12 @@ import erase from './erase';
 import islandRemoval from './islandRemoval';
 import preview from './preview';
 import regionFill from './regionFill';
+import areaFill from './areaFill';
 import setValue from './setValue';
 import threshold from './threshold';
 
 export default {
+  areaFill,
   determineSegmentIndex,
   dynamicThreshold,
   erase,

--- a/packages/tools/src/tools/segmentation/strategies/fillCircle.ts
+++ b/packages/tools/src/tools/segmentation/strategies/fillCircle.ts
@@ -1,124 +1,8 @@
-import { vec3 } from 'gl-matrix';
-import { utilities as csUtils } from '@cornerstonejs/core';
-import type { Types } from '@cornerstonejs/core';
-
-import {
-  getCanvasEllipseCorners,
-  precalculatePointInEllipse,
-} from '../../../utilities/math/ellipse';
-import { getBoundingBoxAroundShapeIJK } from '../../../utilities/boundingBox';
 import BrushStrategy from './BrushStrategy';
-import type { Composition, InitializedOperationData } from './BrushStrategy';
-import type { CanvasCoordinates } from '../../../types';
-import { StrategyCallbacks } from '../../../enums';
 import compositions from './compositions';
-import { pointInSphere } from '../../../utilities/math/sphere';
-
-const { transformWorldToIndex, isEqual } = csUtils;
-
-const initializeCircle = {
-  [StrategyCallbacks.Initialize]: (operationData: InitializedOperationData) => {
-    const {
-      points, // bottom, top, left, right
-      imageVoxelManager: imageVoxelManager,
-      viewport,
-      segmentationImageData,
-      segmentationVoxelManager: segmentationVoxelManager,
-    } = operationData;
-
-    // Happens on a preview setup
-    if (!points) {
-      return;
-    }
-    // Average the points to get the center of the ellipse
-    const center = vec3.fromValues(0, 0, 0);
-    points.forEach((point) => {
-      vec3.add(center, center, point);
-    });
-    vec3.scale(center, center, 1 / points.length);
-
-    operationData.centerWorld = center as Types.Point3;
-    operationData.centerIJK = transformWorldToIndex(
-      segmentationImageData,
-      center as Types.Point3
-    );
-
-    const canvasCoordinates = points.map((p) =>
-      viewport.worldToCanvas(p)
-    ) as CanvasCoordinates;
-
-    // 1. From the drawn tool: Get the ellipse (circle) topLeft and bottomRight
-    // corners in canvas coordinates
-    const [topLeftCanvas, bottomRightCanvas] =
-      getCanvasEllipseCorners(canvasCoordinates);
-
-    // 2. Find the extent of the ellipse (circle) in IJK index space of the image
-    const topLeftWorld = viewport.canvasToWorld(topLeftCanvas);
-    const bottomRightWorld = viewport.canvasToWorld(bottomRightCanvas);
-
-    const circleCornersIJK = points.map((world) => {
-      return transformWorldToIndex(segmentationImageData, world);
-    });
-
-    // get the bounds from the circle points since in oblique images the
-    // circle will not be axis aligned
-    const boundsIJK = getBoundingBoxAroundShapeIJK(
-      circleCornersIJK,
-      segmentationImageData.getDimensions()
-    );
-
-    segmentationVoxelManager.boundsIJK = boundsIJK;
-    imageVoxelManager.isInObject = createPointInEllipse({
-      topLeftWorld,
-      bottomRightWorld,
-      center,
-    });
-  },
-} as Composition;
-
-/**
- * Creates a function that tells the user if the provided point in LPS space
- * is inside the ellipse.
- *
- * This will return a sphere test function if the bounds are a circle or
- * sphere shape (same radius in two or three dimensions), or an elliptical shape
- * if they differ.
- */
-function createPointInEllipse(worldInfo: {
-  topLeftWorld: Types.Point3;
-  bottomRightWorld: Types.Point3;
-  center: Types.Point3 | vec3;
-}) {
-  const { topLeftWorld, bottomRightWorld, center } = worldInfo;
-
-  const xRadius = Math.abs(topLeftWorld[0] - bottomRightWorld[0]) / 2;
-  const yRadius = Math.abs(topLeftWorld[1] - bottomRightWorld[1]) / 2;
-  const zRadius = Math.abs(topLeftWorld[2] - bottomRightWorld[2]) / 2;
-
-  const radius = Math.max(xRadius, yRadius, zRadius);
-  if (
-    isEqual(xRadius, radius) &&
-    isEqual(yRadius, radius) &&
-    isEqual(zRadius, radius)
-  ) {
-    const sphereObj = {
-      center,
-      radius,
-      radius2: radius * radius,
-    };
-    return (pointLPS) => pointInSphere(sphereObj, pointLPS);
-  }
-  // using circle as a form of ellipse
-  const ellipseObj = {
-    center: center as Types.Point3,
-    xRadius,
-    yRadius,
-    zRadius,
-  };
-
-  const { precalculated } = precalculatePointInEllipse(ellipseObj, {});
-  return precalculated;
-}
+import { createPointInEllipse } from './utils/createPointInEllipse';
+import { initializeArea } from './utils/initializeArea';
+import { initializeCircle } from './utils/initializeCircle';
 
 const CIRCLE_STRATEGY = new BrushStrategy(
   'Circle',
@@ -134,6 +18,18 @@ const CIRCLE_THRESHOLD_STRATEGY = new BrushStrategy(
   compositions.regionFill,
   compositions.setValue,
   initializeCircle,
+  compositions.determineSegmentIndex,
+  compositions.dynamicThreshold,
+  compositions.threshold,
+  compositions.preview,
+  compositions.islandRemoval
+);
+
+const AREA_THRESHOLD_STRATEGY = new BrushStrategy(
+  'AreaThreshold',
+  compositions.areaFill,
+  compositions.setValue,
+  initializeArea,
   compositions.determineSegmentIndex,
   compositions.dynamicThreshold,
   compositions.threshold,
@@ -158,6 +54,13 @@ const fillInsideCircle = CIRCLE_STRATEGY.strategyFunction;
 const thresholdInsideCircle = CIRCLE_THRESHOLD_STRATEGY.strategyFunction;
 
 /**
+ * Fill segment inside the area inside the segmentation defined by the operationData.
+ * It fills the segmentation pixels inside the viewport area.
+ * @param enabledElement - The element for which the segment is being erased.
+ * @param operationData - EraseOperationData
+ */
+const thresholdInsideArea = AREA_THRESHOLD_STRATEGY.strategyFunction;
+/**
  * Fill outside the circular region segment inside the segmentation defined by the operationData.
  * It fills the segmentation pixels outside the  defined circle.
  * @param enabledElement - The element for which the segment is being erased.
@@ -168,9 +71,11 @@ export function fillOutsideCircle(): void {
 }
 
 export {
+  AREA_THRESHOLD_STRATEGY,
   CIRCLE_STRATEGY,
   CIRCLE_THRESHOLD_STRATEGY,
-  fillInsideCircle,
-  thresholdInsideCircle,
   createPointInEllipse as createEllipseInPoint,
+  fillInsideCircle,
+  thresholdInsideArea,
+  thresholdInsideCircle,
 };

--- a/packages/tools/src/tools/segmentation/strategies/utils/createPointInEllipse.ts
+++ b/packages/tools/src/tools/segmentation/strategies/utils/createPointInEllipse.ts
@@ -1,0 +1,50 @@
+import { Types, utilities as csUtils } from '@cornerstonejs/core';
+import { vec3 } from 'gl-matrix';
+import { pointInSphere } from '../../../../utilities/math/sphere';
+import { precalculatePointInEllipse } from '../../../../utilities/math/ellipse';
+
+const { isEqual } = csUtils;
+
+/**
+ * Creates a function that tells the user if the provided point in LPS space
+ * is inside the ellipse.
+ *
+ * This will return a sphere test function if the bounds are a circle or
+ * sphere shape (same radius in two or three dimensions), or an elliptical shape
+ * if they differ.
+ */
+export const createPointInEllipse = (worldInfo: {
+  topLeftWorld: Types.Point3;
+  bottomRightWorld: Types.Point3;
+  center: Types.Point3 | vec3;
+}) => {
+  const { topLeftWorld, bottomRightWorld, center } = worldInfo;
+
+  const xRadius = Math.abs(topLeftWorld[0] - bottomRightWorld[0]) / 2;
+  const yRadius = Math.abs(topLeftWorld[1] - bottomRightWorld[1]) / 2;
+  const zRadius = Math.abs(topLeftWorld[2] - bottomRightWorld[2]) / 2;
+
+  const radius = Math.max(xRadius, yRadius, zRadius);
+  if (
+    isEqual(xRadius, radius) &&
+    isEqual(yRadius, radius) &&
+    isEqual(zRadius, radius)
+  ) {
+    const sphereObj = {
+      center,
+      radius,
+      radius2: radius * radius,
+    };
+    return (pointLPS) => pointInSphere(sphereObj, pointLPS);
+  }
+  // using circle as a form of ellipse
+  const ellipseObj = {
+    center: center as Types.Point3,
+    xRadius,
+    yRadius,
+    zRadius,
+  };
+
+  const { precalculated } = precalculatePointInEllipse(ellipseObj, {});
+  return precalculated;
+};

--- a/packages/tools/src/tools/segmentation/strategies/utils/initializeArea.ts
+++ b/packages/tools/src/tools/segmentation/strategies/utils/initializeArea.ts
@@ -1,0 +1,119 @@
+import { StrategyCallbacks } from '../../../../enums';
+import type { Composition, InitializedOperationData } from '../BrushStrategy';
+import { vec3 } from 'gl-matrix';
+import { Types, utilities as csUtils } from '@cornerstonejs/core';
+import { getBoundingBoxAroundShapeIJK } from '../../../../utilities/boundingBox';
+
+const { transformWorldToIndex } = csUtils;
+
+export const initializeArea = {
+  [StrategyCallbacks.Initialize]: (operationData: InitializedOperationData) => {
+    const {
+      points, // bottom, top, left, right
+      imageVoxelManager: imageVoxelManager,
+      viewport,
+      segmentationImageData,
+      segmentationVoxelManager: segmentationVoxelManager,
+    } = operationData;
+
+    // Happens on a preview setup
+    if (!points) {
+      return;
+    }
+
+    // Average the points to get the center of the ellipse
+    const center = vec3.fromValues(0, 0, 0);
+    points.forEach((point) => {
+      vec3.add(center, center, point);
+    });
+    vec3.scale(center, center, 1 / points.length);
+
+    operationData.centerWorld = center as Types.Point3;
+    operationData.centerIJK = center as Types.Point3;
+
+    const [xSize, ySize, zSize] = segmentationImageData.getDimensions();
+
+    const circleCornersIJK = points.map((world, index) => {
+      if (
+        viewport.options.orientation === 'axial' ||
+        viewport.options.orientation === 'acquisition'
+      ) {
+        let worldPoint: Types.Point3;
+
+        switch (index) {
+          // Bottom center coordinate
+          case 0:
+            worldPoint = [0, -ySize / 2, world[2]];
+            break;
+          // Top center coordinate
+          case 1:
+            worldPoint = [0, ySize / 2, world[2]];
+            break;
+          // Left center coordinate
+          case 2:
+            worldPoint = [-xSize / 2, 0, world[2]];
+            break;
+          // Right center coordinate
+          case 3:
+            worldPoint = [xSize / 2, 0, world[2]];
+            break;
+        }
+        return transformWorldToIndex(segmentationImageData, worldPoint);
+      } else if (viewport.options.orientation === 'sagittal') {
+        let worldPoint: Types.Point3;
+
+        switch (index) {
+          // Bottom center coordinate
+          case 0:
+            worldPoint = [world[0], 3000, -600];
+            break;
+          // Top center coordinate
+          case 1:
+            worldPoint = [world[0], -2000, 0];
+            break;
+          // Left center coordinate
+          case 2:
+            worldPoint = [world[0], 0, zSize];
+            break;
+          // Right center coordinate
+          case 3:
+            worldPoint = [world[0], 0, -zSize];
+            break;
+        }
+        return transformWorldToIndex(segmentationImageData, worldPoint);
+      } else if (viewport.options.orientation === 'coronal') {
+        let worldPoint: Types.Point3;
+
+        switch (index) {
+          // Bottom center coordinate
+          case 0:
+            worldPoint = [0, world[1], -1000];
+            break;
+          // Top center coordinate
+          case 1:
+            worldPoint = [0, world[1], 1000];
+            break;
+          // Left center coordinate
+          case 2:
+            worldPoint = [-xSize, world[1], 0];
+            break;
+          // Right center coordinate
+          case 3:
+            worldPoint = [xSize, world[1], 0];
+            break;
+        }
+        return transformWorldToIndex(segmentationImageData, worldPoint);
+      }
+
+      return transformWorldToIndex(segmentationImageData, world);
+    });
+
+    // get the bounds from the circle points since in oblique images the
+    // circle will not be axis aligned
+    segmentationVoxelManager.boundsIJK = getBoundingBoxAroundShapeIJK(
+      circleCornersIJK,
+      segmentationImageData.getDimensions()
+    );
+    imageVoxelManager.isInObject = () => true;
+  },
+} as Composition;

--- a/packages/tools/src/tools/segmentation/strategies/utils/initializeCircle.ts
+++ b/packages/tools/src/tools/segmentation/strategies/utils/initializeCircle.ts
@@ -1,0 +1,70 @@
+import { StrategyCallbacks } from '../../../../enums';
+import type { Composition, InitializedOperationData } from '../BrushStrategy';
+import { vec3 } from 'gl-matrix';
+import { Types, utilities as csUtils } from '@cornerstonejs/core';
+import type { CanvasCoordinates } from '../../../../utilities/math/ellipse/getCanvasEllipseCorners';
+import { getCanvasEllipseCorners } from '../../../../utilities/math/ellipse';
+import { getBoundingBoxAroundShapeIJK } from '../../../../utilities/boundingBox';
+import { createPointInEllipse } from './createPointInEllipse';
+
+const { transformWorldToIndex } = csUtils;
+
+export const initializeCircle = {
+  [StrategyCallbacks.Initialize]: (operationData: InitializedOperationData) => {
+    const {
+      points, // bottom, top, left, right
+      imageVoxelManager: imageVoxelManager,
+      viewport,
+      segmentationImageData,
+      segmentationVoxelManager: segmentationVoxelManager,
+    } = operationData;
+
+    // Happens on a preview setup
+    if (!points) {
+      return;
+    }
+    // Average the points to get the center of the ellipse
+    const center = vec3.fromValues(0, 0, 0);
+    points.forEach((point) => {
+      vec3.add(center, center, point);
+    });
+    vec3.scale(center, center, 1 / points.length);
+
+    operationData.centerWorld = center as Types.Point3;
+    operationData.centerIJK = transformWorldToIndex(
+      segmentationImageData,
+      center as Types.Point3
+    );
+
+    const canvasCoordinates = points.map((p) =>
+      viewport.worldToCanvas(p)
+    ) as CanvasCoordinates;
+
+    // 1. From the drawn tool: Get the ellipse (circle) topLeft and bottomRight
+    // corners in canvas coordinates
+    const [topLeftCanvas, bottomRightCanvas] =
+      getCanvasEllipseCorners(canvasCoordinates);
+
+    // 2. Find the extent of the ellipse (circle) in IJK index space of the image
+    const topLeftWorld = viewport.canvasToWorld(topLeftCanvas);
+    const bottomRightWorld = viewport.canvasToWorld(bottomRightCanvas);
+
+    const circleCornersIJK = points.map((world) => {
+      return transformWorldToIndex(segmentationImageData, world);
+    });
+
+    // get the bounds from the circle points since in oblique images the
+    // circle will not be axis aligned
+    const boundsIJK = getBoundingBoxAroundShapeIJK(
+      circleCornersIJK,
+      segmentationImageData.getDimensions()
+    );
+
+    segmentationVoxelManager.boundsIJK = boundsIJK;
+    imageVoxelManager.isInObject = createPointInEllipse({
+      topLeftWorld,
+      bottomRightWorld,
+      center,
+    });
+  },
+} as Composition;

--- a/packages/tools/src/utilities/contours/detectContourHoles.ts
+++ b/packages/tools/src/utilities/contours/detectContourHoles.ts
@@ -58,7 +58,6 @@ function checkEnclosed(outerContour, innerContour, points) {
       [points[point][0], points[point][1]],
       vertices
     );
-    //console.log(result);
 
     if (!result) {
       pointsNotEnclosed++;
@@ -74,8 +73,6 @@ function checkEnclosed(outerContour, innerContour, points) {
  * @param {*} bypass
  */
 export function processContourHoles(contours, points, useXOR = true) {
-  //console.log(points);
-
   // Add non-closed planars to contour list
   const retContours = contours.filter(
     (contour) => contour.type !== 'CLOSED_PLANAR'

--- a/utils/demo/helpers/labelmapTools.ts
+++ b/utils/demo/helpers/labelmapTools.ts
@@ -44,8 +44,20 @@ const defaultThresholdOption = [...thresholdOptions.keys()][2];
 const thresholdArgs = thresholdOptions.get(defaultThresholdOption);
 const toolMap = new Map();
 
-toolMap.set('ThresholdCircle', {
+toolMap.set('ThresholdArea', {
   tool: BrushTool,
+  baseTool: BrushTool.toolName,
+  configuration: {
+    ...configuration,
+    activeStrategy: 'THRESHOLD_INSIDE_AREA',
+    strategySpecificConfiguration: {
+      ...configuration.strategySpecificConfiguration,
+      THRESHOLD: { ...thresholdArgs },
+    },
+  },
+});
+
+toolMap.set('ThresholdCircle', {
   baseTool: BrushTool.toolName,
   configuration: {
     ...configuration,


### PR DESCRIPTION
### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

- **Issue Link**: N/A
- **Problem Description**: We want to show the threshold for the whole slice.
- **Error Logs**: N/A

- **Specific Requirements**: The threshold needs to be displayed for the entire viewport (slice).
- **Design/UI Guidelines**: No specific guidelines.
- **Integration with Existing Functionality**: Extra flags have been added to ensure backwards compatibility and make the functionality more flexible.
- **Performance Considerations**: No performance issues for one viewport. Volume visualization is currently out of scope.
- **Specific Test Cases/Scenarios**: There are issues with MPR mode (checked during OHIF Viewer integration), where it doesn't recognize any existing segments. Also I need some help with proper edge coordinates for AreaFill (some of them are currently hardcoded with approximate values).

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

- **Changes Made**:
  - Added area-fill strategy composition and manual preview mode.
  - Refactored `fillCircle` by extracting helper functions to improve code readability.
  - No old components were removed.
  - No dependencies were updated.

- **Effects of Changes**:
  - **Before**: Threshold was not displayed for the entire slice.
  - **After**: Threshold is now displayed for the entire slice.

- **Screenshots**:
  - **Before**: N/A (Videos are attached below)
  - **After**: N/A (Videos are attached below)

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

- **Steps to Test**:
  - Run the command `npm run example -- labelmapSegmentationDynamicThreshold`.
  - Open a browser and navigate to `http://localhost:3000`.
  - Ensure the slice is displayed with the threshold correctly shown.

- **Test Cases**:
  - Threshold area with CenterJDK disabled by default
  
[![Threshold area with CenterJDK disabled by default. ](https://docs.ohif.org/img/ohif-logo.svg)](https://github.com/cornerstonejs/cornerstone3D/assets/143810329/fd5bcb1e-de61-4993-a117-65737da601f5)

 - Threshold circle with enabled and disabled CenterJDK 
 
 [![Threshold circle with enabled and disabled CenterJDK.](https://docs.ohif.org/img/ohif-logo.svg)](https://github.com/cornerstonejs/cornerstone3D/assets/143810329/c47c2ca4-4423-4cab-b24e-86b99df38511)

- Manual preview for threshold Circle with CenterJDK enabled by default and manual brush radius

 [![Manual preview for threshold Circle with CenterJDK enabled by default and manual brush radius.](https://docs.ohif.org/img/ohif-logo.svg)](https://github.com/cornerstonejs/cornerstone3D/assets/143810329/89a076b9-b2cc-440f-abba-23c75ae0fc93)

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(ThresholdPreview): add AreaFill, make CircleFill more flexible

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: macOS 14.5"
- [x] "Node version: v18.19.1"
- [x] "Browser: Chrome Version 125.0.6422.61 (Official Build) (arm64)"
