### PR TITLE
fix(growcut): memory limit issue

### DIFF
--- a/packages/tools/src/utilities/segmentation/growCut/runGrowCut.ts
+++ b/packages/tools/src/utilities/segmentation/growCut/runGrowCut.ts
@@ -4,7 +4,7 @@ import type { Types } from '@cornerstonejs/core';
 import shaderCode from './growCutShader';
 
 const GB = 1024 * 1024 * 1024;
-const WEBGPU_MEMORY_LIMIT = 2 * GB;
+const WEBGPU_MEMORY_LIMIT = 1.99 * GB;
 
 const DEFAULT_GROWCUT_OPTIONS = {
   windowSize: 3,
@@ -149,7 +149,7 @@ async function runGrowCut(
     maxBufferSize: WEBGPU_MEMORY_LIMIT,
   };
 
-  const adapter = await navigator.gpu.requestAdapter();
+  const adapter = await navigator.gpu?.requestAdapter();
   const device = await adapter.requestDevice({ requiredLimits });
   const BUFFER_SIZE = volumePixelData.byteLength;
 

--- a/utils/ExampleRunner/example-info.json
+++ b/utils/ExampleRunner/example-info.json
@@ -428,6 +428,10 @@
       "wholeBodySegment": {
         "name": "Whole Body Segment tool",
         "description": "Demonstrates how to segment the whole body of a region selected by the user that is processed in the gpu"
+      },
+      "SAMClientSide": {
+        "name": "Segmentation AI Assistance",
+        "description": "Demonstrates how to use AI assistance tools for segmentation creation using onnx runtime on the client side"
       }
     },
     "tools-advanced": {


### PR DESCRIPTION
This pull request includes changes to the `runGrowCut` function in the `packages/tools/src/utilities/segmentation/growCut/runGrowCut.ts` file and updates to the `example-info.json` file to add a new segmentation tool. The most important changes include adjusting the WebGPU memory limit, making the request adapter call optional, and adding a new AI assistance tool for segmentation.

Changes to WebGPU memory limit and request adapter:

* [`packages/tools/src/utilities/segmentation/growCut/runGrowCut.ts`](diffhunk://#diff-c7480b0fbfe6cd40f34bbab3407c1d9fa3691d3bcd13ad0958a45d147d88acd1L7-R7): Reduced the `WEBGPU_MEMORY_LIMIT` from 2 GB to 1.99 GB to ensure compatibility with certain systems.
* [`packages/tools/src/utilities/segmentation/growCut/runGrowCut.ts`](diffhunk://#diff-c7480b0fbfe6cd40f34bbab3407c1d9fa3691d3bcd13ad0958a45d147d88acd1L152-R152): Modified the `runGrowCut` function to use optional chaining when requesting the GPU adapter to handle cases where the adapter may not be available.

Updates to example tools:

* [`utils/ExampleRunner/example-info.json`](diffhunk://#diff-adf8589ea791112f77b9a1a3046aab1df93caeeb7577cb46f905cbe8ce887570R431-R434): Added a new tool entry for "Segmentation AI Assistance" to demonstrate the use of AI tools for segmentation creation using ONNX runtime on the client side.