### PR TITLE
fix(tools): segmentation colorLUT initial config and crosshairs jump to click

### DIFF
--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -1751,7 +1751,7 @@ export class CrosshairsTool extends AnnotationTool {
     // (undocumented)
     cancel: () => void;
     // (undocumented)
-    _checkIfViewportsRenderingSameScene: (viewport: any, otherViewport: any) => boolean;
+    _checkIfViewportsRenderingSameScene: (viewport: any, otherViewport: any) => any;
     // (undocumented)
     computeToolCenter: () => void;
     // (undocumented)

--- a/packages/core/examples/volumeBasicWadoUri/index.ts
+++ b/packages/core/examples/volumeBasicWadoUri/index.ts
@@ -4,8 +4,9 @@ import {
   initDemo,
   setTitleAndDescription,
   setCtTransferFunctionForVolumeActor,
-  wadoURICreateImageIds,
 } from '../../../../utils/demo/helpers';
+
+import { ctImageIds } from '../../../../utils/demo/helpers/WADOURICreateImageIds';
 
 // This is for debugging purposes
 console.warn(
@@ -36,7 +37,7 @@ async function run() {
   // Init Cornerstone and related libraries
   await initDemo();
 
-  const imageIds = wadoURICreateImageIds();
+  const imageIds = ctImageIds;
 
   // Instantiate a rendering engine
   const renderingEngineId = 'myRenderingEngine';

--- a/packages/core/examples/wadouri/index.ts
+++ b/packages/core/examples/wadouri/index.ts
@@ -5,11 +5,17 @@ import {
   getRenderingEngine,
   init as csRenderInit,
 } from '@cornerstonejs/core';
+
+import { init as initLoader } from '@cornerstonejs/dicom-image-loader';
 import {
   addButtonToToolbar,
   setTitleAndDescription,
   ctVoiRange,
 } from '../../../../utils/demo/helpers';
+import {
+  ctImageIds,
+  ptImageIds,
+} from '../../../../utils/demo/helpers/WADOURICreateImageIds';
 
 // This is for debugging purposes
 console.warn(
@@ -30,39 +36,9 @@ element.style.height = '500px';
 content.appendChild(element);
 // ============================= //
 
-const studyUID = '1.3.6.1.4.1.25403.345050719074.3824.20170125112931.11';
-const contentType = 'application%2Fdicom';
-const wadoURIRoot = 'https://server.dcmjs.org/dcm4chee-arc/aets/DCM4CHEE/wado';
-
-const ctSeriesUID = '1.3.6.1.4.1.25403.345050719074.3824.20170125113028.6';
-const ctObjectUID = '1.3.6.1.4.1.25403.345050719074.3824.20170125113100.3';
-
-const ptSeriesUID = '1.3.6.1.4.1.25403.345050719074.3824.20170125112950.1';
-const ptObjectUID = '1.3.6.1.4.1.25403.345050719074.3824.20170125112959.5';
-
 // Instantiate a rendering engine
 const renderingEngineId = 'myRenderingEngine';
 const viewportId = 'CT_STACK';
-
-const createWADOURIImageId = (params) => {
-  return `wadouri:${params.wadoURIRoot}?requestType=WADO&studyUID=${params.studyUID}&seriesUID=${params.seriesUID}&objectUID=${params.objectUID}&contentType=${params.contentType}`;
-};
-
-const ctImageId = createWADOURIImageId({
-  wadoURIRoot,
-  studyUID,
-  seriesUID: ctSeriesUID,
-  objectUID: ctObjectUID,
-  contentType,
-});
-
-const ptImageId = createWADOURIImageId({
-  wadoURIRoot,
-  studyUID,
-  seriesUID: ptSeriesUID,
-  objectUID: ptObjectUID,
-  contentType,
-});
 
 addButtonToToolbar({
   title: 'Load CT Image',
@@ -75,7 +51,7 @@ addButtonToToolbar({
       viewportId
     ) as Types.IStackViewport;
 
-    viewport.setStack([ctImageId]);
+    viewport.setStack(ctImageIds);
   },
 });
 
@@ -90,7 +66,7 @@ addButtonToToolbar({
       viewportId
     ) as Types.IStackViewport;
 
-    viewport.setStack([ptImageId]);
+    viewport.setStack(ptImageIds);
   },
 });
 /**
@@ -99,6 +75,7 @@ addButtonToToolbar({
 async function run() {
   // Init Cornerstone and related libraries
   await csRenderInit();
+  await initLoader();
 
   const renderingEngine = new RenderingEngine(renderingEngineId);
 
@@ -107,9 +84,6 @@ async function run() {
     viewportId,
     type: ViewportType.STACK,
     element,
-    defaultOptions: {
-      background: [0.2, 0, 0.2] as Types.Point3,
-    },
   };
 
   renderingEngine.enableElement(viewportInput);
@@ -120,7 +94,7 @@ async function run() {
   ) as Types.IStackViewport;
 
   // Define a stack containing a single image
-  const stack = [ctImageId];
+  const stack = ctImageIds;
 
   // Set the stack on the viewport
   await viewport.setStack(stack);

--- a/packages/tools/examples/crossHairs/index.ts
+++ b/packages/tools/examples/crossHairs/index.ts
@@ -106,14 +106,12 @@ addButtonToToolbar({
     const resetZoom = true;
     const resetToCenter = true;
     const resetRotation = true;
-    const supressEvents = false;
-    viewport1.resetCamera(
+    viewport1.resetCamera({
       resetPan,
       resetZoom,
       resetToCenter,
       resetRotation,
-      supressEvents
-    );
+    });
 
     viewport1.render();
   },

--- a/packages/tools/examples/labelmapSegmentColorChange/index.ts
+++ b/packages/tools/examples/labelmapSegmentColorChange/index.ts
@@ -220,10 +220,10 @@ async function run() {
       segmentationId: segmentationId1,
       type: csToolsEnums.SegmentationRepresentations.Labelmap,
       config: {
-        colorLUT: [
+        colorLUTOrIndex: [
           [0, 0, 0, 0],
-          [125, 152, 180, 255],
-          [125, 152, 20, 255],
+          [0, 0, 255, 255],
+          [255, 255, 0, 255],
         ],
       },
     },

--- a/packages/tools/src/stateManagement/segmentation/internalAddSegmentationRepresentation.ts
+++ b/packages/tools/src/stateManagement/segmentation/internalAddSegmentationRepresentation.ts
@@ -47,27 +47,29 @@ function getColorLUTIndex(config: RepresentationPublicInput['config']): number {
   // Destructure colorLUTOrIndex from the config, with a fallback to undefined if config is undefined
   const { colorLUTOrIndex } = config || {};
 
-  // Determine if colorLUTOrIndex is a numeric index or a Color LUT object
-  const isIndexProvided = typeof colorLUTOrIndex === 'number';
-
-  // If an index is provided, retrieve the corresponding Color LUT; otherwise, use the default Color LUT
-  const selectedColorLUT: Types.ColorLUT = isIndexProvided
-    ? getColorLUT(colorLUTOrIndex)
-    : CORNERSTONE_COLOR_LUT;
-
-  // Determine the Color LUT index:
-  // - Use the provided index if available
-  // - Otherwise, obtain the next available index
-  const colorLUTIndex: number = isIndexProvided
-    ? colorLUTOrIndex
-    : getNextColorLUTIndex();
-
-  // If a Color LUT object is provided instead of an index, add it to the state with the determined index
-  if (!isIndexProvided) {
-    addColorLUT(selectedColorLUT, colorLUTIndex);
+  // If no colorLUTOrIndex provided, get next available index and add default LUT
+  if (colorLUTOrIndex === undefined) {
+    const index = addColorLUT(CORNERSTONE_COLOR_LUT);
+    return index;
   }
 
-  return colorLUTIndex;
+  // If numeric index provided, return it directly
+  if (typeof colorLUTOrIndex === 'number') {
+    return colorLUTOrIndex;
+  }
+
+  // If colorLUTOrIndex is a ColorLUT array, add it with a new index
+  if (
+    Array.isArray(colorLUTOrIndex) &&
+    colorLUTOrIndex.every((item) => Array.isArray(item) && item.length === 4)
+  ) {
+    const index = addColorLUT(colorLUTOrIndex);
+    return index;
+  }
+
+  // Fallback: use default LUT with next available index
+  const index = addColorLUT(CORNERSTONE_COLOR_LUT);
+  return index;
 }
 
 export { internalAddSegmentationRepresentation };

--- a/packages/tools/src/tools/CrosshairsTool.ts
+++ b/packages/tools/src/tools/CrosshairsTool.ts
@@ -414,7 +414,6 @@ class CrosshairsTool extends AnnotationTool {
     const { element } = eventDetail;
 
     const { currentPoints } = eventDetail;
-    debugger;
     const jumpWorld = currentPoints.world;
 
     const enabledElement = getEnabledElement(element);

--- a/packages/tools/src/tools/CrosshairsTool.ts
+++ b/packages/tools/src/tools/CrosshairsTool.ts
@@ -414,6 +414,7 @@ class CrosshairsTool extends AnnotationTool {
     const { element } = eventDetail;
 
     const { currentPoints } = eventDetail;
+    debugger;
     const jumpWorld = currentPoints.world;
 
     const enabledElement = getEnabledElement(element);
@@ -1888,21 +1889,13 @@ class CrosshairsTool extends AnnotationTool {
   };
 
   _checkIfViewportsRenderingSameScene = (viewport, otherViewport) => {
-    const actors = viewport.getActors();
-    const otherViewportActors = otherViewport.getActors();
+    const volumeIds = viewport.getAllVolumeIds();
+    const otherVolumeIds = otherViewport.getAllVolumeIds();
 
-    let sameScene = true;
-
-    actors.forEach((actor) => {
-      if (
-        actors.length !== otherViewportActors.length ||
-        otherViewportActors.find(({ uid }) => uid === actor.uid) === undefined
-      ) {
-        sameScene = false;
-      }
-    });
-
-    return sameScene;
+    return (
+      volumeIds.length === otherVolumeIds.length &&
+      volumeIds.every((id) => otherVolumeIds.includes(id))
+    );
   };
 
   _jump = (enabledElement, jumpWorld) => {

--- a/packages/tools/src/types/SegmentationStateTypes.ts
+++ b/packages/tools/src/types/SegmentationStateTypes.ts
@@ -137,6 +137,6 @@ export type RepresentationPublicInput = {
   segmentationId: string;
   type?: Enums.SegmentationRepresentations;
   config?: {
-    colorLUTOrIndex?: Types.ColorLUT[] | number;
+    colorLUTOrIndex?: Types.ColorLUT | number;
   };
 };

--- a/utils/demo/helpers/WADOURICreateImageIds.js
+++ b/utils/demo/helpers/WADOURICreateImageIds.js
@@ -136,7 +136,7 @@ const sopInstanceUIDs = [
   ['1.3.6.1.4.1.14519.5.2.1.7009.2403.113692692484570386248172588190'],
 ];
 
-export default function wadoURICreateImageIds() {
+export function wadoURICreateImageIds() {
   const seriesUID =
     '1.3.6.1.4.1.14519.5.2.1.7009.2403.226151125820845824875394858561';
   const studyUID =
@@ -149,3 +149,30 @@ export default function wadoURICreateImageIds() {
 
   return imageIds;
 }
+
+const ctImageIds = [
+  'wadouri:https://ohif-assets-new.s3.us-east-1.amazonaws.com/ACRIN-Regular/CT+CT+IMAGES/CT000000.dcm',
+  'wadouri:https://ohif-assets-new.s3.us-east-1.amazonaws.com/ACRIN-Regular/CT+CT+IMAGES/CT000001.dcm',
+  'wadouri:https://ohif-assets-new.s3.us-east-1.amazonaws.com/ACRIN-Regular/CT+CT+IMAGES/CT000002.dcm',
+  'wadouri:https://ohif-assets-new.s3.us-east-1.amazonaws.com/ACRIN-Regular/CT+CT+IMAGES/CT000003.dcm',
+  'wadouri:https://ohif-assets-new.s3.us-east-1.amazonaws.com/ACRIN-Regular/CT+CT+IMAGES/CT000004.dcm',
+  'wadouri:https://ohif-assets-new.s3.us-east-1.amazonaws.com/ACRIN-Regular/CT+CT+IMAGES/CT000005.dcm',
+  'wadouri:https://ohif-assets-new.s3.us-east-1.amazonaws.com/ACRIN-Regular/CT+CT+IMAGES/CT000006.dcm',
+  'wadouri:https://ohif-assets-new.s3.us-east-1.amazonaws.com/ACRIN-Regular/CT+CT+IMAGES/CT000007.dcm',
+  'wadouri:https://ohif-assets-new.s3.us-east-1.amazonaws.com/ACRIN-Regular/CT+CT+IMAGES/CT000008.dcm',
+  'wadouri:https://ohif-assets-new.s3.us-east-1.amazonaws.com/ACRIN-Regular/CT+CT+IMAGES/CT000009.dcm',
+];
+
+const ptImageIds = [
+  'wadouri:https://ohif-assets-new.s3.us-east-1.amazonaws.com/ACRIN-Regular/PT+PET+AC/PT000000.dcm',
+  'wadouri:https://ohif-assets-new.s3.us-east-1.amazonaws.com/ACRIN-Regular/PT+PET+AC/PT000001.dcm',
+  'wadouri:https://ohif-assets-new.s3.us-east-1.amazonaws.com/ACRIN-Regular/PT+PET+AC/PT000002.dcm',
+  'wadouri:https://ohif-assets-new.s3.us-east-1.amazonaws.com/ACRIN-Regular/PT+PET+AC/PT000003.dcm',
+  'wadouri:https://ohif-assets-new.s3.us-east-1.amazonaws.com/ACRIN-Regular/PT+PET+AC/PT000004.dcm',
+  'wadouri:https://ohif-assets-new.s3.us-east-1.amazonaws.com/ACRIN-Regular/PT+PET+AC/PT000005.dcm',
+  'wadouri:https://ohif-assets-new.s3.us-east-1.amazonaws.com/ACRIN-Regular/PT+PET+AC/PT000006.dcm',
+  'wadouri:https://ohif-assets-new.s3.us-east-1.amazonaws.com/ACRIN-Regular/PT+PET+AC/PT000007.dcm',
+  'wadouri:https://ohif-assets-new.s3.us-east-1.amazonaws.com/ACRIN-Regular/PT+PET+AC/PT000008.dcm',
+  'wadouri:https://ohif-assets-new.s3.us-east-1.amazonaws.com/ACRIN-Regular/PT+PET+AC/PT000009.dcm',
+];
+export { ctImageIds, ptImageIds };

--- a/utils/demo/helpers/index.js
+++ b/utils/demo/helpers/index.js
@@ -26,7 +26,7 @@ import setCtTransferFunctionForVolumeActor, {
 import setPetColorMapTransferFunctionForVolumeActor from './setPetColorMapTransferFunctionForVolumeActor';
 import setPetTransferFunctionForVolumeActor from './setPetTransferFunctionForVolumeActor';
 import setTitleAndDescription from './setTitleAndDescription';
-import wadoURICreateImageIds from './WADOURICreateImageIds';
+import { wadoURICreateImageIds } from './WADOURICreateImageIds';
 import { createAndCacheGeometriesFromSurfaces } from './createAndCacheGeometriesFromSurfaces';
 import { createAndCacheGeometriesFromContours } from './createAndCacheGeometriesFromContours';
 


### PR DESCRIPTION
fixes https://github.com/cornerstonejs/cornerstone3D/issues/1584
fixes https://github.com/cornerstonejs/cornerstone3D/issues/1604

This pull request includes several changes across multiple files to improve the handling of image IDs, segmentation representations, and viewport rendering checks. The most important changes include modifying the `_checkIfViewportsRenderingSameScene` method, updating the `colorLUTOrIndex` configuration, and refactoring the image ID creation process.

### Improvements to viewport rendering checks:
* [`packages/tools/src/tools/CrosshairsTool.ts`](diffhunk://#diff-2aecc4dd196e6f973c0ce4be3f0ffe15570adbc3cdcd81c45eeffaf928a07c37L1891-R1897): Modified the `_checkIfViewportsRenderingSameScene` method to compare volume IDs instead of actors, ensuring a more accurate scene comparison.

### Updates to segmentation representations:
* [`packages/tools/src/types/SegmentationStateTypes.ts`](diffhunk://#diff-d6eeae0af8d7837cd84a7e12d49d0280fdf1d7d43ee8ee0c2004282eabf5df29L140-R140): Changed the type of `colorLUTOrIndex` to accept a single `ColorLUT` instead of an array, simplifying the configuration.
* [`packages/tools/src/stateManagement/segmentation/internalAddSegmentationRepresentation.ts`](diffhunk://#diff-0153ff619168e4074ab0f409b96ef7c6cf50c3adb1f838c51d54b688c3378273L50-R72): Refactored the `getColorLUTIndex` function to handle different types of `colorLUTOrIndex` values more robustly.

### Refactoring image ID creation:
* [`utils/demo/helpers/WADOURICreateImageIds.js`](diffhunk://#diff-18f7d7bc6c473f9314aa1acf40dc1f2d8a3048aa3ab15125aa837b033e44de94L139-R139): Split the `wadoURICreateImageIds` function into separate exports for `ctImageIds` and `ptImageIds`, and updated imports accordingly. [[1]](diffhunk://#diff-18f7d7bc6c473f9314aa1acf40dc1f2d8a3048aa3ab15125aa837b033e44de94L139-R139) [[2]](diffhunk://#diff-18f7d7bc6c473f9314aa1acf40dc1f2d8a3048aa3ab15125aa837b033e44de94R152-R178) [[3]](diffhunk://#diff-a37ef1a075d9c02a07b03457cf30836c1701b00418ec937545a6d6d85a4f7443L29-R29)

### Code cleanup and simplification:
* [`packages/core/examples/wadouri/index.ts`](diffhunk://#diff-c51eb143e58129becd06e09cdbd258511fbc9c76dc799cdd692effab3db5a785R8-R18): Removed hardcoded image IDs and replaced them with imported `ctImageIds` and `ptImageIds`, and added initialization for the DICOM image loader. [[1]](diffhunk://#diff-c51eb143e58129becd06e09cdbd258511fbc9c76dc799cdd692effab3db5a785R8-R18) [[2]](diffhunk://#diff-c51eb143e58129becd06e09cdbd258511fbc9c76dc799cdd692effab3db5a785L33-L66) [[3]](diffhunk://#diff-c51eb143e58129becd06e09cdbd258511fbc9c76dc799cdd692effab3db5a785L78-R54) [[4]](diffhunk://#diff-c51eb143e58129becd06e09cdbd258511fbc9c76dc799cdd692effab3db5a785L93-R69) [[5]](diffhunk://#diff-c51eb143e58129becd06e09cdbd258511fbc9c76dc799cdd692effab3db5a785R78) [[6]](diffhunk://#diff-c51eb143e58129becd06e09cdbd258511fbc9c76dc799cdd692effab3db5a785L110-L112) [[7]](diffhunk://#diff-c51eb143e58129becd06e09cdbd258511fbc9c76dc799cdd692effab3db5a785L123-R97)
* [`packages/tools/examples/crossHairs/index.ts`](diffhunk://#diff-7dc3b0a635836a5b4dc49c35d3c93fc380588bf76dfefd361a03e55085a819d2L109-R114): Simplified the `resetCamera` method call by using an object for parameters.

These changes collectively enhance the maintainability and functionality of the codebase, particularly in handling image data and segmentation configurations.