### PR TITLE
fix(ReferenceLinesTool) Issue 1512 - Reference lines displayed on assets with different Frame of References (UIDs), causing user confusion

### DIFF
--- a/packages/tools/examples/referenceLines/index.ts
+++ b/packages/tools/examples/referenceLines/index.ts
@@ -141,7 +141,6 @@ addDropdownToToolbar({
 
     toolGroup.setToolConfiguration(ReferenceLinesTool.toolName, {
       sourceViewportId: selectedViewportId,
-      enforceSameFrameOfReference: true,
     });
 
     toolGroup.setToolEnabled(ReferenceLinesTool.toolName);
@@ -180,7 +179,6 @@ async function run() {
   // Add the tools to the tool group and specify which volume they are pointing at
   toolGroup.addTool(ReferenceLinesTool.toolName, {
     sourceViewportId: selectedViewportId,
-    enforceSameFrameOfReference: true,
   });
   toolGroup.addTool(ZoomTool.toolName, { volumeId });
   toolGroup.addTool(StackScrollMouseWheelTool.toolName);

--- a/packages/tools/examples/referenceLines/index.ts
+++ b/packages/tools/examples/referenceLines/index.ts
@@ -141,6 +141,7 @@ addDropdownToToolbar({
 
     toolGroup.setToolConfiguration(ReferenceLinesTool.toolName, {
       sourceViewportId: selectedViewportId,
+      enforceSameFrameOfReference: true,
     });
 
     toolGroup.setToolEnabled(ReferenceLinesTool.toolName);
@@ -179,6 +180,7 @@ async function run() {
   // Add the tools to the tool group and specify which volume they are pointing at
   toolGroup.addTool(ReferenceLinesTool.toolName, {
     sourceViewportId: selectedViewportId,
+    enforceSameFrameOfReference: true,
   });
   toolGroup.addTool(ZoomTool.toolName, { volumeId });
   toolGroup.addTool(StackScrollMouseWheelTool.toolName);

--- a/packages/tools/src/tools/ReferenceLinesTool.ts
+++ b/packages/tools/src/tools/ReferenceLinesTool.ts
@@ -41,7 +41,7 @@ class ReferenceLines extends AnnotationDisplayTool {
       supportedInteractionTypes: ['Mouse', 'Touch'],
       configuration: {
         sourceViewportId: '',
-        enforceSameFrameOfReference: false,
+        enforceSameFrameOfReference: true,
         showFullDimension: false,
       },
     }

--- a/packages/tools/src/tools/ReferenceLinesTool.ts
+++ b/packages/tools/src/tools/ReferenceLinesTool.ts
@@ -41,6 +41,7 @@ class ReferenceLines extends AnnotationDisplayTool {
       supportedInteractionTypes: ['Mouse', 'Touch'],
       configuration: {
         sourceViewportId: '',
+        enforceSameFrameOfReference: false,
         showFullDimension: false,
       },
     }
@@ -170,6 +171,14 @@ class ReferenceLines extends AnnotationDisplayTool {
     }
 
     if (!annotation || !annotation?.data?.handles?.points) {
+      return renderStatus;
+    }
+
+    if (
+      this.configuration.enforceSameFrameOfReference &&
+      sourceViewport.getFrameOfReferenceUID() !==
+        targetViewport.getFrameOfReferenceUID()
+    ) {
       return renderStatus;
     }
 


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

In the ReferenceLinesTool, reference lines are incorrectly displayed across assets with different Frame of References (FoR) UIDs. This behavior can confuse users as reference lines are intended to be shown only on assets that share the same FoR UID. When reference lines appear on unrelated assets, it creates a misleading impression and affects the accuracy of cross-referencing between different images or data.

More details: https://github.com/cornerstonejs/cornerstone3D/issues/1512, https://github.com/cornerstonejs/cornerstone3D/issues/1501

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

`enforceSameFrameOfReference` configuration flag has been added to ReferenceLinesTool. Now developers can toggle this flag to avoid such situation if needed.
Example of  `enforceSameFrameOfReference` flag toggled on in action:

https://github.com/user-attachments/assets/47a79a8a-4678-473a-adcc-aacdfc952903


<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
1. Run reference Line example
2. Replace second asset with some random CT image (example: 1.3.6.1.4.1.14519.5.2.1.40445112212390159711541259681923198035)
3. Refence line is not showed on this asset if `enforceSameFrameOfReference ` flag is toggled on

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Windows 11"
- [x] "Node version:  16.20.2"
- [x] "Browser: Chrome 125.0.6422.113"

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
