### PR TITLE
feat: stack scroll out of bounds event

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -879,6 +879,8 @@ export enum EVENTS {
     // (undocumented)
     STACK_NEW_IMAGE = "CORNERSTONE_STACK_NEW_IMAGE",
     // (undocumented)
+    STACK_SCROLL_OUT_OF_BOUNDS = "STACK_SCROLL_OUT_OF_BOUNDS",
+    // (undocumented)
     STACK_VIEWPORT_NEW_STACK = "CORNERSTONE_STACK_VIEWPORT_NEW_STACK",
     // (undocumented)
     STACK_VIEWPORT_SCROLL = "CORNERSTONE_STACK_VIEWPORT_SCROLL",
@@ -956,6 +958,8 @@ declare namespace EventTypes {
         StackViewportNewStackEventDetail,
         StackViewportScrollEvent,
         StackViewportScrollEventDetail,
+        StackScrollOutOfBoundsEvent,
+        StackScrollOutOfBoundsEventDetail,
         CameraResetEvent,
         CameraResetEventDetail
     }
@@ -3089,6 +3093,15 @@ type StackNewImageEventDetail = {
     imageIdIndex: number;
     viewportId: string;
     renderingEngineId: string;
+};
+
+// @public (undocumented)
+type StackScrollOutOfBoundsEvent = CustomEvent_2<StackScrollOutOfBoundsEventDetail>;
+
+// @public (undocumented)
+type StackScrollOutOfBoundsEventDetail = {
+    imageIdIndex: number;
+    direction: number;
 };
 
 // @public (undocumented)

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -84,7 +84,6 @@ import {
   PixelDataTypedArray,
 } from '../types';
 import {
-  StackScrollOutOfBoundsEventDetail,
   StackViewportNewStackEventDetail,
   StackViewportScrollEventDetail,
   VoiModifiedEventDetail,
@@ -2600,19 +2599,6 @@ class StackViewport extends Viewport implements IStackViewport, IImagesLoader {
       this.debouncedTimeout = window.setTimeout(() => {
         this.setImageIdIndex(newTargetImageIdIndex);
       }, 40);
-    }
-
-    const imageIdIndex = this.getCurrentImageIdIndex();
-
-    if (
-      imageIdIndex + delta > this.getImageIds().length - 1 ||
-      imageIdIndex + delta < 0
-    ) {
-      const eventData: StackScrollOutOfBoundsEventDetail = {
-        imageIdIndex,
-        direction: delta,
-      };
-      triggerEvent(this.element, Events.STACK_SCROLL_OUT_OF_BOUNDS, eventData);
     }
 
     const eventData: StackViewportScrollEventDetail = {

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -84,6 +84,7 @@ import {
   PixelDataTypedArray,
 } from '../types';
 import {
+  StackScrollOutOfBoundsEventDetail,
   StackViewportNewStackEventDetail,
   StackViewportScrollEventDetail,
   VoiModifiedEventDetail,
@@ -2599,6 +2600,19 @@ class StackViewport extends Viewport implements IStackViewport, IImagesLoader {
       this.debouncedTimeout = window.setTimeout(() => {
         this.setImageIdIndex(newTargetImageIdIndex);
       }, 40);
+    }
+
+    const imageIdIndex = this.getCurrentImageIdIndex();
+
+    if (
+      imageIdIndex + delta > this.getImageIds().length - 1 ||
+      imageIdIndex + delta < 0
+    ) {
+      const eventData: StackScrollOutOfBoundsEventDetail = {
+        imageIdIndex,
+        direction: delta,
+      };
+      triggerEvent(this.element, Events.STACK_SCROLL_OUT_OF_BOUNDS, eventData);
     }
 
     const eventData: StackViewportScrollEventDetail = {

--- a/packages/core/src/enums/Events.ts
+++ b/packages/core/src/enums/Events.ts
@@ -208,6 +208,11 @@ enum Events {
   STACK_VIEWPORT_SCROLL = 'CORNERSTONE_STACK_VIEWPORT_SCROLL',
 
   /**
+   * Triggers when the scroll function is called with a delta that is out of bounds in the stack viewport.
+   */
+  STACK_SCROLL_OUT_OF_BOUNDS = 'STACK_SCROLL_OUT_OF_BOUNDS',
+
+  /**
    * Triggers on the eventTarget when a new geometry is added to the geometry cache
    */
   GEOMETRY_CACHE_GEOMETRY_ADDED = 'CORNERSTONE_GEOMETRY_CACHE_GEOMETRY_ADDED',

--- a/packages/core/src/types/EventTypes.ts
+++ b/packages/core/src/types/EventTypes.ts
@@ -311,6 +311,16 @@ type StackViewportScrollEventDetail = {
 };
 
 /**
+ * Stack Scroll out of bounds event detail
+ */
+type StackScrollOutOfBoundsEventDetail = {
+  /** the current imageId index in the stack that we just scroll to */
+  imageIdIndex: number;
+  /** direction of the scroll */
+  direction: number;
+};
+
+/**
  * CameraModified Event type
  */
 type CameraModifiedEvent = CustomEventType<CameraModifiedEventDetail>;
@@ -431,6 +441,9 @@ type StackViewportNewStackEvent =
 
 type StackViewportScrollEvent = CustomEventType<StackViewportScrollEventDetail>;
 
+type StackScrollOutOfBoundsEvent =
+  CustomEventType<StackScrollOutOfBoundsEventDetail>;
+
 export type {
   CameraModifiedEventDetail,
   CameraModifiedEvent,
@@ -478,6 +491,8 @@ export type {
   StackViewportNewStackEventDetail,
   StackViewportScrollEvent,
   StackViewportScrollEventDetail,
+  StackScrollOutOfBoundsEvent,
+  StackScrollOutOfBoundsEventDetail,
   CameraResetEvent,
   CameraResetEventDetail,
 };

--- a/packages/tools/examples/stackManipulationTools/index.ts
+++ b/packages/tools/examples/stackManipulationTools/index.ts
@@ -6,6 +6,7 @@ import {
   addDropdownToToolbar,
 } from '../../../../utils/demo/helpers';
 import * as cornerstoneTools from '@cornerstonejs/tools';
+import { StackScrollOutOfBoundsEvent } from 'core/src/types/EventTypes';
 
 // This is for debugging purposes
 console.warn(
@@ -16,6 +17,7 @@ const {
   PanTool,
   WindowLevelTool,
   StackScrollMouseWheelTool,
+  StackScrollTool,
   ZoomTool,
   PlanarRotateTool,
   ToolGroupManager,
@@ -26,7 +28,11 @@ const { ViewportType } = Enums;
 const { MouseBindings } = csToolsEnums;
 
 const toolGroupId = 'STACK_TOOL_GROUP_ID';
-const leftClickTools = [WindowLevelTool.toolName, PlanarRotateTool.toolName];
+const leftClickTools = [
+  WindowLevelTool.toolName,
+  PlanarRotateTool.toolName,
+  StackScrollTool.toolName,
+];
 const defaultLeftClickTool = leftClickTools[0];
 let currentLeftClickTool = leftClickTools[0];
 
@@ -77,6 +83,46 @@ addDropdownToToolbar({
   },
 });
 
+const lastEvents = [];
+const lastEventsDiv = document.createElement('div');
+
+content.appendChild(lastEventsDiv);
+
+function updateLastEvents(number, eventName, detail) {
+  if (lastEvents.length > 4) {
+    lastEvents.pop();
+  }
+
+  lastEvents.unshift({ number, eventName, detail });
+
+  // Display
+  lastEventsDiv.innerHTML = '';
+
+  lastEvents.forEach((le) => {
+    const element = document.createElement('p');
+
+    element.style.border = '1px solid black';
+    element.innerText = le.number + ' ' + le.eventName + '\n\n' + le.detail;
+
+    lastEventsDiv.appendChild(element);
+  });
+}
+
+let eventNumber = 1;
+
+const { STACK_SCROLL_OUT_OF_BOUNDS } = Enums.Events;
+
+element.addEventListener(STACK_SCROLL_OUT_OF_BOUNDS, ((
+  evt: StackScrollOutOfBoundsEvent
+) => {
+  updateLastEvents(
+    eventNumber,
+    STACK_SCROLL_OUT_OF_BOUNDS,
+    JSON.stringify(evt.detail)
+  );
+  eventNumber++;
+}) as EventListener);
+
 /**
  * Runs the demo
  */
@@ -88,6 +134,7 @@ async function run() {
   cornerstoneTools.addTool(PanTool);
   cornerstoneTools.addTool(WindowLevelTool);
   cornerstoneTools.addTool(StackScrollMouseWheelTool);
+  cornerstoneTools.addTool(StackScrollTool);
   cornerstoneTools.addTool(ZoomTool);
   cornerstoneTools.addTool(PlanarRotateTool);
 
@@ -100,6 +147,7 @@ async function run() {
   toolGroup.addTool(PanTool.toolName);
   toolGroup.addTool(ZoomTool.toolName);
   toolGroup.addTool(StackScrollMouseWheelTool.toolName, { loop: false });
+  toolGroup.addTool(StackScrollTool.toolName, { loop: false });
   toolGroup.addTool(PlanarRotateTool.toolName);
 
   // Set the initial state of the tools, here all tools are active and bound to

--- a/packages/tools/examples/stackManipulationTools/index.ts
+++ b/packages/tools/examples/stackManipulationTools/index.ts
@@ -1,4 +1,9 @@
-import { RenderingEngine, Types, Enums } from '@cornerstonejs/core';
+import {
+  eventTarget,
+  RenderingEngine,
+  Types,
+  Enums,
+} from '@cornerstonejs/core';
 import {
   initDemo,
   createImageIdsAndCacheMetaData,
@@ -112,7 +117,7 @@ let eventNumber = 1;
 
 const { STACK_SCROLL_OUT_OF_BOUNDS } = Enums.Events;
 
-element.addEventListener(STACK_SCROLL_OUT_OF_BOUNDS, ((
+eventTarget.addEventListener(STACK_SCROLL_OUT_OF_BOUNDS, ((
   evt: StackScrollOutOfBoundsEvent
 ) => {
   updateLastEvents(

--- a/packages/tools/src/utilities/scroll.ts
+++ b/packages/tools/src/utilities/scroll.ts
@@ -41,6 +41,24 @@ export default function scroll(
   if (viewport instanceof VolumeViewport) {
     scrollVolume(viewport, volumeId, delta, scrollSlabs);
   } else {
+    const imageIdIndex = viewport.getCurrentImageIdIndex();
+
+    if (
+      imageIdIndex + delta >
+        (viewport as Types.IStackViewport).getImageIds().length - 1 ||
+      imageIdIndex + delta < 0
+    ) {
+      const eventData: Types.EventTypes.StackScrollOutOfBoundsEventDetail = {
+        imageIdIndex,
+        direction: delta,
+      };
+      csUtils.triggerEvent(
+        eventTarget,
+        EVENTS.STACK_SCROLL_OUT_OF_BOUNDS,
+        eventData
+      );
+    }
+
     (viewport as Types.IStackViewport).scroll(
       delta,
       options.debounceLoading,


### PR DESCRIPTION
Triggered `STACK_SCROLL_OUT_OF_BOUNDS` event in the `scroll` function of the stack viewport. Updated `stackManipulationTools` example to demonstrate the events trigger. 

https://github.com/OHIF/OHIF-Office-Hours/blob/main/notes/2024-08-08.md - followed the guides in the answer here.