### PR TITLE
fix: Dynamic threshold wasn't working in the beta branch

### DIFF
--- a/packages/core/src/utilities/VoxelManager.ts
+++ b/packages/core/src/utilities/VoxelManager.ts
@@ -97,7 +97,7 @@ export default class VoxelManager<T> {
   public setAtIJK = (i: number, j: number, k: number, v) => {
     const index = this.toIndex([i, j, k]);
     const changed = this._set(index, v);
-    if (changed) {
+    if (changed !== false) {
       this.modifiedSlices.add(k);
       VoxelManager.addBounds(this.boundsIJK, [i, j, k]);
     }
@@ -129,7 +129,7 @@ export default class VoxelManager<T> {
    */
   public setAtIndex = (index, v) => {
     const changed = this._set(index, v);
-    if (changed) {
+    if (changed !== false) {
       const pointIJK = this.toIJK(index);
       this.modifiedSlices.add(pointIJK[2]);
       VoxelManager.addBounds(this.boundsIJK, pointIJK);

--- a/packages/tools/examples/labelmapSegmentationDynamicThreshold/index.ts
+++ b/packages/tools/examples/labelmapSegmentationDynamicThreshold/index.ts
@@ -195,6 +195,8 @@ async function run() {
 
   // Define tool groups to add the segmentation display tool to
   const toolGroup = ToolGroupManager.createToolGroup(toolGroupId);
+  // Activate preview
+  labelmapTools.preview.enabled = true;
   addManipulationBindings(toolGroup, { toolMap: labelmapTools.toolMap });
 
   // Get Cornerstone imageIds for the source data and fetch metadata into RAM

--- a/packages/tools/src/tools/segmentation/BrushTool.ts
+++ b/packages/tools/src/tools/segmentation/BrushTool.ts
@@ -415,10 +415,10 @@ class BrushTool extends BaseTool {
   };
 
   previewCallback = () => {
+    this._previewData.timer = null;
     if (this._previewData.preview) {
       return;
     }
-    this._previewData.timer = null;
     this._previewData.preview = this.applyActiveStrategyCallback(
       getEnabledElement(this._previewData.element),
       this.getOperationData(this._previewData.element),

--- a/packages/tools/src/tools/segmentation/strategies/BrushStrategy.ts
+++ b/packages/tools/src/tools/segmentation/strategies/BrushStrategy.ts
@@ -194,12 +194,12 @@ export default class BrushStrategy {
       segmentationVoxelManager.getArrayOfModifiedSlices()
     );
 
-    // reset the modified slices since we are done
-    segmentationVoxelManager.resetModifiedSlices();
-
     // We are only previewing if there is a preview index, and there is at
     // least one slice modified
     if (!previewSegmentIndex || !previewVoxelManager.modifiedSlices.size) {
+      // reset the modified slices since we are done
+      segmentationVoxelManager.resetModifiedSlices();
+
       return null;
     }
     // Use the original initialized data set to preserve preview info


### PR DESCRIPTION
### Context

The preview wasn't showing at all for the dynamic threshold.

### Changes & Results

The preview mode wasn't working, nor was the bidirectional auto-calculation for segmentations.
The changes are:
* Don't reset changed slices array for preview mode
* Record changed data when set data returns undefined as well as when it returns true
* Enable the preview mode for the example

### Testing

Run yarn example for
```
yarn example labelmapSegmentationDynamicThreshold
yarn example segmentBidirectionalTool
```

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
