### PR TITLE
fix: jpeg codec build

### DIFF
--- a/packages/dicomImageLoader/.webpack/webpack-base.js
+++ b/packages/dicomImageLoader/.webpack/webpack-base.js
@@ -48,7 +48,6 @@ module.exports = {
     },
   },
   module: {
-    noParse: [/(codecs)/],
     rules: [
       {
         test: /\.wasm/,
@@ -56,20 +55,12 @@ module.exports = {
       },
       {
         test: /\.(mjs|js|ts)$/,
-        exclude: [/(node_modules)/, /(codecs)/],
+        exclude: [/(node_modules)/],
         use: {
           loader: 'babel-loader',
           options: {
             cacheDirectory: false,
           },
-        },
-      },
-      {
-        test: path.join(codecs, 'jpeg.js'),
-        loader: 'exports-loader',
-        options: {
-          type: 'commonjs',
-          exports: 'JpegImage',
         },
       },
     ],

--- a/packages/docs/docs/getting-started/vue-angular-react-etc.md
+++ b/packages/docs/docs/getting-started/vue-angular-react-etc.md
@@ -14,3 +14,32 @@ Follow the links below to see how to use cornerstone3D with your favorite framew
 - [Cornerstone3D with Angular](https://github.com/cornerstonejs/angular-cornerstone3d)
   - [Community maintained project](https://github.com/yanqzsu/ng-cornerstone)
 - [Cornerstone3D with Next.js](https://github.com/cornerstonejs/nextjs-cornerstone3d)
+
+
+## Vite
+
+To update your Vite configuration, use the CommonJS plugin, exclude `dicom-image-loader` from optimization, and include `dicom-parser`. We plan to convert `dicom-image-loader` to an ES module, eliminating the need for exclusion in the future.
+
+```javascript
+import { viteCommonjs } from "@originjs/vite-plugin-commonjs"
+
+
+export default defineConfig({
+  plugins: [viteCommonjs()],
+  optimizeDeps: {
+    exclude: ["@cornerstonejs/dicom-image-loader"],
+    include: ["dicom-parser"],
+  },
+})
+```
+
+
+## Webpack
+
+For webpack, simply install the cornerstone3D library and import it into your project.
+
+If you previously used
+
+`noParse: [/(codec)/],`
+
+to avoid parsing codecs in your webpack module, remove that line. The cornerstone3D library now includes the codecs as an ES module.

--- a/packages/docs/docs/migration-guides/2x/1-general.md
+++ b/packages/docs/docs/migration-guides/2x/1-general.md
@@ -24,6 +24,14 @@ Watch this video guide for a [visual walkthrough](https://www.youtube.com/embed/
   allowfullscreen
 ></iframe>
 
+## Frameworks
+
+We have worked hard to enhance the developer experience when using Cornerstone3D with various frameworks like React, Vue, Angular, Vite, and Webpack.
+
+For more information, please refer to the [frameworks](../../getting-started/vue-angular-react-etc.md) page.
+
+You need to modify your Vite and Webpack configurations to correctly import the Cornerstone3D library. Check each framework's repository for more details.
+
 ## Typescript Version
 
 We have upgraded the typescript version from 4.6 to 5.5 in the 2.0 version of the cornerstone3D.

--- a/packages/tools/src/utilities/cine/playClip.ts
+++ b/packages/tools/src/utilities/cine/playClip.ts
@@ -61,7 +61,6 @@ function playClip(
     playClipOptions.dynamicCineEnabled ?? true;
 
   const { viewport } = enabledElement;
-  const volume = _getVolumeFromViewport(viewport as Types.IBaseVolumeViewport);
 
   const playClipContext = _createCinePlayContext(viewport, playClipOptions);
   let playClipData = getToolState(element);


### PR DESCRIPTION
This pull request includes several changes to the `dicomImageLoader` package and updates to the documentation for better integration with various frameworks. The most important changes include the removal of codec-related configurations in the Webpack setup, updates to the Vite and Webpack configuration instructions in the documentation, and the addition of a new section in the migration guide.

Codebase simplification:

* [`packages/dicomImageLoader/.webpack/webpack-base.js`](diffhunk://#diff-f5d5875990769c4c835c8412dd5d7c647ddcc3b6b6e3c864e26d29069ec9adcfL51-L74): Removed `noParse` and `exports-loader` configurations related to codecs as they are now included as ES modules.

Documentation updates:

* [`packages/docs/docs/getting-started/vue-angular-react-etc.md`](diffhunk://#diff-d15f97c5fa52257bb2d1fb0b355258ffdedb4ac3c31598e6f77a762003cacaeeR17-R45): Added instructions for updating Vite and Webpack configurations to correctly import the Cornerstone3D library.
* [`packages/docs/docs/migration-guides/2x/1-general.md`](diffhunk://#diff-fc8004d6ffdbd3173a07ac7d056de5cabec32f6389e71a401b370ca6f6ad82e1R27-R34): Added a new section on framework integration, directing users to the updated configuration instructions.

Other changes:

* [`packages/tools/src/utilities/cine/playClip.ts`](diffhunk://#diff-7d179e40cf3e8d173095cb00390ee226e659dc9b71e006987d2bc49b8521c394L64): Removed an unused variable `volume` from the `playClip` function.