### PR TITLE
feat(synchronizer): frame view synchronizer

### DIFF
--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -1682,6 +1682,9 @@ function createBidirectionalToolData(bidirectionalData: BidirectionalData, viewp
 function createCameraPositionSynchronizer(synchronizerName: string): Synchronizer;
 
 // @public (undocumented)
+function createFrameViewSynchronizer(synchronizerName: string): Synchronizer;
+
+// @public (undocumented)
 function createImageIdReferenceMap(imageIdsArray: string[], segmentationImageIds: string[]): Map<string, string>;
 
 // @public (undocumented)
@@ -5490,7 +5493,8 @@ declare namespace synchronizers {
         createZoomPanSynchronizer,
         createImageSliceSynchronizer,
         createStackImageSynchronizer,
-        createPresentationViewSynchronizer_2 as createSlabThicknessSynchronizer
+        createPresentationViewSynchronizer_2 as createSlabThicknessSynchronizer,
+        createFrameViewSynchronizer
     }
 }
 export { synchronizers }

--- a/packages/core/src/RenderingEngine/Viewport.ts
+++ b/packages/core/src/RenderingEngine/Viewport.ts
@@ -1078,6 +1078,9 @@ class Viewport implements IViewport {
    * value is [0,0].
    */
   public getPan(initialCamera = this.initialCamera): Point2 {
+    if (!initialCamera) {
+      initialCamera = this.getCamera();
+    }
     const activeCamera = this.getVtkActiveCamera();
     const focalPoint = activeCamera.getFocalPoint() as Point3;
 

--- a/packages/tools/src/synchronizers/callbacks/frameViewSyncCallback.ts
+++ b/packages/tools/src/synchronizers/callbacks/frameViewSyncCallback.ts
@@ -37,6 +37,10 @@ export default async function frameViewSyncCallback(
     Number(targetViewportIndex) - Number(sourceViewportIndex);
   const targetSliceIndex = sourceSliceIndex + sliceDifference;
 
+  if (targetSliceIndex === tViewport.getSliceIndex()) {
+    return;
+  }
+
   jumpToSlice(tViewport.element, {
     imageIndex: targetSliceIndex,
   });

--- a/packages/tools/src/synchronizers/callbacks/frameViewSyncCallback.ts
+++ b/packages/tools/src/synchronizers/callbacks/frameViewSyncCallback.ts
@@ -1,0 +1,43 @@
+import { getRenderingEngine, Types } from '@cornerstonejs/core';
+
+import { Synchronizer } from '../../store';
+import { jumpToSlice } from '../../utilities';
+
+export default async function frameViewSyncCallback(
+  synchronizerInstance: Synchronizer,
+  sourceViewport: Types.IViewportId,
+  targetViewport: Types.IViewportId
+): Promise<void> {
+  const renderingEngine = getRenderingEngine(targetViewport.renderingEngineId);
+  if (!renderingEngine) {
+    throw new Error(
+      `No RenderingEngine for Id: ${targetViewport.renderingEngineId}`
+    );
+  }
+  const sViewport = renderingEngine.getViewport(
+    sourceViewport.viewportId
+  ) as Types.IStackViewport;
+
+  const { viewportIndex: targetViewportIndex } =
+    synchronizerInstance.getOptions(targetViewport.viewportId);
+
+  const { viewportIndex: sourceViewportIndex } =
+    synchronizerInstance.getOptions(sourceViewport.viewportId);
+
+  if (targetViewportIndex === undefined || sourceViewportIndex === undefined) {
+    throw new Error('No viewportIndex provided');
+  }
+
+  const tViewport = renderingEngine.getViewport(
+    targetViewport.viewportId
+  ) as Types.IStackViewport;
+
+  const sourceSliceIndex = sViewport.getSliceIndex();
+  const sliceDifference =
+    Number(targetViewportIndex) - Number(sourceViewportIndex);
+  const targetSliceIndex = sourceSliceIndex + sliceDifference;
+
+  jumpToSlice(tViewport.element, {
+    imageIndex: targetSliceIndex,
+  });
+}

--- a/packages/tools/src/synchronizers/index.ts
+++ b/packages/tools/src/synchronizers/index.ts
@@ -4,6 +4,7 @@ import createVOISynchronizer from './synchronizers/createVOISynchronizer';
 import createZoomPanSynchronizer from './synchronizers/createZoomPanSynchronizer';
 import createImageSliceSynchronizer from './synchronizers/createImageSliceSynchronizer';
 import createSlabThicknessSynchronizer from './synchronizers/createSlabThicknessSynchronizer';
+import createFrameViewSynchronizer from './synchronizers/createFrameViewSynchronizer';
 
 // for backward compatibility
 const createStackImageSynchronizer = createImageSliceSynchronizer;
@@ -16,4 +17,5 @@ export {
   createImageSliceSynchronizer,
   createStackImageSynchronizer,
   createSlabThicknessSynchronizer,
+  createFrameViewSynchronizer,
 };

--- a/packages/tools/src/synchronizers/synchronizers/createFrameViewSynchronizer.ts
+++ b/packages/tools/src/synchronizers/synchronizers/createFrameViewSynchronizer.ts
@@ -3,10 +3,10 @@ import { Enums } from '@cornerstonejs/core';
 import frameViewSyncCallback from '../callbacks/frameViewSyncCallback';
 import Synchronizer from '../../store/SynchronizerManager/Synchronizer';
 
-const { STACK_NEW_IMAGE } = Enums.Events;
+const { CAMERA_MODIFIED } = Enums.Events;
 
 /**
- * A helper that creates a new `Synchronizer` which listens to the `STACK_NEW_IMAGE`
+ * A helper that creates a new `Synchronizer` which listens to the `CAMERA_MODIFIED`
  * rendering event and calls the `FrameViewSyncCallback`.
  *
  * @param synchronizerName - The name of the synchronizer.
@@ -17,7 +17,7 @@ export default function createFrameViewSynchronizer(
 ): Synchronizer {
   const frameViewSynchronizer = createSynchronizer(
     synchronizerName,
-    STACK_NEW_IMAGE,
+    CAMERA_MODIFIED,
     frameViewSyncCallback
   );
 

--- a/packages/tools/src/synchronizers/synchronizers/createFrameViewSynchronizer.ts
+++ b/packages/tools/src/synchronizers/synchronizers/createFrameViewSynchronizer.ts
@@ -1,0 +1,25 @@
+import { createSynchronizer } from '../../store/SynchronizerManager';
+import { Enums } from '@cornerstonejs/core';
+import frameViewSyncCallback from '../callbacks/frameViewSyncCallback';
+import Synchronizer from '../../store/SynchronizerManager/Synchronizer';
+
+const { STACK_NEW_IMAGE } = Enums.Events;
+
+/**
+ * A helper that creates a new `Synchronizer` which listens to the `STACK_NEW_IMAGE`
+ * rendering event and calls the `FrameViewSyncCallback`.
+ *
+ * @param synchronizerName - The name of the synchronizer.
+ * @returns A new `Synchronizer` instance.
+ */
+export default function createFrameViewSynchronizer(
+  synchronizerName: string
+): Synchronizer {
+  const frameViewSynchronizer = createSynchronizer(
+    synchronizerName,
+    STACK_NEW_IMAGE,
+    frameViewSyncCallback
+  );
+
+  return frameViewSynchronizer;
+}

--- a/packages/tools/src/utilities/viewport/jumpToSlice.ts
+++ b/packages/tools/src/utilities/viewport/jumpToSlice.ts
@@ -32,6 +32,9 @@ async function jumpToSlice(
 
   const { viewport } = enabledElement;
 
+  if (!_getImageSliceData(viewport, debounceLoading)) {
+    return;
+  }
   const { imageIndex: currentImageIndex, numberOfSlices } = _getImageSliceData(
     viewport,
     debounceLoading


### PR DESCRIPTION
### Context

Source of idea: https://santesoft.com/win/sante-dicom-viewer-lite/sante-dicom-viewer-lite.html

<img width="1773" alt="image" src="https://github.com/cornerstonejs/cornerstone3D/assets/93064150/15f9481b-406c-4cd5-ae25-f2542a10959d">

<img width="1773" alt="image" src="https://github.com/cornerstonejs/cornerstone3D/assets/93064150/33f9cfb0-4039-4bc0-aa9d-53c9ce39a7e9">

<img width="1768" alt="image" src="https://github.com/OHIF/Viewers/assets/93064150/fce5286e-5b0a-4fcf-8222-4b1d875ce3bf">

<img width="1775" alt="image" src="https://github.com/cornerstonejs/cornerstone3D/assets/93064150/0875abdf-b1ff-4fdf-bb5d-160826b6b127">
