### PR TITLE
fix: Add HTTP headers from configuration for streaming image loading

### DIFF
--- a/packages/dicomImageLoader/src/imageLoader/internal/streamRequest.ts
+++ b/packages/dicomImageLoader/src/imageLoader/internal/streamRequest.ts
@@ -37,7 +37,8 @@ export default function streamRequest(
   // Make the request for the streamable image frame (i.e. HTJ2K)
   const loadIterator = new ProgressiveIterator('streamRequest');
   loadIterator.generate(async (iterator, reject) => {
-    const headers = Object.assign({}, defaultHeaders /* beforeSendHeaders */);
+    const beforeSendHeaders = globalOptions.beforeSend?.(null, url, defaultHeaders, {});
+    const headers = Object.assign({}, defaultHeaders, beforeSendHeaders);
 
     Object.keys(headers).forEach(function (key) {
       if (headers[key] === null) {
@@ -50,7 +51,7 @@ export default function streamRequest(
 
     try {
       const response = await fetch(url, {
-        headers: defaultHeaders,
+        headers,
         signal: undefined,
       });
 

--- a/packages/tools/src/utilities/planarFreehandROITool/smoothAnnotation.ts
+++ b/packages/tools/src/utilities/planarFreehandROITool/smoothAnnotation.ts
@@ -1,7 +1,5 @@
 import { Types } from '@cornerstonejs/core';
 import { mat4, vec3 } from 'gl-matrix';
-import { PlanarFreehandROITool } from '../../tools';
-import { ToolGroupManager } from '../../store';
 import { PlanarFreehandROIAnnotation } from '../../types/ToolSpecificAnnotationTypes';
 import interpolateSegmentPoints from './interpolation/interpolateSegmentPoints';
 


### PR DESCRIPTION
### Context

The streaming image loading didn't call the before send method, so the headers weren't getting set correctly.

### Changes & Results

Just call the before send configured to generate appropriate headers.

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
