### PR TITLE
fix(cornerstoneNiftiImageLoader): Resolve getRange issue for NIfTI volumes

### DIFF
--- a/packages/nifti-volume-loader/src/cornerstoneNiftiImageLoader.ts
+++ b/packages/nifti-volume-loader/src/cornerstoneNiftiImageLoader.ts
@@ -197,6 +197,18 @@ function createImage(
     scalarData: pixelData,
   });
 
+  let minPixelValue = pixelData[0];
+  let maxPixelValue = pixelData[0];
+  for (let i = 1; i < pixelData.length; i++) {
+    const pixelValue = pixelData[i];
+    if (pixelValue < minPixelValue) {
+      minPixelValue = pixelValue;
+    }
+    if (pixelValue > maxPixelValue) {
+      maxPixelValue = pixelValue;
+    }
+  }
+
   return {
     imageId,
     dataType: niftiScalarData.constructor
@@ -213,5 +225,7 @@ function createImage(
     getCanvas: undefined,
     numberOfComponents: undefined,
     voxelManager,
+    minPixelValue,
+    maxPixelValue,
   };
 }


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

When loading a volume from a NIfTI file, there was a bug where retrieving the volume’s VoxelManager and executing `getRange` did not return the correct range. It always returned `[-Infinity, Infinity]`. This issue has been fixed.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

The createImage function in cornerstoneNiftiImageLoader.ts should include minPixel and maxPixel in its return value, but it currently doesn’t. I added code to calculate minPixel and maxPixel and included them in the return value.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

In `examples/niftiWithTools/index.ts`, you can verify that `getRange` works correctly by passing a callback function as follows to the part where `volume.load` is executed.

```
  await volume.load(() => {
    console.log(volume.voxelManager?.getRange());
  });
```

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->maxOS 15.1
- [x] "Node version: <!--[e.g. 16.14.0]"-->v21.7.1
- [x] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->Chrome 130.0.6723.117

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
