### PR TITLE
fix(splineSegROI): fix for CCW splines

### DIFF
--- a/packages/tools/examples/splineContourSegmentationTools/index.ts
+++ b/packages/tools/examples/splineContourSegmentationTools/index.ts
@@ -86,7 +86,19 @@ createInfoSection(content, { ordered: true })
     'Notice that each segment index has a different color assigned to it'
   )
   .addInstruction('Change the style for the segmentation')
-  .addInstruction('Confirm the style is applied properly');
+  .addInstruction('Confirm the style is applied properly')
+  .addInstruction('You can draw overlapping splines to:')
+  .openNestedSection()
+  .addInstruction(
+    'Merge both splines when the first point of the second spline is inside the first spline'
+  )
+  .addInstruction(
+    'Subctract the second spline from the first spline when the first point of the second spline is outside the first spline'
+  )
+  .closeNestedSection()
+  .addInstruction(
+    'The resulting contour is converted to freehand ROI when splines are merged/subtracted'
+  );
 
 function updateInputsForCurrentSegmentation() {
   // We can use any toolGroupId because they are all configured in the same way

--- a/packages/tools/src/tools/annotation/SplineROITool.ts
+++ b/packages/tools/src/tools/annotation/SplineROITool.ts
@@ -720,7 +720,8 @@ class SplineROITool extends ContourSegmentationBaseTool {
           closed: data.contour.closed,
           targetWindingDirection: ContourWindingDirection.Clockwise,
         },
-        viewport
+        viewport,
+        { updateWindingDirection: data.contour.closed }
       );
     });
 

--- a/packages/tools/src/tools/base/ContourBaseTool.ts
+++ b/packages/tools/src/tools/base/ContourBaseTool.ts
@@ -220,6 +220,9 @@ abstract class ContourBaseTool extends AnnotationTool {
     transforms: {
       canvasToWorld: (point: Types.Point2) => Types.Point3;
       worldToCanvas: (point: Types.Point3) => Types.Point2;
+    },
+    options?: {
+      updateWindingDirection?: boolean;
     }
   ) {
     const decimateConfig = this.configuration?.decimate || {};
@@ -229,6 +232,7 @@ abstract class ContourBaseTool extends AnnotationTool {
         enabled: !!decimateConfig.enabled,
         epsilon: decimateConfig.epsilon,
       },
+      updateWindingDirection: options?.updateWindingDirection,
     });
   }
 

--- a/packages/tools/src/utilities/contours/updateContourPolyline.ts
+++ b/packages/tools/src/utilities/contours/updateContourPolyline.ts
@@ -33,6 +33,7 @@ export default function updateContourPolyline(
     worldToCanvas: (point: Types.Point3) => Types.Point2;
   },
   options?: {
+    updateWindingDirection?: boolean;
     decimate?: {
       enabled?: boolean;
       epsilon?: number;
@@ -55,8 +56,7 @@ export default function updateContourPolyline(
   let { closed } = polylineData;
   const numPoints = polyline.length;
   const polylineWorldPoints = new Array(numPoints);
-  const currentPolylineWindingDirection =
-    math.polyline.getWindingDirection(polyline);
+  let windingDirection = math.polyline.getWindingDirection(polyline);
   const parentAnnotation = getParentAnnotation(annotation) as ContourAnnotation;
 
   if (closed === undefined) {
@@ -75,28 +75,32 @@ export default function updateContourPolyline(
     closed = currentClosedState;
   }
 
-  // It must be in the opposite direction if it is a child annotation (hole)
-  let windingDirection = parentAnnotation
-    ? parentAnnotation.data.contour.windingDirection * -1
-    : targetWindingDirection;
+  if (options?.updateWindingDirection !== false) {
+    // It must be in the opposite direction if it is a child annotation (hole)
+    let updatedWindingDirection = parentAnnotation
+      ? parentAnnotation.data.contour.windingDirection * -1
+      : targetWindingDirection;
 
-  if (windingDirection === undefined) {
-    windingDirection = currentPolylineWindingDirection;
-  }
-
-  if (windingDirection !== currentPolylineWindingDirection) {
-    polyline.reverse();
-  }
-
-  const handlePoints = data.handles.points.map((p) => worldToCanvas(p));
-
-  if (handlePoints.length > 2) {
-    const currentHandlesWindingDirection =
-      math.polyline.getWindingDirection(handlePoints);
-
-    if (currentHandlesWindingDirection !== windingDirection) {
-      data.handles.points.reverse();
+    if (updatedWindingDirection === undefined) {
+      updatedWindingDirection = windingDirection;
     }
+
+    if (updatedWindingDirection !== windingDirection) {
+      polyline.reverse();
+    }
+
+    const handlePoints = data.handles.points.map((p) => worldToCanvas(p));
+
+    if (handlePoints.length > 2) {
+      const currentHandlesWindingDirection =
+        math.polyline.getWindingDirection(handlePoints);
+
+      if (currentHandlesWindingDirection !== updatedWindingDirection) {
+        data.handles.points.reverse();
+      }
+    }
+
+    windingDirection = updatedWindingDirection;
   }
 
   for (let i = 0; i < numPoints; i++) {


### PR DESCRIPTION
### Context

Drawing a CCW spline Segmentation ROI contour results in a weird behavior because the points are always sorted in CW direction.

### Changes & Results

Changed the spline Segmentation ROI to do not update the winding direction until the spline ROI is closed.

### Testing

Run `splineContourSegmentationTools` example and draw CW and CCW splines w/ or w/o a hole.