### PR TITLE
chore: clean up some code for new prs

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -1435,7 +1435,8 @@ class HistoryMemo_2 {
     // (undocumented)
     redo(items?: number): void;
     // (undocumented)
-    get size(): any;
+    get size(): number;
+    set size(newSize: number);
     // (undocumented)
     undo(items?: number): void;
 }

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -2826,8 +2826,8 @@ declare namespace growCut {
 type GrowCutBoundingBoxOptions = GrowCutOptions & {
     positiveSeedValue?: number;
     negativeSeedValue?: number;
-    negativePixelRange: [number, number];
-    positivePixelRange: [number, number];
+    negativePixelRange?: [number, number];
+    positivePixelRange?: [number, number];
 };
 
 // @public (undocumented)

--- a/packages/ai/examples/SAMClientSide/index.ts
+++ b/packages/ai/examples/SAMClientSide/index.ts
@@ -18,6 +18,7 @@ import {
   addSegmentIndexDropdown,
   labelmapTools,
   annotationTools,
+  addSliderToToolbar,
 } from '../../../../utils/demo/helpers';
 
 import { ONNXSegmentationController } from '@cornerstonejs/ai';
@@ -43,6 +44,16 @@ const configuration = {
   },
 };
 const logs = [];
+
+addSliderToToolbar({
+  title: 'P Cutoff',
+  step: 1,
+  range: [1, 255],
+  defaultValue: 64,
+  onSelectedValueChange: (value) => {
+    ai.setPCutoff(value);
+  },
+});
 
 /**
  * Log to the specified logger.

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -1552,10 +1552,7 @@ class StackViewport extends Viewport {
 
     const { imagePlaneModule, imagePixelModule } = this.buildMetadata(image);
 
-    let rowCosines, columnCosines;
-
-    rowCosines = imagePlaneModule.rowCosines;
-    columnCosines = imagePlaneModule.columnCosines;
+    let { rowCosines, columnCosines } = imagePlaneModule;
 
     // if null or undefined
     if (rowCosines == null || columnCosines == null) {

--- a/packages/core/src/utilities/historyMemo/index.ts
+++ b/packages/core/src/utilities/historyMemo/index.ts
@@ -29,6 +29,15 @@ export class HistoryMemo {
     return this._size;
   }
 
+  /** Sets the size, clearing all history elements */
+  public set size(newSize: number) {
+    this.ring = new Array<Memo>(newSize);
+    this._size = newSize;
+    this.position = -1;
+    this.redoAvailable = 0;
+    this.undoAvailable = 0;
+  }
+
   /**
    * Undoes up to the given number of items off the ring
    */

--- a/packages/tools/src/tools/annotation/SplineROITool.ts
+++ b/packages/tools/src/tools/annotation/SplineROITool.ts
@@ -439,8 +439,6 @@ class SplineROITool extends ContourSegmentationBaseTool {
     const { element } = eventDetail;
     const { currentPoints } = eventDetail;
     const { canvas: canvasPoint, world: worldPoint } = currentPoints;
-    const enabledElement = getEnabledElement(element);
-    const { renderingEngine } = enabledElement;
     let closeContour = data.handles.points.length >= 2 && doubleClick;
     let addNewPoint = true;
 

--- a/packages/tools/src/tools/annotation/WholeBodySegmentTool.ts
+++ b/packages/tools/src/tools/annotation/WholeBodySegmentTool.ts
@@ -77,7 +77,7 @@ class WholeBodySegmentTool extends GrowCutBaseTool {
     const { element, currentPoints } = eventData;
     const { world: currentWorldPoint } = currentPoints;
     const enabledElement = getEnabledElement(element);
-    const { renderingEngine, viewport } = enabledElement;
+    const { viewport } = enabledElement;
     const linePoints = this._getHorizontalLineWorldPoints(
       enabledElement,
       currentWorldPoint
@@ -88,13 +88,13 @@ class WholeBodySegmentTool extends GrowCutBaseTool {
     triggerAnnotationRenderForViewportUIDs([viewport.id]);
   };
 
-  private _endCallback = (evt: EventTypes.InteractionEventType) => {
+  private _endCallback = async (evt: EventTypes.InteractionEventType) => {
     const eventData = evt.detail;
     const { element } = eventData;
     const enabledElement = getEnabledElement(element);
-    const { renderingEngine, viewport } = enabledElement;
+    const { viewport } = enabledElement;
 
-    this.runGrowCut();
+    await this.runGrowCut();
     this._deactivateDraw(element);
 
     this.growCutData = null;

--- a/packages/tools/src/tools/annotation/WholeBodySegmentTool.ts
+++ b/packages/tools/src/tools/annotation/WholeBodySegmentTool.ts
@@ -189,7 +189,6 @@ class WholeBodySegmentTool extends GrowCutBaseTool {
       },
     };
 
-    // @ts-expect-error
     const options: GrowCutBoundingBoxOptions = {
       positiveSeedValue: segmentIndex,
       negativeSeedValue: 255,

--- a/packages/tools/src/tools/segmentation/strategies/compositions/islandRemoval.ts
+++ b/packages/tools/src/tools/segmentation/strategies/compositions/islandRemoval.ts
@@ -20,6 +20,10 @@ export enum SegmentationEnum {
   INTERIOR = 3,
   // Exterior means it is outside the island
   EXTERIOR = 4,
+  // Exterior small means it is small enough to flood it
+  INTERIOR_SMALL = -5,
+  // Interior test means the segment is being size tested.
+  INTERIOR_TEST = -6,
 }
 
 /**

--- a/packages/tools/src/tools/segmentation/strategies/compositions/labelmapStatistics.ts
+++ b/packages/tools/src/tools/segmentation/strategies/compositions/labelmapStatistics.ts
@@ -35,6 +35,11 @@ export default {
 
     const spacing = segmentationImageData.getSpacing();
 
+    const { boundsIJK: boundsOrig } = segmentationVoxelManager;
+    if (!boundsOrig) {
+      return VolumetricCalculator.getStatistics({ spacing });
+    }
+
     segmentationVoxelManager.forEach((voxel) => {
       const { value, pointIJK } = voxel;
       if (indicesArr.indexOf(value) === -1) {

--- a/packages/tools/src/utilities/segmentation/growCut/runGrowCutForBoundingBox.ts
+++ b/packages/tools/src/utilities/segmentation/growCut/runGrowCutForBoundingBox.ts
@@ -20,8 +20,8 @@ type BoundingBoxInfo = {
 type GrowCutBoundingBoxOptions = GrowCutOptions & {
   positiveSeedValue?: number;
   negativeSeedValue?: number;
-  negativePixelRange: [number, number];
-  positivePixelRange: [number, number];
+  negativePixelRange?: [number, number];
+  positivePixelRange?: [number, number];
 };
 
 function _setNegativeSeedValues(
@@ -34,7 +34,6 @@ function _setNegativeSeedValues(
     negativePixelRange = NEGATIVE_PIXEL_RANGE,
   } = options;
   const subVolPixelData = subVolume.voxelManager.getCompleteScalarDataArray();
-  const labelmapData = labelmap.voxelManager.getCompleteScalarDataArray();
   const [width, height, numSlices] = labelmap.dimensions;
   const middleSliceIndex = Math.floor(numSlices / 2);
   const visited = new Array(width * height).fill(false);


### PR DESCRIPTION
This pull request includes various improvements and fixes across multiple files. The most important changes include adding a setter for the `size` property in `HistoryMemo`, making certain pixel range properties optional in `GrowCutBoundingBoxOptions`, and adding a slider to the toolbar in the `SAMClientSide` example.

### Improvements to `HistoryMemo`:

* Added a setter for the `size` property, which clears all history elements when the size is set. (`packages/core/src/utilities/historyMemo/index.ts`)
* Updated the `size` property to have a type of `number` instead of `any`. (`common/reviews/api/core.api.md`)

### Enhancements to `GrowCutBoundingBoxOptions`:

* Made `negativePixelRange` and `positivePixelRange` properties optional. (`common/reviews/api/tools.api.md`, `packages/tools/src/utilities/segmentation/growCut/runGrowCutForBoundingBox.ts`) [[1]](diffhunk://#diff-2403182f0aa88e43f1f8fcd59594bbd3a62cac992598d1ab80e4e0f1bdd0628eL2829-R2830) [[2]](diffhunk://#diff-bda287e1fde89205d73d8dbd2a52ac199038d2bbd8db814cd1110b8712277f46L23-R24)

### Additions to `SAMClientSide` example:

* Added `addSliderToToolbar` import and implemented a slider for `P Cutoff` in the toolbar. (`packages/ai/examples/SAMClientSide/index.ts`) [[1]](diffhunk://#diff-e5ca9c7162c66cefa9485db2ea0be810d5370aa28b04af1db35e25bdd328f3f8R21) [[2]](diffhunk://#diff-e5ca9c7162c66cefa9485db2ea0be810d5370aa28b04af1db35e25bdd328f3f8R48-R57)

### Codebase simplification:

* Simplified the extraction of `rowCosines` and `columnCosines` in `StackViewport`. (`packages/core/src/RenderingEngine/StackViewport.ts`)

### Asynchronous improvements:

* Updated `_endCallback` to be asynchronous and awaited the `runGrowCut` function. (`packages/tools/src/tools/annotation/WholeBodySegmentTool.ts`)