### PR TITLE
feat(ultrasound): add ULTRASOUND_ENHANCED_REGION and CALIBRATION to wadouri metadata pr…

### DIFF
--- a/packages/dicomImageLoader/src/imageLoader/wadouri/metaData/USHelpers.ts
+++ b/packages/dicomImageLoader/src/imageLoader/wadouri/metaData/USHelpers.ts
@@ -1,0 +1,56 @@
+/**
+ * This function retrieves the ultrasound regions from the provided metadata.
+ * @param metadata - The metadata from which to retrieve the ultrasound regions.
+ * @returns An array of ultrasound regions, or null if no regions are found.
+ */
+
+function getUSEnhancedRegions(metadata) {
+  const sequence = metadata.elements['x00186011'];
+  if (!sequence || !sequence.items) {
+    return [];
+  }
+
+  const regions = sequence.items.map((item) => {
+    const physicalDeltaX = item.dataSet.double('x0018602c');
+    const physicalDeltaY = item.dataSet.double('x0018602e');
+    const physicalUnitsXDirection = item.dataSet.uint16('x00186024');
+    const physicalUnitsYDirection = item.dataSet.uint16('x00186026');
+
+    const regionLocationMinY0 = item.dataSet.uint16('x0018601a');
+    const regionLocationMaxY1 = item.dataSet.uint16('x0018601e');
+    const regionLocationMinX0 = item.dataSet.uint16('x00186018');
+    const regionLocationMaxX1 = item.dataSet.uint16('x0018601c');
+    const referencePixelX0 = item.dataSet.int32('x00186020') || null;
+    const referencePixelY0 = item.dataSet.int32('x00186022') || null;
+
+    const referencePhysicalPixelValueY = item.dataSet.uint16('x0018602a');
+    const referencePhysicalPixelValueX = item.dataSet.uint16('x00186028');
+    const regionSpatialFormat = item.dataSet.uint16('x00186012');
+
+    const regionDataType = item.dataSet.uint16('x00186014');
+    const regionFlags = item.dataSet.uint16('x00186016');
+    const transducerFrequency = item.dataSet.uint16('x00186030');
+    return {
+      regionLocationMinY0,
+      regionLocationMaxY1,
+      regionLocationMinX0,
+      regionLocationMaxX1,
+      referencePixelX0,
+      referencePixelY0,
+      physicalDeltaX,
+      physicalDeltaY,
+      physicalUnitsXDirection,
+      physicalUnitsYDirection,
+      referencePhysicalPixelValueY,
+      referencePhysicalPixelValueX,
+      regionSpatialFormat,
+      regionDataType,
+      regionFlags,
+      transducerFrequency,
+    };
+  });
+
+  return regions;
+}
+
+export { getUSEnhancedRegions };

--- a/packages/dicomImageLoader/src/imageLoader/wadouri/metaData/metaDataProvider.ts
+++ b/packages/dicomImageLoader/src/imageLoader/wadouri/metaData/metaDataProvider.ts
@@ -20,6 +20,7 @@ import {
   getInstanceModule,
   instanceModuleNames,
 } from '../../getInstanceModule';
+import { getUSEnhancedRegions } from './USHelpers';
 
 function metaDataProvider(type, imageId) {
   const { MetadataModules } = external.cornerstone.Enums;
@@ -282,6 +283,20 @@ function metaDataProvider(type, imageId) {
       ),
       actualFrameDuration: dataSet.intString(dataSet.string('x00181242')),
     };
+  }
+
+  if (type === MetadataModules.ULTRASOUND_ENHANCED_REGION) {
+    return getUSEnhancedRegions(dataSet);
+  }
+
+  if (type === MetadataModules.CALIBRATION) {
+    const modality = dataSet.string('x00080060');
+    if (modality === 'US') {
+      const enhancedRegion = getUSEnhancedRegions(dataSet);
+      return {
+        sequenceOfUltrasoundRegions: enhancedRegion,
+      };
+    }
   }
 
   // Note: this is not a DICOM module, but rather an aggregation on all others


### PR DESCRIPTION
…ovider

<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
Add ultrasound metadata providers to wadouri .

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
- Add new file USHelpers to wadouri 
- Add types ULTRASOUND_ENHANCED_REGION and CALIBRATION to wadouri metadata provider

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

Measurement of US cases with the Wadouri loader now sets the measurement units in mm instead of px.

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

Upload US dicoms with wadouri and use the length tool.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
