### PR TITLE
Cine: Improve dynamic volume cine stopping logic

### DIFF
--- a/packages/tools/src/utilities/cine/playClip.ts
+++ b/packages/tools/src/utilities/cine/playClip.ts
@@ -267,20 +267,22 @@ function _stopClip(
  */
 function _stopDynamicVolumeCine(element: HTMLDivElement) {
   const { viewport } = getEnabledElement(element);
-  const volume = _getVolumeFromViewport(viewport as Types.IBaseVolumeViewport);
+  if (viewport instanceof VolumeViewport) {
+    const volume = _getVolumeFromViewport(viewport);
+    if (volume?.isDynamicVolume()) {
+      const dynamicCineElement = dynamicVolumesPlayingMap.get(volume.volumeId);
+
+      dynamicVolumesPlayingMap.delete(volume.volumeId);
+
+      if (dynamicCineElement && dynamicCineElement !== element) {
+        stopClip(<HTMLDivElement>dynamicCineElement);
+      }
+    }
+  }
 
   // If the current viewport has a 4D volume loaded it may be playing
   // if it is also loaded on another viewport and user has started CINE
   // for that one. This guarantees the other viewport will also be stopped.
-  if (volume?.isDynamicVolume()) {
-    const dynamicCineElement = dynamicVolumesPlayingMap.get(volume.volumeId);
-
-    dynamicVolumesPlayingMap.delete(volume.volumeId);
-
-    if (dynamicCineElement && dynamicCineElement !== element) {
-      stopClip(<HTMLDivElement>dynamicCineElement);
-    }
-  }
 }
 
 /**
@@ -356,6 +358,10 @@ function _stopClipWithData(playClipData) {
 function _getVolumeFromViewport(
   viewport: Types.IBaseVolumeViewport
 ): Types.IImageVolume {
+  if (!(viewport instanceof VolumeViewport)) {
+    return undefined;
+  }
+
   const volumeIds = viewport.getAllVolumeIds();
 
   if (!volumeIds?.length) {


### PR DESCRIPTION
-  Refactor `_stopDynamicVolumeCine` to ensure type checking for `VolumeViewport` before accessing volume
-  Move the check for dynamic volume playback inside the type check for `VolumeViewport`
-  Add type safety in `_getVolumeFromViewport` by returning `undefined` if the viewport is not an instance of `VolumeViewport`

<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
