### PR TITLE
save 2nd point for arrow annotation

### DIFF
--- a/packages/adapters/src/adapters/Cornerstone3D/ArrowAnnotate.js
+++ b/packages/adapters/src/adapters/Cornerstone3D/ArrowAnnotate.js
@@ -98,20 +98,28 @@ class ArrowAnnotate {
         const { points, arrowFirst } = data.handles;
 
         let point;
+        let point2;
 
         if (arrowFirst) {
             point = points[0];
+            point2 = points[1];
         } else {
             point = points[1];
+            point2 = points[0];
         }
 
         const pointImage = worldToImageCoords(referencedImageId, point);
+        const pointImage2 = worldToImageCoords(referencedImageId, point2);
 
         const TID300RepresentationArguments = {
             points: [
                 {
                     x: pointImage[0],
                     y: pointImage[1]
+                },
+                {
+                    x: pointImage2[0],
+                    y: pointImage2[1]
                 }
             ],
             trackingIdentifierTextValue,


### PR DESCRIPTION
Fortunately, TID300 at dcmjs, supports 2nd point in Point class. 

https://github.com/dcmjs-org/dcmjs/blob/master/src/utilities/TID300/Point.js

To support ArrowAnnotate at OHiF, OHIF code should be also modified (`extensions/cornerstone-dicom-sr/src/tools/DICOMSRDIsplayTool.ts`)