### PR TITLE
fix: Annotations showing up on incorrect images

### DIFF
--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -3042,13 +3042,11 @@ class StackViewport extends Viewport {
       }
     }
 
-    let { imageURI } = options;
+    const { imageURI } = options;
 
-    if (!imageURI) {
-      // Remove the dataLoader scheme since that can change
-      imageURI = imageIdToURI(referencedImageId);
-      return true;
-    } else if (imageIdToURI(referencedImageId) === imageURI) {
+    // Direct URI match check
+    const currentImageURI = imageIdToURI(referencedImageId);
+    if (!imageURI || currentImageURI === imageURI) {
       return true;
     }
 

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -3049,11 +3049,13 @@ class StackViewport extends Viewport {
       imageURI = imageIdToURI(currentImageId);
     }
 
-    const referencedImageURI = imageIdToURI(referencedImageId);
+    const referenceColonIndex = referencedImageId.indexOf(':');
+    const referencedImageURI = referencedImageId.substring(
+      referenceColonIndex + 1
+    );
 
-    const endsWith = referencedImageId?.endsWith(imageURI);
-    if (endsWith) {
-      return endsWith;
+    if (referencedImageURI === imageURI) {
+      return true;
     }
 
     // if camera focal point is provided, we can use that as a point

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -3046,15 +3046,9 @@ class StackViewport extends Viewport {
 
     if (!imageURI) {
       // Remove the dataLoader scheme since that can change
-      imageURI = imageIdToURI(currentImageId);
-    }
-
-    const referenceColonIndex = referencedImageId.indexOf(':');
-    const referencedImageURI = referencedImageId.substring(
-      referenceColonIndex + 1
-    );
-
-    if (referencedImageURI === imageURI) {
+      imageURI = imageIdToURI(referencedImageId);
+      return true;
+    } else if (imageIdToURI(referencedImageId) === imageURI) {
       return true;
     }
 


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

Fixes issue described here: https://github.com/cornerstonejs/cornerstone3D/issues/1455

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

Modified the image URI check in the `isReferenceViewable` function in `StackViewport` from an `endsWith` match to an exact match. This stops annotations on images with IDs like `dicom:126` (which is the format used by the wadoURI filemanager) from displaying on the images `dicom:26` and `dicom:6` as well.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

The repro provided in the linked issue demonstrates the bug, replacing the UMD build of `@cornerstonejs/core` with one containing this change will fix the bug.

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Windows 11"<!--[e.g. Windows 10, macOS 10.15.4]"-->
- [x] "Node version: 18.12.1"<!--[e.g. 16.14.0]"-->
- [x] "Browser: Chrome 128.0.6613.120"
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
