### PR TITLE
fix: Smooth annotations for off viewport destroyed coords

### DIFF
--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -5251,7 +5251,7 @@ function setToolGroupSpecificConfig_2(toolGroupId: string, segmentationRepresent
 function showAllAnnotations(): void;
 
 // @public (undocumented)
-function smoothAnnotation(enabledElement: Types_2.IEnabledElement, annotation: PlanarFreehandROIAnnotation, knotsRatioPercentage: number): boolean;
+function smoothAnnotation(annotation: PlanarFreehandROIAnnotation, options?: SmoothOptions): boolean;
 
 // @public (undocumented)
 export class SphereScissorsTool extends BaseTool {

--- a/packages/tools/examples/planarFreehandROITool/index.ts
+++ b/packages/tools/examples/planarFreehandROITool/index.ts
@@ -4,6 +4,7 @@ import {
   Enums,
   volumeLoader,
   getRenderingEngine,
+  getEnabledElement,
 } from '@cornerstonejs/core';
 import {
   initDemo,
@@ -40,6 +41,7 @@ const volumeName = 'CT_VOLUME_ID'; // Id of the volume less loader prefix
 const volumeLoaderScheme = 'cornerstoneStreamingImageVolume'; // Loader id which defines which volume loader to use
 const volumeId = `${volumeLoaderScheme}:${volumeName}`; // VolumeId with loader id + volume id
 const renderingEngineId = 'myRenderingEngine';
+
 const viewportIds = ['CT_STACK', 'CT_VOLUME_SAGITTAL'];
 
 // ======== Set up page ======== //
@@ -153,6 +155,25 @@ function addToggleInterpolationButton(toolGroup) {
   });
 }
 
+function addSmoothButton(toolGroup) {
+  addButtonToToolbar({
+    title: 'Smooth',
+    onClick: () => {
+      const annotations = cornerstoneTools.annotation.state.getAllAnnotations();
+      const renderingEngine = getRenderingEngine(renderingEngineId);
+      annotations.forEach((annotation) => {
+        cornerstoneTools.utilities.planarFreehandROITool.smoothAnnotation(
+          <
+            cornerstoneTools.Types.ToolSpecificAnnotationTypes.PlanarFreehandROIAnnotation
+          >annotation,
+          { loop: 5 }
+        );
+      });
+      renderingEngine.renderViewports(viewportIds);
+    },
+  });
+}
+
 let shouldCalculateStats = false;
 function addToggleCalculateStatsButton(toolGroup) {
   addButtonToToolbar({
@@ -221,6 +242,7 @@ async function run() {
 
   // set up toggle interpolation tool button.
   addToggleInterpolationButton(toolGroup);
+  addSmoothButton(toolGroup);
 
   // set up toggle calculate stats tool button.
   addToggleCalculateStatsButton(toolGroup);
@@ -245,9 +267,6 @@ async function run() {
     wadoRsRoot: 'https://d3t6nz73ql33tx.cloudfront.net/dicomweb',
   });
 
-  // Instantiate a rendering engine
-  const renderingEngine = new RenderingEngine(renderingEngineId);
-
   // Create a stack and a volume viewport
   const viewportInputArray = [
     {
@@ -268,6 +287,9 @@ async function run() {
       },
     },
   ];
+
+  // Instantiate a rendering engine
+  const renderingEngine = new RenderingEngine(renderingEngineId);
 
   renderingEngine.setViewports(viewportInputArray);
 

--- a/packages/tools/src/utilities/planarFreehandROITool/smoothAnnotation.ts
+++ b/packages/tools/src/utilities/planarFreehandROITool/smoothAnnotation.ts
@@ -1,88 +1,100 @@
 import { Types } from '@cornerstonejs/core';
+import { mat4, vec3 } from 'gl-matrix';
 import { PlanarFreehandROITool } from '../../tools';
 import { ToolGroupManager } from '../../store';
 import { PlanarFreehandROIAnnotation } from '../../types/ToolSpecificAnnotationTypes';
 import interpolateSegmentPoints from './interpolation/interpolateSegmentPoints';
 
+export type SmoothOptions = {
+  knotsRatioPercentage: number;
+  loop: number;
+};
+
 function shouldPreventInterpolation(
-  enabledElement: Types.IEnabledElement,
   annotation: PlanarFreehandROIAnnotation,
-  knotsRatioPercentage: number
+  options?: SmoothOptions
 ): boolean {
-  if (!annotation?.data?.polyline || knotsRatioPercentage <= 0) {
+  const knotsRatioPercentage = options?.knotsRatioPercentage || 30;
+  if (
+    !annotation?.data?.contour?.polyline?.length ||
+    knotsRatioPercentage <= 0
+  ) {
     return true;
   }
 
-  if (!enabledElement.viewport) {
-    return true;
-  }
-
-  const { renderingEngineId, viewportId, FrameOfReferenceUID } = enabledElement;
-  const toolGroup = ToolGroupManager.getToolGroupForViewport(
-    viewportId,
-    renderingEngineId
-  );
-
-  if (annotation.metadata.FrameOfReferenceUID !== FrameOfReferenceUID) {
-    return true;
-  }
-
-  if (!toolGroup) {
-    return true;
-  }
-
-  const toolInstance = toolGroup.getToolInstance(annotation.metadata.toolName);
-
-  // strategy to prevent non PlanarFreehandTool
-  if (!(toolInstance instanceof PlanarFreehandROITool)) {
-    return true;
-  }
-
-  return (
-    toolInstance.isDrawing ||
-    toolInstance.isEditingOpen ||
-    toolInstance.isEditingClosed
-  );
+  return false;
 }
+
+function rotateMatrix(normal, focal) {
+  const mat = mat4.create();
+  const eye = vec3.add(vec3.create(), focal, normal);
+  const up =
+    Math.abs(normal[0]) > 0.1
+      ? vec3.fromValues(-normal[1], normal[0], 0)
+      : vec3.fromValues(0, -normal[2], normal[1]);
+  // Use the focal point as the "eye" position so that the focal point get rotated to 0 for the k coordinate.
+  mat4.lookAt(mat, focal, eye, up);
+  return mat;
+}
+
 /**
  * Interpolates a given annotation from a given enabledElement.
  * It mutates annotation param.
- * The param knotsRatioPercentage defines the percentage of points to be considered as knots on the interpolation process.
+ * The param options.knotsRatioPercentage defines the percentage of points to be considered as knots on the interpolation process.
  * Interpolation will be skipped in case: annotation is not present in enabledElement (or there is no toolGroup associated with it), related tool is being modified.
+ * The param options.loop can be set to run smoothing repeatedly.  This results in
+ * additional smoothing.
  */
 export default function smoothAnnotation(
-  enabledElement: Types.IEnabledElement,
   annotation: PlanarFreehandROIAnnotation,
-  knotsRatioPercentage: number
+  options?: SmoothOptions
 ): boolean {
   // prevent running while there is any tool annotation being modified
-  if (
-    shouldPreventInterpolation(enabledElement, annotation, knotsRatioPercentage)
-  ) {
+  if (shouldPreventInterpolation(annotation, options)) {
     return false;
   }
 
-  const { viewport } = enabledElement;
+  const { viewPlaneNormal } = annotation.metadata;
   // use only 2 dimensions on interpolation (what visually matters),
   // otherwise a 3d interpolation might have a totally different output as it consider one more dimension.
-  const canvasPoints = annotation.data.contour.polyline.map(
-    viewport.worldToCanvas
+  const rotateMat = rotateMatrix(
+    viewPlaneNormal,
+    annotation.data.contour.polyline[0]
   );
-  const interpolatedCanvasPoints = <Types.Point2[]>(
+  const canvasPoints = <Types.Point2[]>annotation.data.contour.polyline.map(
+    (p) => {
+      const planeP = vec3.transformMat4(vec3.create(), p, rotateMat);
+      return [planeP[0], planeP[1]];
+    }
+  );
+  let interpolatedCanvasPoints = <Types.Point2[]>(
     interpolateSegmentPoints(
       canvasPoints,
       0,
       canvasPoints.length,
-      knotsRatioPercentage
+      options?.knotsRatioPercentage || 30
     )
   );
 
   if (interpolatedCanvasPoints === canvasPoints) {
     return false;
   }
+  for (let i = 1; i < options?.loop; i++) {
+    interpolatedCanvasPoints = <Types.Point2[]>(
+      interpolateSegmentPoints(
+        interpolatedCanvasPoints,
+        0,
+        canvasPoints.length,
+        options?.knotsRatioPercentage || 30
+      )
+    );
+  }
 
-  annotation.data.contour.polyline = interpolatedCanvasPoints.map(
-    viewport.canvasToWorld
+  const unRotate = mat4.invert(mat4.create(), rotateMat);
+  annotation.data.contour.polyline = <Types.Point3[]>(
+    interpolatedCanvasPoints.map((p) =>
+      vec3.transformMat4([0, 0, 0], [...p, 0], unRotate)
+    )
   );
 
   return true;


### PR DESCRIPTION
### Context

If smooth annotations got called on an annotation not currently in view, it would destroy the annotation.
Also, smoothing a closed annotation would result in a sharp point due to not smoothing the start/end overlap.
Finally, smoothing functions were accessing the old contour polyline data to test whether to smooth, so smoothing was broken unless setting extra values.

### Changes & Results

Use mat4.lookAt to generate a rotation matrix instead of the viewport rotation matrix instead of using canvas coordinates, as the canvas coordinates aren't always available.

Rotate the closed contours randomly to fix the sharp point being generated (you could actually cause it to interpolate to a square like container, with 4 sharp points)

Fix the prevent smoothing test so it works on the newer contour polyline lengths.

### Testing

Run 
yarn example planarFreehandROITool
Create some annotations on/off viewport (navigate away to make them off)
Smooth multiple times, check that the annotations are still smooth.
Create a closed (small) contour, smooth it, see that it approaches a circle or at least doesn't have a sharp point after several smoothings.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
