### PR TITLE
fix(ColorbarCanvas): Fix colorbar rendering issue on small window widths

### DIFF
--- a/packages/tools/src/utilities/voi/colorbar/ColorbarCanvas.ts
+++ b/packages/tools/src/utilities/voi/colorbar/ColorbarCanvas.ts
@@ -218,11 +218,6 @@ class ColorbarCanvas {
     const { _voiRange: voiRange } = this;
     const range = this._showFullImageRange ? this._imageRange : { ...voiRange };
 
-    const { windowWidth } = utilities.windowLevel.toWindowLevel(
-      voiRange.lower,
-      voiRange.upper
-    );
-
     let previousColorPoint = undefined;
     let currentColorPoint = getColorPoint(0);
 
@@ -231,7 +226,9 @@ class ColorbarCanvas {
     let rawPixelValue = range.lower;
 
     for (let i = 0; i < maxValue; i++) {
-      const tVoiRange = (rawPixelValue - voiRange.lower) / windowWidth;
+      const tVoiRange =
+        (rawPixelValue - voiRange.lower) /
+        Math.abs(voiRange.upper - voiRange.lower);
 
       // Find the color in a linear way (O(n) complexity).
       // currentColorPoint shall move to the next color until tVoiRange is smaller


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

When the window width is small, the colorbar doesn't render properly, with the top part appearing gray instead of white.


https://github.com/user-attachments/assets/8c2f633c-b001-4b2d-839b-70a46dd23a00

<img width="300" alt="スクリーンショット 2024-12-02 13 07 26" src="https://github.com/user-attachments/assets/1c12dc10-e542-4e76-9224-9a5e2484c4d1">

<img width="300" alt="スクリーンショット 2024-12-02 13 07 34" src="https://github.com/user-attachments/assets/7a840388-688d-44da-a3fe-812eecd48578">


<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

This issue seems to be caused by an incorrect `tVoiRange` value, which is calculated using `windowWidth`. To fix this, I replaced the `windowWidth` value with a different calculation: `Math.abs(voiRange.upper - voiRange.lower)`, instead of relying on the `windowWidth` provided by the `toWindowLevel` function.

Initially, I suspected that the issue might originate in the `toWindowLevel` function itself, because it calculates `windowWidth` using the formula  `Math.abs(high - low) + 1`.  My assumption was that it should use `Math.abs(high - low)` instead. However, I found this PR https://github.com/cornerstonejs/cornerstone3D/pull/736 that says this formula aligns with the DICOM standard. While I don't fully understand why the DICOM standard is like this - since  it goes against my intuition - it is clear that this calculation doesn't work well for colorbar rendering. 

As a result, I only replaced the `windowWidth` variable with the value calculated by `Math.abs(high - low)` for this specific issue.  

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

I visually confirmed that this issue has been resolved using `examples/colorbar/index.ts`.

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: maxOS 15.1"
- [x] "Node version: v21.7.1"
- [x] "Browser: Chrome 130.0.6723.117"
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
