### PR TITLE
await setVolumesForViewports while converting viewport from stack to vol

### DIFF
--- a/packages/core/src/utilities/convertStackToVolumeViewport.ts
+++ b/packages/core/src/utilities/convertStackToVolumeViewport.ts
@@ -76,7 +76,7 @@ async function convertStackToVolumeViewport({
     renderingEngine.getViewport(viewportId)
   );
 
-  setVolumesForViewports(
+  await setVolumesForViewports(
     renderingEngine,
     [
       {


### PR DESCRIPTION
### Context

I suspect, that `setVolumesForViewports` is missing await in [convertStackToVolumeViewport.ts](https://github.com/cornerstonejs/cornerstone3D/compare/main...ZuevArseniy:cornerstone3D:await_for_setvolumestoviewport_while_converting?expand=1#diff-e689093148549b3039f493c7b7ee6e593fc0f6a947f6e2307a85e300f0eb4910)
Similar step in convertVolumeToStack (i.e. setting stack images) has await,
Moreover, while using this function in my project, I observed, that when promise returned by convertStackToVolumeViewport.ts is resolved - it doesn't always contain volume (and actor) for an asset. (Unfortunatelly I can't share these assets, as this is a private medical information). However, upon waiting for couple of seconds, volume is added to viewport and actor becomes available.

### Changes & Results

- added await to setVolumesForViewports

below is the console.log of `viewport.getActors()` after calling `convertStackToVolumeViewport`

<img width="745" alt="Screenshot 2024-09-03 at 12 23 14" src="https://github.com/user-attachments/assets/eeb302a5-37f7-4c9a-b0c7-9c42cbe6e2fd">
<img width="718" alt="Screenshot 2024-09-03 at 12 22 38" src="https://github.com/user-attachments/assets/050641e6-f82d-4fbb-90c7-5ec2f11eaef5">

### Testing

I couldn't reproduce it with assets shiped with cornerstone examples, and can't share mine unfortunatelly.
However, I find this change straightforward and unless there was a seriour reason to do so, I suspect this `await` was just forgotten.
However, to verify that nothing got broken at least, this example could be used https://www.cornerstonejs.org/live-examples/stacktovolumewithannotations 

### Checklist

#### PR

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

- [] The documentation page has been updated as necessary for any public API
  additions or removals. (no changes in any public api)

#### Tested Environment

- [] "OS: macOS 13.6.3
- [] "Node version: 20.16.0
- [] "Browser: Chrome 128.0.6613.86
