### PR TITLE
fix: VolumeViewport3D reset Properties

### DIFF
--- a/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
@@ -919,6 +919,10 @@ abstract class BaseVolumeViewport extends Viewport implements IVolumeViewport {
       this.setRotation(properties.rotation);
     }
 
+    if (properties.preset !== undefined) {
+      this.setPreset(properties.preset, volumeId, false);
+    }
+
     this.render();
   }
 

--- a/packages/core/src/RenderingEngine/VolumeViewport3D.ts
+++ b/packages/core/src/RenderingEngine/VolumeViewport3D.ts
@@ -1,5 +1,12 @@
-import { BlendModes, OrientationAxis } from '../enums';
+import { BlendModes, OrientationAxis, Events } from '../enums';
+import { RENDERING_DEFAULTS } from '../constants';
+import cache from '../cache';
+import setDefaultVolumeVOI from './helpers/setDefaultVolumeVOI';
+import { triggerEvent, isImageActor } from '../utilities';
+import { setTransferFunctionNodes } from '../utilities/transferFunctionUtils';
+import type vtkVolume from '@kitware/vtk.js/Rendering/Core/Volume';
 import type { ViewportInput } from '../types/IViewport';
+import type { ImageActor } from '../types/IActor';
 import BaseVolumeViewport from './BaseVolumeViewport';
 
 /**
@@ -61,8 +68,54 @@ class VolumeViewport3D extends BaseVolumeViewport {
     return null;
   }
 
+  /**
+   * Resets the properties of the volume to their default values.
+   *
+   * @param [volumeId] - The id of the volume to reset. If not provided, the default volume will be reset.
+   */
   resetProperties(volumeId?: string): void {
-    return null;
+    const volumeActor = volumeId
+      ? this.getActor(volumeId)
+      : this.getDefaultActor();
+
+    if (!volumeActor) {
+      throw new Error(`No actor found for the given volumeId: ${volumeId}`);
+    }
+
+    // if a custom slabThickness was set, we need to reset it
+    if (volumeActor.slabThickness) {
+      volumeActor.slabThickness = RENDERING_DEFAULTS.MINIMUM_SLAB_THICKNESS;
+      this.viewportProperties.slabThickness = undefined;
+      this.updateClippingPlanesForActors(this.getCamera());
+    }
+
+    const imageVolume = cache.getVolume(volumeActor.uid);
+
+    if (!imageVolume) {
+      throw new Error(
+        `imageVolume with id: ${volumeActor.uid} does not exist in cache`
+      );
+    }
+
+    setDefaultVolumeVOI(volumeActor.actor as vtkVolume, imageVolume, false);
+
+    if (isImageActor(volumeActor)) {
+      const transferFunction = (volumeActor.actor as ImageActor)
+        .getProperty()
+        .getRGBTransferFunction(0);
+
+      setTransferFunctionNodes(
+        transferFunction,
+        this.initialTransferFunctionNodes
+      );
+    }
+
+    this.setCamera(this.initialCamera);
+    triggerEvent(
+      this.element,
+      Events.VOI_MODIFIED,
+      super.getVOIModifiedEventDetail(volumeId)
+    );
   }
 
   resetSlabThickness(): void {


### PR DESCRIPTION
### Context

VolumeViewport3D had not implemented the `resetProperties` function making it unable to be reset when needed. Not only that but the BaseVolumeViewport did not reset the `preset` property when you executed `resetToDefaultProperties` function, neglecting a portion of the main features of its class.

### Changes & Results
Implemented `resetProperties` on VolumeViewport3D (very similar to VolumeViewport implementation maybe we could move this up in the hierarchy) and updated the `resetToDefaultProperties` function to consider the `preset` property.

### Testing
Run `https://www.[cornerstonejs.org/live-examples/volumeviewport3d](https://www.cornerstonejs.org/live-examples/volumeviewport3d)` and then call `viewport.resetProperties()` and `viewport.resetToDefaultProperties()` to see the rotation and the preset being reset