### PR TITLE
fix(camera): Update camera clipping range logic in VolumeViewport

### DIFF
--- a/packages/core/src/RenderingEngine/VolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/VolumeViewport.ts
@@ -203,9 +203,11 @@ class VolumeViewport extends BaseVolumeViewport {
   protected setCameraClippingRange() {
     const activeCamera = this.getVtkActiveCamera();
     if (activeCamera.getParallelProjection()) {
+      // which makes more sense. However, in situations like MPR where the camera is
+      // oblique, the slab thickness might not be sufficient.
       activeCamera.setClippingRange(
-        activeCamera.getDistance() - this.getSlabThickness(),
-        activeCamera.getDistance() + this.getSlabThickness()
+        -RENDERING_DEFAULTS.MAXIMUM_RAY_DISTANCE,
+        RENDERING_DEFAULTS.MAXIMUM_RAY_DISTANCE
       );
     } else {
       activeCamera.setClippingRange(

--- a/packages/tools/src/eventListeners/segmentation/imageChangeEventListener.ts
+++ b/packages/tools/src/eventListeners/segmentation/imageChangeEventListener.ts
@@ -169,12 +169,14 @@ function _imageChangeEventListener(evt) {
       // not derived from it. We need to find a way to handle this case, but don't think
       // it makes sense to do it for the stack viewport, as the volume viewport is designed to handle this case.
       const originToUse = currentOrigin;
+      const constructor = derivedImage.voxelManager.getConstructor();
+      const newPixelData = derivedImage.voxelManager.getScalarData();
 
       const scalarArray = vtkDataArray.newInstance({
         name: 'Pixels',
         numberOfComponents: 1,
-        // @ts-ignore
-        values: [...derivedImage.voxelManager.getScalarData()],
+        // @ts-expect-error
+        values: new constructor(newPixelData),
       });
 
       const imageData = vtkImageData.newInstance();


### PR DESCRIPTION
fixes #1563 

This pull request includes significant improvements to the `VolumeViewport` and `imageChangeEventListener` functionalities. The most important changes involve modifying the camera clipping range logic and updating the way pixel data is handled in derived images.

### Improvements to `VolumeViewport`:

* Modified the `setCameraClippingRange` method to use `RENDERING_DEFAULTS.MAXIMUM_RAY_DISTANCE` for setting the clipping range, improving the handling of oblique camera angles. (`packages/core/src/RenderingEngine/VolumeViewport.ts`)

### Updates to `imageChangeEventListener`:

* Updated the `_imageChangeEventListener` function to use the constructor of the voxel manager for creating new pixel data, ensuring proper handling of derived images. (`packages/tools/src/eventListeners/segmentation/imageChangeEventListener.ts`)