### PR TITLE
fix(core): correctly set the orientation of the volume

### DIFF
--- a/packages/core/src/utilities/convertStackToVolumeViewport.ts
+++ b/packages/core/src/utilities/convertStackToVolumeViewport.ts
@@ -87,9 +87,11 @@ async function convertStackToVolumeViewport({
   );
 
   const volumeViewportNewVolumeHandler = () => {
-    volumeViewport.setCamera({
-      ...prevCamera,
-    });
+    if (!options.orientation) {
+      volumeViewport.setCamera({
+        ...prevCamera,
+      });
+    }
     volumeViewport.render();
 
     element.removeEventListener(


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
The `convertStackToVolumeViewport` method in core\utilities can accept `options: { orientation?: OrientationAxis }`, but the converted VolumeViewport does not correctly set the Orientation.
<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
* I reviewed the code for this method and seems that setCamera affects the setting of the orientation. Therefore, I added a condition to avoid reapplying the old camera when orientation is provided.
* Now convertStackToVolumeViewport can correctly set the orientation of the VolumeViewport.
<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
To verify the changes, we can use the examples provided in the Cornerstone3D tools: https://github.com/cornerstonejs/cornerstone3D/blob/main/packages/tools/examples/stackToVolumeWithAnnotations/index.ts
```
    if (viewport.type === ViewportType.STACK) {
      newViewport = await csUtilities.convertStackToVolumeViewport({
        viewport: viewport as Types.IStackViewport,
        options: {
          background: <Types.Point3>[0, 0.4, 0],
          volumeId: volumeId,
          // passing an orientation
          orientation: csEnums.OrientationAxis.SAGITTAL,
        },
      });
    }
```
![PR](https://github.com/cornerstonejs/cornerstone3D/assets/45812192/0c0f2552-40ed-4552-86ff-641aec5373e2)

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [X] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [X] My code has been well-documented (function documentation, inline comments,
  etc.)

- [X] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals. (No need to change)

#### Tested Environment

- [x] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->Windows 11 22631.3593
- [x] "Node version: <!--[e.g. 16.14.0]"-->v18.19.1
- [X] "Browser: Edge  125.0.2535.67, Chrome 125.0.6422.112
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
