### PR TITLE
fix: Navigation issues and naming issues for video/wsi

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -2522,7 +2522,7 @@ enum MetadataModules {
     // (undocumented)
     VOI_LUT = "voiLutModule",
     // (undocumented)
-    WEB_CLIENT = "webClient"
+    WADO_WEB_CLIENT = "wadoWebClient"
 }
 
 // @public (undocumented)
@@ -2533,7 +2533,14 @@ const metadataProvider: {
 
 // @public (undocumented)
 const metadataProvider_2: {
-    add: (imageId: string, payload: any) => void;
+    add: (imageId: string, payload: {
+        metadata: any;
+        type: string;
+    }) => void;
+    addRaw: (imageId: string, payload: {
+        metadata: any;
+        type: string;
+    }) => void;
     get: (type: string, imageId: string) => any;
     clear: () => void;
 };

--- a/package.json
+++ b/package.json
@@ -175,5 +175,6 @@
     "not dead",
     "not ie < 11",
     "not op_mini all"
-  ]
+  ],
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/packages/core/src/RenderingEngine/VideoViewport.ts
+++ b/packages/core/src/RenderingEngine/VideoViewport.ts
@@ -224,7 +224,7 @@ class VideoViewport extends Viewport implements IVideoViewport {
   public setDataIds(imageIds: string[], options?: ImageSetOptions) {
     this.setVideo(
       imageIds[0],
-      (options?.viewReference?.sliceIndex as number) || 1
+      ((options?.viewReference?.sliceIndex as number) || 0) + 1
     );
   }
 

--- a/packages/core/src/RenderingEngine/WSIViewport.ts
+++ b/packages/core/src/RenderingEngine/WSIViewport.ts
@@ -442,7 +442,10 @@ class WSIViewport extends Viewport implements IWSIViewport {
    * This is a wrapper for setWSI to allow generic behaviour
    */
   public setDataIds(imageIds: string[]) {
-    const webClient = metaData.get(MetadataModules.WEB_CLIENT, imageIds[0]);
+    const webClient = metaData.get(
+      MetadataModules.WADO_WEB_CLIENT,
+      imageIds[0]
+    );
     if (!webClient) {
       throw new Error(
         `To use setDataIds on WSI data, you must provide metaData.webClient for ${imageIds[0]}`
@@ -454,7 +457,7 @@ class WSIViewport extends Viewport implements IWSIViewport {
   }
 
   public async setWSI(imageIds: string[], client) {
-    this.microscopyElement.style.background = 'red';
+    this.microscopyElement.style.background = 'black';
     this.microscopyElement.innerText = 'Loading';
     this.imageIds = imageIds;
     const DicomMicroscopyViewer = await WSIViewport.getDicomMicroscopyViewer();

--- a/packages/core/src/enums/MetadataModules.ts
+++ b/packages/core/src/enums/MetadataModules.ts
@@ -28,10 +28,14 @@ enum MetadataModules {
   ULTRASOUND_ENHANCED_REGION = 'ultrasoundEnhancedRegionModule',
   VOI_LUT = 'voiLutModule',
   /**
-   * Some modules need direct access to a web client.  This allows getting
-   * it as metadata in order to get it generically.
+   * Some modules need direct access to a data services (WADO) web client.
+   * This allows getting images and metadata as raw results for display.
+   * This is DICOMweb WADO, not base WADO, and should support:
+   *    * Series level metadata retrieve
+   *    * Bulkdata retrieve
+   *    * Image retrieve
    */
-  WEB_CLIENT = 'webClient',
+  WADO_WEB_CLIENT = 'wadoWebClient',
 }
 
 export default MetadataModules;

--- a/packages/core/src/utilities/genericMetadataProvider.ts
+++ b/packages/core/src/utilities/genericMetadataProvider.ts
@@ -6,20 +6,33 @@ let state: Record<string, any> = {}; // Calibrated pixel spacing per imageId
  */
 const metadataProvider = {
   /**
-   * Adds metadata for an imageId.
+   * Adds a cloned copy of the metadata for an imageId as the given type.
+   * Note that this will strip out any functions or other non-cloneables.
+   *
    * @param imageId - the imageId for the metadata to store
    * @param payload - the payload
    */
-  add: (imageId: string, payload: any): void => {
+  add: (imageId: string, payload: { metadata: any; type: string }): void => {
+    metadataProvider.addRaw(imageId, {
+      ...payload,
+      metadata: structuredClone(payload.metadata),
+    });
+  },
+
+  /**
+   * Adds a raw metadata instances for an imageId.  This allows preserving
+   * class inheritance values and member functions/proxy instances, but runs
+   * the risk that the raw object can be modified through side affects.
+   */
+  addRaw: (imageId: string, payload: { metadata: any; type: string }) => {
     const type = payload.type;
 
     if (!state[imageId]) {
       state[imageId] = {};
     }
 
-    // Use the raw metadata, or create a deep copy of payload.metadata
-    state[imageId][type] =
-      payload.rawMetadata ?? structuredClone(payload.metadata);
+    // Use the raw metadata here
+    state[imageId][type] = payload.metadata;
   },
 
   /**

--- a/packages/tools/src/tools/ZoomTool.ts
+++ b/packages/tools/src/tools/ZoomTool.ts
@@ -23,8 +23,11 @@ class ZoomTool extends BaseTool {
       configuration: {
         // whether zoom to the center of the image OR zoom to the mouse position
         zoomToCenter: false,
-        minZoomScale: 0.1,
-        maxZoomScale: 30,
+        // Use large ranges to allow for microscopy viewing.
+        // TODO: Change the definitions of these to be relative to 1:1 pixel and
+        // relative to scale to fit sizing
+        minZoomScale: 0.001,
+        maxZoomScale: 3000,
         pinchToZoom: true,
         pan: true,
         invert: false,

--- a/utils/demo/helpers/addManipulationBindings.ts
+++ b/utils/demo/helpers/addManipulationBindings.ts
@@ -86,8 +86,8 @@ export default function addManipulationBindings(
   toolGroup.addTool(PanTool.toolName);
   // Allow significant zooming to occur
   toolGroup.addTool(ZoomTool.toolName, {
-    minZoomScale: 0.01,
-    maxZoomScale: 400,
+    minZoomScale: 0.001,
+    maxZoomScale: 4000,
   });
   if (is3DViewport) {
     toolGroup.addTool(TrackballRotateTool.toolName);


### PR DESCRIPTION
### Context

There was a request to change the generic metadata provider as to how to stores metadata for object based metadata.  Also, changed some navigation setup so that WSI and Video viewports navigate correctly.

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
