### PR TITLE
fix: Palette color display

### DIFF
--- a/packages/dicomImageLoader/src/imageLoader/createImage.ts
+++ b/packages/dicomImageLoader/src/imageLoader/createImage.ts
@@ -253,12 +253,12 @@ function createImage(
             imageFrame.rows
           );
           if (!useRGBA) {
+            // Use a hard coded 3 samples per pixel for the destination, as the
+            // original samples per pixel may not be 3 for palette color
             imageData = {
               ...imageData,
               data: new Uint8ClampedArray(
-                imageFrame.samplesPerPixel *
-                  imageFrame.columns *
-                  imageFrame.rows
+                3 * imageFrame.columns * imageFrame.rows
               ),
             };
           }


### PR DESCRIPTION
### Context
Palette color displays resulted in a buffer size mismatch, resulting in not being able to display palette color images.

### Changes & Results
In load image, use a fixed 3 for the number of samples for the output of the color conversion instead of the (wrong) 1 samples per pixel that palette color uses.

### Testing

Display a palette color image in OHIF.  

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
