### PR TITLE
RenderingEngine & Synchronizer: Improve error handling and code robustness

### DIFF
--- a/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
@@ -1790,7 +1790,7 @@ abstract class BaseVolumeViewport extends Viewport {
     const querySeparator = volumeId.includes('?') ? '&' : '?';
     return `volumeId:${volumeId}${querySeparator}sliceIndex=${sliceIndex}&viewPlaneNormal=${viewPlaneNormal.join(
       ','
-    )}&focalPoint=${focalPoint.join(',')}`;
+    )}`;
   }
 
   private _addVolumeId(volumeId: string): void {

--- a/packages/tools/src/store/SynchronizerManager/Synchronizer.ts
+++ b/packages/tools/src/store/SynchronizerManager/Synchronizer.ts
@@ -359,6 +359,11 @@ class Synchronizer {
 
     viewports.forEach((vp) => {
       const eventSource = this.getEventSource(vp);
+
+      if (!eventSource) {
+        return;
+      }
+
       eventSource.removeEventListener(
         Enums.Events.ELEMENT_DISABLED,
         disableHandler
@@ -380,9 +385,13 @@ class Synchronizer {
     const { renderingEngineId, viewportId } = viewportInfo;
     const renderingEngine = getRenderingEngine(renderingEngineId);
     if (!renderingEngine) {
-      throw new Error(`No RenderingEngine for Id: ${renderingEngineId}`);
+      return null;
     }
-    return renderingEngine.getViewport(viewportId).element;
+    const viewport = renderingEngine.getViewport(viewportId);
+    if (!viewport) {
+      return null;
+    }
+    return viewport.element;
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/OHIF/Viewers/issues/4539
Fixes https://github.com/OHIF/Viewers/issues/4535

This pull request includes changes to improve error handling and code readability in the `BaseVolumeViewport` and `Synchronizer` classes. The most important changes include modifying the return value for missing `RenderingEngine` and `viewport` instances, and improving the `volumeId` query string construction.

Error handling improvements:

* [`packages/tools/src/store/SynchronizerManager/Synchronizer.ts`](diffhunk://#diff-87a71761bf4c3cb80f734f572a35cf9e1f733fab14ad8602c0abef241da8df01L383-R394): Modified the `getEventSource` method to return `null` instead of throwing an error when the `RenderingEngine` or `viewport` is not found.
* [`packages/tools/src/store/SynchronizerManager/Synchronizer.ts`](diffhunk://#diff-87a71761bf4c3cb80f734f572a35cf9e1f733fab14ad8602c0abef241da8df01R362-R366): Added a check to return early if `eventSource` is not found in the `viewports.forEach` loop.

Code readability improvements:

* [`packages/core/src/RenderingEngine/BaseVolumeViewport.ts`](diffhunk://#diff-d8f8b6f60e39bf30c7ddecc31bda70056c63091aad137431809e7cf16eadd3b9L1793-R1793): Simplified the `volumeId` query string construction by removing redundant code.