### PR TITLE
fix: Fixed examples where VolumeRotateTool was not added to Cornerstone3D

### DIFF
--- a/packages/tools/examples/dynamicPetCt/index.ts
+++ b/packages/tools/examples/dynamicPetCt/index.ts
@@ -30,6 +30,7 @@ const {
   synchronizers,
   MIPJumpToClickTool,
   CrosshairsTool,
+  VolumeRotateTool,
 } = cornerstoneTools;
 
 const { MouseBindings } = csToolsEnums;
@@ -316,6 +317,7 @@ function setUpToolGroups() {
   cornerstoneTools.addTool(StackScrollTool);
   cornerstoneTools.addTool(MIPJumpToClickTool);
   cornerstoneTools.addTool(CrosshairsTool);
+  cornerstoneTools.addTool(VolumeRotateTool);
 
   // Define tool groups for the main 9 viewports.
   // Crosshairs currently only supports 3 viewports for a toolgroup due to the
@@ -398,8 +400,16 @@ function setUpToolGroups() {
   // MIP Tool Groups
   const mipToolGroup = ToolGroupManager.createToolGroup(mipToolGroupUID);
 
-  mipToolGroup.addTool('VolumeRotateMouseWheel');
-  mipToolGroup.addTool('MIPJumpToClickTool', {
+  mipToolGroup?.addTool(VolumeRotateTool.toolName);
+  mipToolGroup.setToolActive(VolumeRotateTool.toolName, {
+    bindings: [
+      {
+        mouseButton: MouseBindings.Wheel, // mouse wheel
+      },
+    ],
+  });
+
+  mipToolGroup.addTool(MIPJumpToClickTool.toolName, {
     targetViewportIds: [
       viewportIds.CT.AXIAL,
       viewportIds.CT.SAGITTAL,
@@ -415,16 +425,13 @@ function setUpToolGroups() {
 
   // Set the initial state of the tools, here we set one tool active on left click.
   // This means left click will draw that tool.
-  mipToolGroup.setToolActive('MIPJumpToClickTool', {
+  mipToolGroup.setToolActive(MIPJumpToClickTool.toolName, {
     bindings: [
       {
         mouseButton: MouseBindings.Primary, // Left Click
       },
     ],
   });
-  // As the Stack Scroll mouse wheel is a tool using the `mouseWheelCallback`
-  // hook instead of mouse buttons, it does not need to assign any mouse button.
-  mipToolGroup.setToolActive('VolumeRotateMouseWheel');
 
   mipToolGroup.addViewport(viewportIds.PETMIP.CORONAL, renderingEngineId);
 }

--- a/packages/tools/examples/orientationMarker/index.ts
+++ b/packages/tools/examples/orientationMarker/index.ts
@@ -149,6 +149,7 @@ async function run() {
   cornerstoneTools.addTool(ZoomTool);
   cornerstoneTools.addTool(StackScrollTool);
   cornerstoneTools.addTool(TrackballRotateTool);
+  cornerstoneTools.addTool(VolumeRotateTool);
 
   ctToolGroup.addTool(OrientationMarkerTool.toolName);
   ctToolGroup.addTool(ZoomTool.toolName);

--- a/packages/tools/examples/petCt/index.ts
+++ b/packages/tools/examples/petCt/index.ts
@@ -17,7 +17,6 @@ import {
   addButtonToToolbar,
 } from '../../../../utils/demo/helpers';
 import * as cornerstoneTools from '@cornerstonejs/tools';
-import { VolumeRotateTool } from '@cornerstonejs/tools';
 
 const {
   ToolGroupManager,
@@ -30,6 +29,7 @@ const {
   MIPJumpToClickTool,
   CrosshairsTool,
   TrackballRotateTool,
+  VolumeRotateTool,
 } = cornerstoneTools;
 
 const { MouseBindings } = csToolsEnums;
@@ -328,6 +328,7 @@ function setUpToolGroups() {
   cornerstoneTools.addTool(MIPJumpToClickTool);
   cornerstoneTools.addTool(CrosshairsTool);
   cornerstoneTools.addTool(TrackballRotateTool);
+  cornerstoneTools.addTool(VolumeRotateTool);
 
   // Define tool groups for the main 9 viewports.
   // Crosshairs currently only supports 3 viewports for a toolgroup due to the
@@ -413,22 +414,19 @@ function setUpToolGroups() {
   mipToolGroup.setToolActive(VolumeRotateTool.toolName, {
     bindings: [{ mouseButton: MouseBindings.Wheel }],
   });
-  mipToolGroup.addTool('MIPJumpToClickTool', {
+  mipToolGroup.addTool(MIPJumpToClickTool.toolName, {
     toolGroupId: ptToolGroupId,
   });
 
   // Set the initial state of the tools, here we set one tool active on left click.
   // This means left click will draw that tool.
-  mipToolGroup.setToolActive('MIPJumpToClickTool', {
+  mipToolGroup.setToolActive(MIPJumpToClickTool.toolName, {
     bindings: [
       {
         mouseButton: MouseBindings.Primary, // Left Click
       },
     ],
   });
-  // As the Stack Scroll mouse wheel is a tool using the `mouseWheelCallback`
-  // hook instead of mouse buttons, it does not need to assign any mouse button.
-  mipToolGroup.setToolActive('VolumeRotateMouseWheel');
 
   mipToolGroup.addViewport(viewportIds.PETMIP.CORONAL, renderingEngineId);
 }


### PR DESCRIPTION


<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
Fixed examples where VolumeRotateTool was not added to Cornerstone3D
<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
Fixed an issue in examples where mip images cannot be rotated because VolumeRotateTool is not added to Cornerstone3D
<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
