### PR TITLE
fix: Improve configuration handling and adjust example batch size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,12 +13,22 @@ defaults: &defaults
 commands:
   install_bun:
     steps:
+      - restore_cache:
+          keys:
+            - bun-cache-v2-{{ arch }}-latest
       - run:
           name: Install Bun
           command: |
-            curl -fsSL https://bun.sh/install | bash
+            if [ ! -d "$HOME/.bun" ]; then
+              curl -fsSL https://bun.sh/install | bash
+            fi
             echo 'export BUN_INSTALL="$HOME/.bun"' >> $BASH_ENV
             echo 'export PATH="$BUN_INSTALL/bin:$PATH"' >> $BASH_ENV
+            source $BASH_ENV
+      - save_cache:
+          key: bun-cache-v2-{{ arch }}-latest
+          paths:
+            - ~/.bun
 
 jobs:
   CHECKOUT:

--- a/packages/core/src/init.ts
+++ b/packages/core/src/init.ts
@@ -105,7 +105,7 @@ function init(configuration = config): boolean {
   config = deepMerge(defaultConfig, configuration);
 
   if (isIOS()) {
-    if (configuration.rendering.preferSizeOverAccuracy) {
+    if (configuration.rendering?.preferSizeOverAccuracy) {
       config.rendering.preferSizeOverAccuracy = true;
     } else {
       console.log(

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -68,6 +68,6 @@ export default defineConfig({
     command: 'yarn build-and-serve-static-examples',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
-    timeout: 150 * 1000,
+    timeout: 500 * 1000,
   },
 });

--- a/utils/ExampleRunner/build-all-examples-cli.js
+++ b/utils/ExampleRunner/build-all-examples-cli.js
@@ -158,9 +158,9 @@ if (configuration.examples) {
   shell.ShellString(exampleIndexMarkdown).to(path.join(docsDir, 'examples.md'));
 
   if (options.build == true) {
-    // Split the examples into batches of 10
+    // Split the examples into batches of 4
     const exampleEntries = Object.entries(allExamplePaths);
-    const batches = chunkArray(exampleEntries, 10);
+    const batches = chunkArray(exampleEntries, 4);
 
     batches.forEach((batch, index) => {
       const batchNames = batch.map(([name, path]) => name);


### PR DESCRIPTION
-  Use optional chaining for accessing preferSizeOverAccuracy in iOS configuration
-  Change example batching from 10 to 4 in the build-all-examples-cli script

<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
