### PR TITLE
fix(measurements): include volumeid and other useful properties in annotation metadata

### DIFF
--- a/packages/tools/src/tools/annotation/AngleTool.ts
+++ b/packages/tools/src/tools/annotation/AngleTool.ts
@@ -128,6 +128,7 @@ class AngleTool extends AnnotationTool {
         viewUp: <Types.Point3>[...viewUp],
         FrameOfReferenceUID,
         referencedImageId,
+        ...viewport.getViewReference({ points: [worldPos] }),
       },
       data: {
         handles: {

--- a/packages/tools/src/tools/annotation/ArrowAnnotateTool.ts
+++ b/packages/tools/src/tools/annotation/ArrowAnnotateTool.ts
@@ -117,6 +117,7 @@ class ArrowAnnotateTool extends AnnotationTool {
         viewUp: <Types.Point3>[...viewUp],
         FrameOfReferenceUID,
         referencedImageId,
+        ...viewport.getViewReference({ points: [worldPos] }),
       },
       data: {
         text: '',

--- a/packages/tools/src/tools/annotation/BidirectionalTool.ts
+++ b/packages/tools/src/tools/annotation/BidirectionalTool.ts
@@ -158,6 +158,7 @@ class BidirectionalTool extends AnnotationTool {
         viewUp: <Types.Point3>[...viewUp],
         FrameOfReferenceUID,
         referencedImageId,
+        ...viewport.getViewReference({ points: [worldPos] }),
       },
       data: {
         handles: {

--- a/packages/tools/src/tools/annotation/CircleROITool.ts
+++ b/packages/tools/src/tools/annotation/CircleROITool.ts
@@ -188,6 +188,7 @@ class CircleROITool extends AnnotationTool {
         viewUp: <Types.Point3>[...viewUp],
         FrameOfReferenceUID,
         referencedImageId,
+        ...viewport.getViewReference({ points: [worldPos] }),
       },
       data: {
         label: '',

--- a/packages/tools/src/tools/annotation/CobbAngleTool.ts
+++ b/packages/tools/src/tools/annotation/CobbAngleTool.ts
@@ -134,6 +134,7 @@ class CobbAngleTool extends AnnotationTool {
         viewUp: <Types.Point3>[...viewUp],
         FrameOfReferenceUID,
         referencedImageId,
+        ...viewport.getViewReference({ points: [worldPos] }),
       },
       data: {
         handles: {

--- a/packages/tools/src/tools/annotation/EllipticalROITool.ts
+++ b/packages/tools/src/tools/annotation/EllipticalROITool.ts
@@ -193,6 +193,7 @@ class EllipticalROITool extends AnnotationTool {
         viewUp: <Types.Point3>[...viewUp],
         FrameOfReferenceUID,
         referencedImageId,
+        ...viewport.getViewReference({ points: [worldPos] }),
       },
       data: {
         label: '',

--- a/packages/tools/src/tools/annotation/RectangleROITool.ts
+++ b/packages/tools/src/tools/annotation/RectangleROITool.ts
@@ -171,6 +171,7 @@ class RectangleROITool extends AnnotationTool {
         viewUp: <Types.Point3>[...viewUp],
         FrameOfReferenceUID,
         referencedImageId,
+        ...viewport.getViewReference({ points: [worldPos] }),
       },
       data: {
         label: '',


### PR DESCRIPTION
### Context

Use viewport.getViewReference() to include useful properties like volumeid in metadata