### PR TITLE
fix: Fix HTJ2K decoder leak

### DIFF
--- a/packages/dicomImageLoader/src/shared/decoders/decodeHTJ2K.ts
+++ b/packages/dicomImageLoader/src/shared/decoders/decodeHTJ2K.ts
@@ -57,8 +57,7 @@ export function initialize(decodeConfig?: LoaderDecodeOptions): Promise<void> {
 // https://github.com/chafey/openjpegjs/blob/master/test/browser/index.html
 async function decodeAsync(compressedImageFrame: ByteArray, imageInfo) {
   await initialize();
-  // const decoder = local.decoder; // This is much slower for some reason
-  const decoder = new local.codec.HTJ2KDecoder();
+  const decoder = local.decoder;
 
   // get pointer to the source/encoded bit stream buffer in WASM memory
   // that can hold the encoded bitstream


### PR DESCRIPTION


<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

Commit 85fd19396762f54c6806fdbebf0235139a67629a changed decodeHTJ2K.js to allocate a new HTJ2KDecoder with each call to decodeAsync. The old decoders somehow stay alive, and are not cleaned from the WASM memory. Each new HTJ2KDecoder allocates in turns buffers for the encoded and decoded pixel data while decoding.

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

The change to allocate a new decoder per frame argued that reusing the old decoder is "much slower", but I could not reproduce any slowdowns either in the browser or on Node. This commit therefore reverts the change, so that each call to decodeAsync reuses the same decoder instance.

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Linux <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [x] "Node version: 20.11 <!--[e.g. 16.14.0]"-->
- [x] "Browser: Chrome 126, Firefox 128
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
