### PR TITLE
chore(example)：dynamicPetCt petCt volumeViewportSynchronization Voi synchronizer

### DIFF
--- a/packages/tools/examples/dynamicPetCt/index.ts
+++ b/packages/tools/examples/dynamicPetCt/index.ts
@@ -529,22 +529,22 @@ function setUpSynchronizers() {
 
 async function setUpDisplay() {
   const { metaDataManager } = cornerstoneDICOMImageLoader.wadors;
-  const wadoRsRoot = 'https://d33do7qe4w26qo.cloudfront.net/dicomweb';
+  const wadoRsRoot = 'https://d3t6nz73ql33tx.cloudfront.net/dicomweb';
   const StudyInstanceUID =
-    '1.3.6.1.4.1.12842.1.1.14.3.20220915.105557.468.2963630849';
+    '1.3.6.1.4.1.14519.5.2.1.7009.2403.334240657131972136850343327463';
 
   // Get Cornerstone imageIds and fetch metadata into RAM
   let ctImageIds = await createImageIdsAndCacheMetaData({
     StudyInstanceUID,
     SeriesInstanceUID:
-      '1.3.6.1.4.1.12842.1.1.14.4.20220915.121025.435.2500855592',
+      '1.3.6.1.4.1.14519.5.2.1.7009.2403.226151125820845824875394858561',
     wadoRsRoot,
   });
 
   const ptImageIds = await createImageIdsAndCacheMetaData({
     StudyInstanceUID,
     SeriesInstanceUID:
-      '1.3.6.1.4.1.12842.1.1.22.4.20220915.124758.560.4125514885',
+      '1.3.6.1.4.1.14519.5.2.1.7009.2403.879445243400782656317561081015',
     wadoRsRoot,
   });
 

--- a/packages/tools/examples/dynamicPetCt/index.ts
+++ b/packages/tools/examples/dynamicPetCt/index.ts
@@ -366,9 +366,7 @@ function setUpToolGroups() {
   // volume to use for the WindowLevelTool for the fusion viewports
   ctToolGroup.addTool(WindowLevelTool.toolName);
   ptToolGroup.addTool(WindowLevelTool.toolName);
-  fusionToolGroup.addTool(WindowLevelTool.toolName, {
-    volumeId: ptVolumeId,
-  });
+  fusionToolGroup.addTool(WindowLevelTool.toolName);
 
   [ctToolGroup, ptToolGroup, fusionToolGroup].forEach((toolGroup) => {
     toolGroup.setToolActive(WindowLevelTool.toolName, {
@@ -437,6 +435,7 @@ function setUpSynchronizers() {
   const coronalCameraSynchronizerId = 'CORONAL_CAMERA_SYNCHRONIZER_ID';
   const ctVoiSynchronizerId = 'CT_VOI_SYNCHRONIZER_ID';
   const ptVoiSynchronizerId = 'PT_VOI_SYNCHRONIZER_ID';
+  const fusionVoiSynchronizerId = 'FUSION_VOI_SYNCHRONIZER_ID';
 
   const axialCameraPositionSynchronizer = createCameraPositionSynchronizer(
     axialCameraSynchronizerId
@@ -452,6 +451,10 @@ function setUpSynchronizers() {
     syncColormap: false,
   });
   const ptVoiSynchronizer = createVOISynchronizer(ptVoiSynchronizerId, {
+    syncInvertState: false,
+    syncColormap: false,
+  });
+  const fusionVoiSynchronizer = createVOISynchronizer(fusionVoiSynchronizerId, {
     syncInvertState: false,
     syncColormap: false,
   });
@@ -500,27 +503,30 @@ function setUpSynchronizers() {
     });
   });
   [
-    viewportIds.FUSION.AXIAL,
-    viewportIds.FUSION.SAGITTAL,
-    viewportIds.FUSION.CORONAL,
+    viewportIds.PT.AXIAL,
+    viewportIds.PT.SAGITTAL,
+    viewportIds.PT.CORONAL,
+    viewportIds.PETMIP.CORONAL,
   ].forEach((viewportId) => {
-    // In this example, the fusion viewports are only targets for CT VOI
-    // synchronization, not sources
-    ctVoiSynchronizer.addTarget({
+    ptVoiSynchronizer.add({
       renderingEngineId,
       viewportId,
     });
   });
   [
-    viewportIds.PT.AXIAL,
-    viewportIds.PT.SAGITTAL,
-    viewportIds.PT.CORONAL,
     viewportIds.FUSION.AXIAL,
     viewportIds.FUSION.SAGITTAL,
     viewportIds.FUSION.CORONAL,
-    viewportIds.PETMIP.CORONAL,
   ].forEach((viewportId) => {
-    ptVoiSynchronizer.add({
+    fusionVoiSynchronizer.add({
+      renderingEngineId,
+      viewportId,
+    });
+    ctVoiSynchronizer.addTarget({
+      renderingEngineId,
+      viewportId,
+    });
+    ptVoiSynchronizer.addTarget({
       renderingEngineId,
       viewportId,
     });

--- a/packages/tools/examples/dynamicPetCt/index.ts
+++ b/packages/tools/examples/dynamicPetCt/index.ts
@@ -447,8 +447,14 @@ function setUpSynchronizers() {
   const coronalCameraPositionSynchronizer = createCameraPositionSynchronizer(
     coronalCameraSynchronizerId
   );
-  const ctVoiSynchronizer = createVOISynchronizer(ctVoiSynchronizerId);
-  const ptVoiSynchronizer = createVOISynchronizer(ptVoiSynchronizerId);
+  const ctVoiSynchronizer = createVOISynchronizer(ctVoiSynchronizerId, {
+    syncInvertState: false,
+    syncColormap: false,
+  });
+  const ptVoiSynchronizer = createVOISynchronizer(ptVoiSynchronizerId, {
+    syncInvertState: false,
+    syncColormap: false,
+  });
 
   // Add viewports to camera synchronizers
   [

--- a/packages/tools/examples/petCt/index.ts
+++ b/packages/tools/examples/petCt/index.ts
@@ -61,11 +61,13 @@ const sagittalCameraSynchronizerId = 'SAGITTAL_CAMERA_SYNCHRONIZER_ID';
 const coronalCameraSynchronizerId = 'CORONAL_CAMERA_SYNCHRONIZER_ID';
 const ctVoiSynchronizerId = 'CT_VOI_SYNCHRONIZER_ID';
 const ptVoiSynchronizerId = 'PT_VOI_SYNCHRONIZER_ID';
+const fusionVoiSynchronizerId = 'FUSION_VOI_SYNCHRONIZER_ID';
 let axialCameraPositionSynchronizer;
 let sagittalCameraPositionSynchronizer;
 let coronalCameraPositionSynchronizer;
 let ctVoiSynchronizer;
 let ptVoiSynchronizer;
+let fusionVoiSynchronizer;
 let mipToolGroup;
 const viewportIds = {
   CT: { AXIAL: 'CT_AXIAL', SAGITTAL: 'CT_SAGITTAL', CORONAL: 'CT_CORONAL' },
@@ -375,9 +377,7 @@ function setUpToolGroups() {
   // volume to use for the WindowLevelTool for the fusion viewports
   ctToolGroup.addTool(WindowLevelTool.toolName);
   ptToolGroup.addTool(WindowLevelTool.toolName);
-  fusionToolGroup.addTool(WindowLevelTool.toolName, {
-    volumeId: ptVolumeId,
-  });
+  fusionToolGroup.addTool(WindowLevelTool.toolName);
 
   [ctToolGroup, ptToolGroup, fusionToolGroup].forEach((toolGroup) => {
     toolGroup.setToolActive(WindowLevelTool.toolName, {
@@ -447,6 +447,10 @@ function setUpSynchronizers() {
     syncInvertState: false,
     syncColormap: false,
   });
+  fusionVoiSynchronizer = createVOISynchronizer(fusionVoiSynchronizerId, {
+    syncInvertState: false,
+    syncColormap: false,
+  });
   // Add viewports to camera synchronizers
   [
     viewportIds.CT.AXIAL,
@@ -491,27 +495,30 @@ function setUpSynchronizers() {
     });
   });
   [
-    viewportIds.FUSION.AXIAL,
-    viewportIds.FUSION.SAGITTAL,
-    viewportIds.FUSION.CORONAL,
+    viewportIds.PT.AXIAL,
+    viewportIds.PT.SAGITTAL,
+    viewportIds.PT.CORONAL,
+    viewportIds.PETMIP.CORONAL,
   ].forEach((viewportId) => {
-    // In this example, the fusion viewports are only targets for CT VOI
-    // synchronization, not sources
-    ctVoiSynchronizer.addTarget({
+    ptVoiSynchronizer.add({
       renderingEngineId,
       viewportId,
     });
   });
   [
-    viewportIds.PT.AXIAL,
-    viewportIds.PT.SAGITTAL,
-    viewportIds.PT.CORONAL,
     viewportIds.FUSION.AXIAL,
     viewportIds.FUSION.SAGITTAL,
     viewportIds.FUSION.CORONAL,
-    viewportIds.PETMIP.CORONAL,
   ].forEach((viewportId) => {
-    ptVoiSynchronizer.add({
+    fusionVoiSynchronizer.add({
+      renderingEngineId,
+      viewportId,
+    });
+    ctVoiSynchronizer.addTarget({
+      renderingEngineId,
+      viewportId,
+    });
+    ptVoiSynchronizer.addTarget({
       renderingEngineId,
       viewportId,
     });

--- a/packages/tools/examples/petCt/index.ts
+++ b/packages/tools/examples/petCt/index.ts
@@ -439,8 +439,14 @@ function setUpSynchronizers() {
   coronalCameraPositionSynchronizer = createCameraPositionSynchronizer(
     coronalCameraSynchronizerId
   );
-  ctVoiSynchronizer = createVOISynchronizer(ctVoiSynchronizerId);
-  ptVoiSynchronizer = createVOISynchronizer(ptVoiSynchronizerId);
+  ctVoiSynchronizer = createVOISynchronizer(ctVoiSynchronizerId, {
+    syncInvertState: false,
+    syncColormap: false,
+  });
+  ptVoiSynchronizer = createVOISynchronizer(ptVoiSynchronizerId, {
+    syncInvertState: false,
+    syncColormap: false,
+  });
   // Add viewports to camera synchronizers
   [
     viewportIds.CT.AXIAL,

--- a/packages/tools/examples/volumeViewportSynchronization/index.ts
+++ b/packages/tools/examples/volumeViewportSynchronization/index.ts
@@ -198,7 +198,10 @@ async function run() {
 
   // Create synchronizers
   createCameraPositionSynchronizer(cameraSynchronizerId);
-  createVOISynchronizer(voiSynchronizerId);
+  createVOISynchronizer(voiSynchronizerId, {
+    syncInvertState: false,
+    syncColormap: false,
+  });
 
   // Get Cornerstone imageIds and fetch metadata into RAM
   const imageIds = await createImageIdsAndCacheMetaData({


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

https://www.cornerstonejs.org/live-examples/petct
https://www.cornerstonejs.org/live-examples/dynamicpetct
https://www.cornerstonejs.org/live-examples/volumeViewportSynchronization
I found that the synchronizer effect of dynamicPetCt 、petCt、 volumeViewportSynchronization examples is wrong, corrected it, and StudyInstanceUID is invalid
### Changes & Results



<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

fix: examples: dynamicPetCt and petCt for Voi synchronizer

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
