### PR TITLE
fix(StackViewport): check if imagePlaneModule exists before destructuring

### DIFF
--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -1601,6 +1601,9 @@ class StackViewport extends Viewport implements IStackViewport, IImagesLoader {
       return;
     }
     const imagePlaneModule = metaData.get(MetadataModules.IMAGE_PLANE, imageId);
+    if (!imagePlaneModule) {
+      return;
+    }
     const { imagePositionPatient, frameOfReferenceUID: FrameOfReferenceUID } =
       imagePlaneModule;
     let { rowCosines, columnCosines } = imagePlaneModule;


### PR DESCRIPTION


<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

Fix needed for getFrameOfReferenceUID function in StackViewport.
The following error was introduced in v1.71.5 when the getFrameOfReferenceUID function was updated.
https://github.com/cornerstonejs/cornerstone3D/compare/v1.71.4...v1.71.5


```
Cannot destructure property 'imagePositionPatient' of 'imagePlaneModule' as it is undefined.
TypeError: Cannot destructure property 'imagePositionPatient' of 'imagePlaneModule' as it is undefined.
    at StackViewport.getImagePlaneReferenceData (https://localhost/dicom/static/js/bundle.js:82009:7)
    at StackViewport.getFrameOfReferenceUID (https://localhost/dicom/static/js/bundle.js:80937:54)
    at getEnabledElementByIds (https://localhost/dicom/static/js/bundle.js:91136:40)
    at HTMLDivElement._imageChangeEventListener (https://localhost/dicom/static/js/bundle.js:102808:82)
    at triggerEvent (https://localhost/dicom/static/js/bundle.js:97747:13)
    at https://localhost/dicom/static/js/bundle.js:80145:63
    at Array.forEach (<anonymous>)
    at RenderingEngine._renderFlaggedViewports (https://localhost/dicom/static/js/bundle.js:80141:24)
```

Fixes #1270 #1272 

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

added imagePlaneModule check in getImagePlaneReferenceData to return undefined if metadata imagePlaneModule doesn't exist

The result is no more exception when calling getFrameOfReferenceUID if image does not contain imagePlaneModule metadata.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: macOS 14.4.1 <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: v20.2.0 <!--[e.g. 16.14.0]"-->
- [] "Browser: Chrome  124.0.6367.202
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
