### PR TITLE
chore(deps): bump netlify-cli from 14.3.1 to 17.28.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "lint-staged": "^13.2.2",
     "lodash": "^4.17.21",
     "mocha": "^10.4.0",
-    "netlify-cli": "^14.3.1",
+    "netlify-cli": "^17.28.0",
     "open-cli": "^7.0.1",
     "path-browserify": "^1.0.1",
     "postcss": "^8.4.23",


### PR DESCRIPTION
netlify-cli v14.3.1

```yarn
λ yarn install
yarn install v1.22.22
$ node preinstall.js
preinstall.js
No GITHUB_TOKEN found, skipping private repo customization
[1/5] Validating package.json...
[2/5] Resolving packages...
[3/5] Fetching packages...
[4/5] Linking dependencies...
warning "netlify-cli > @netlify/build@29.46.2" has unmet peer dependency "@opentelemetry/api@~1.8.0".
warning "netlify-cli > @netlify/build > @netlify/opentelemetry-utils@1.2.1" has unmet peer dependency "@opentelemetry/api@~1.8.0".
warning "netlify-cli > @netlify/zip-it-and-ship-it > @netlify/serverless-functions-api > @opentelemetry/core@1.24.1" has unmet peer dependency "@opentelemetry/api@>=1.0.0 <1.9.0".
warning "netlify-cli > @netlify/zip-it-and-ship-it > @netlify/serverless-functions-api > @opentelemetry/otlp-transformer@0.50.0" has unmet peer dependency "@opentelemetry/api@>=1.3.0 <1.9.0".
warning "netlify-cli > @netlify/zip-it-and-ship-it > @netlify/serverless-functions-api > @opentelemetry/resources@1.24.1" has unmet peer dependency "@opentelemetry/api@>=1.0.0 <1.9.0".
warning "netlify-cli > @netlify/zip-it-and-ship-it > @netlify/serverless-functions-api > @opentelemetry/sdk-trace-base@1.24.1" has unmet peer dependency "@opentelemetry/api@>=1.0.0 <1.9.0".
warning "netlify-cli > @netlify/zip-it-and-ship-it > @netlify/serverless-functions-api > @opentelemetry/otlp-transformer > @opentelemetry/core@1.23.0" has unmet peer dependency "@opentelemetry/api@>=1.0.0 <1.9.0".
warning "netlify-cli > @netlify/zip-it-and-ship-it > @netlify/serverless-functions-api > @opentelemetry/otlp-transformer > @opentelemetry/resources@1.23.0" has unmet peer dependency "@opentelemetry/api@>=1.0.0 <1.9.0".
warning "netlify-cli > @netlify/zip-it-and-ship-it > @netlify/serverless-functions-api > @opentelemetry/otlp-transformer > @opentelemetry/sdk-logs@0.50.0" has unmet peer dependency "@opentelemetry/api@>=1.4.0 <1.9.0".
warning "netlify-cli > @netlify/zip-it-and-ship-it > @netlify/serverless-functions-api > @opentelemetry/otlp-transformer > @opentelemetry/sdk-metrics@1.23.0" has unmet peer dependency "@opentelemetry/api@>=1.3.0 <1.9.0".
warning "netlify-cli > @netlify/zip-it-and-ship-it > @netlify/serverless-functions-api > @opentelemetry/otlp-transformer > @opentelemetry/sdk-trace-base@1.23.0" has unmet peer dependency "@opentelemetry/api@>=1.0.0 <1.9.0".
warning " > @cornerstonejs/tools@1.78.2" has unmet peer dependency "@icr/polyseg-wasm@0.4.0".
warning " > @cornerstonejs/tools@1.78.2" has unmet peer dependency "@kitware/vtk.js@30.4.1".
warning " > @cornerstonejs/tools@1.78.2" has unmet peer dependency "@types/d3-array@^3.0.4".
warning " > @cornerstonejs/tools@1.78.2" has unmet peer dependency "@types/d3-interpolate@^3.0.1".
warning " > @cornerstonejs/tools@1.78.2" has unmet peer dependency "d3-array@^3.2.3".
warning " > @cornerstonejs/tools@1.78.2" has unmet peer dependency "d3-interpolate@^3.0.1".
warning " > @cornerstonejs/tools@1.78.2" has unmet peer dependency "gl-matrix@^3.4.3".
warning "workspace-aggregator-ef7aa583-dc3c-4e7d-8ae8-6001561653c7 > @cornerstonejs/core > @kitware/vtk.js@30.4.1" has unmet peer dependency "wslink@>=1.1.0 || ^2.0.0".
warning "workspace-aggregator-ef7aa583-dc3c-4e7d-8ae8-6001561653c7 > docs > @docusaurus/core > react-loadable-ssr-addon-v5-slorber@1.0.1" has unmet peer dependency "react-loadable@*".
warning "workspace-aggregator-ef7aa583-dc3c-4e7d-8ae8-6001561653c7 > docs > @docusaurus/preset-classic > @docusaurus/theme-search-algolia > @docsearch/react > @algolia/autocomplete-preset-algolia@1.9.3" has unmet peer dependency "@algolia/client-search@>= 4.9.1 < 6".
warning "workspace-aggregator-ef7aa583-dc3c-4e7d-8ae8-6001561653c7 > docs > @docusaurus/preset-classic > @docusaurus/theme-search-algolia > @docsearch/react > @algolia/autocomplete-core > @algolia/autocomplete-plugin-algolia-insights@1.9.3" has unmet peer dependency "search-insights@>= 1 < 3".
warning "workspace-aggregator-ef7aa583-dc3c-4e7d-8ae8-6001561653c7 > docs > @docusaurus/preset-classic > @docusaurus/theme-search-algolia > @docsearch/react > @algolia/autocomplete-core > @algolia/autocomplete-shared@1.9.3" has unmet peer dependency "@algolia/client-search@>= 4.9.1 < 6".
[5/5] Building fresh packages...
[13/14] ⠐ netlify-cli
[-/14] ⠐ waiting...
[-/14] ⠐ waiting...
[-/14] ⠈ waiting...
error C:\wamp64\www\projects\my-fork\fork-cornerstone3D\node_modules\netlify-cli: Command failed.
Exit code: 1
Command: node ./scripts/postinstall.mjs
Arguments:
Directory: C:\wamp64\www\projects\my-fork\fork-cornerstone3D\node_modules\netlify-cli
Output:
C:\wamp64\www\projects\my-fork\fork-cornerstone3D\node_modules\netlify-cli\node_modules\@octokit\endpoint\dist-node\index.js:22
    if (isPlainObject.isPlainObject(options[key])) {
                      ^

TypeError: isPlainObject.isPlainObject is not a function
    at C:\wamp64\www\projects\my-fork\fork-cornerstone3D\node_modules\netlify-cli\node_modules\@octokit\endpoint\dist-node\index.js:22:23
    at Array.forEach (<anonymous>)
    at mergeDeep (C:\wamp64\www\projects\my-fork\fork-cornerstone3D\node_modules\netlify-cli\node_modules\@octokit\endpoint\dist-node\index.js:21:24)
    at merge (C:\wamp64\www\projects\my-fork\fork-cornerstone3D\node_modules\netlify-cli\node_modules\@octokit\endpoint\dist-node\index.js:63:25)
    at withDefaults (C:\wamp64\www\projects\my-fork\fork-cornerstone3D\node_modules\netlify-cli\node_modules\@octokit\endpoint\dist-node\index.js:357:20)
    at Object.<anonymous> (C:\wamp64\www\projects\my-fork\fork-cornerstone3D\node_modules\netlify-cli\node_modules\@octokit\endpoint\dist-node\index.js:385:18)
    at Module._compile (node:internal/modules/cjs/loader:1358:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1416:10)
    at Module.load (node:internal/modules/cjs/loader:1208:32)
```

Update netlify-cli v17.28.0

```
λ yarn install
yarn install v1.22.22
$ node preinstall.js
preinstall.js
No GITHUB_TOKEN found, skipping private repo customization
[1/5] Validating package.json...
[2/5] Resolving packages...
[3/5] Fetching packages...
[4/5] Linking dependencies...
warning " > @cornerstonejs/tools@1.78.2" has unmet peer dependency "@icr/polyseg-wasm@0.4.0".
warning " > @cornerstonejs/tools@1.78.2" has unmet peer dependency "@kitware/vtk.js@30.4.1".
warning " > @cornerstonejs/tools@1.78.2" has unmet peer dependency "@types/d3-array@^3.0.4".
warning " > @cornerstonejs/tools@1.78.2" has unmet peer dependency "@types/d3-interpolate@^3.0.1".
warning " > @cornerstonejs/tools@1.78.2" has unmet peer dependency "d3-array@^3.2.3".
warning " > @cornerstonejs/tools@1.78.2" has unmet peer dependency "d3-interpolate@^3.0.1".
warning " > @cornerstonejs/tools@1.78.2" has unmet peer dependency "gl-matrix@^3.4.3".
warning "workspace-aggregator-7715c543-d35e-41c6-b75a-fef823f8c9fb > @cornerstonejs/core > @kitware/vtk.js@30.4.1" has unmet peer dependency "wslink@>=1.1.0 || ^2.0.0".
warning "workspace-aggregator-7715c543-d35e-41c6-b75a-fef823f8c9fb > docs > @docusaurus/core > react-loadable-ssr-addon-v5-slorber@1.0.1" has unmet peer dependency "react-loadable@*".
warning "workspace-aggregator-7715c543-d35e-41c6-b75a-fef823f8c9fb > docs > @docusaurus/preset-classic > @docusaurus/theme-search-algolia > @docsearch/react > @algolia/autocomplete-preset-algolia@1.9.3" has unmet peer dependency "@algolia/client-search@>= 4.9.1 < 6".
warning "workspace-aggregator-7715c543-d35e-41c6-b75a-fef823f8c9fb > docs > @docusaurus/preset-classic > @docusaurus/theme-search-algolia > @docsearch/react > @algolia/autocomplete-core > @algolia/autocomplete-plugin-algolia-insights@1.9.3" has unmet peer dependency "search-insights@>= 1 < 3".
warning "workspace-aggregator-7715c543-d35e-41c6-b75a-fef823f8c9fb > docs > @docusaurus/preset-classic > @docusaurus/theme-search-algolia > @docsearch/react > @algolia/autocomplete-core > @algolia/autocomplete-shared@1.9.3" has unmet peer dependency "@algolia/client-search@>= 4.9.1 < 6".
[5/5] Building fresh packages...
success Saved lockfile.
$ husky install
husky - Git hooks installed
Done in 110.69s.
```