### PR TITLE
fix(getVtkActiveCamera): don't try to access renderer if it's undefined

### DIFF
--- a/packages/core/src/RenderingEngine/Viewport.ts
+++ b/packages/core/src/RenderingEngine/Viewport.ts
@@ -1301,6 +1301,11 @@ class Viewport {
   protected getVtkActiveCamera(): vtkCamera | vtkSlabCamera {
     const renderer = this.getRenderer();
 
+    if (!renderer) {
+      console.warn('No renderer found for the viewport');
+      return null;
+    }
+
     return renderer.getActiveCamera();
   }
 

--- a/packages/core/src/RenderingEngine/VolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/VolumeViewport.ts
@@ -203,6 +203,12 @@ class VolumeViewport extends BaseVolumeViewport {
 
   protected setCameraClippingRange() {
     const activeCamera = this.getVtkActiveCamera();
+
+    if (!activeCamera) {
+      console.warn('No active camera found');
+      return;
+    }
+
     if (activeCamera.getParallelProjection()) {
       // which makes more sense. However, in situations like MPR where the camera is
       // oblique, the slab thickness might not be sufficient.


### PR DESCRIPTION
### Context

It's in the title