### PR TITLE
fix: average blend mode and trackball rotate reset camera

### DIFF
--- a/common/reviews/api/dicom-image-loader.api.md
+++ b/common/reviews/api/dicom-image-loader.api.md
@@ -124,11 +124,15 @@ const cornerstoneDICOMImageLoader: {
         setOptions: setOptions;
         getOptions: getOptions;
     };
+    decodeImageFrame: typeof decodeImageFrame;
 };
 export default cornerstoneDICOMImageLoader;
 
 // @public (undocumented)
 export function createImage(imageId: string, pixelData: ByteArray, transferSyntax: string, options?: DICOMLoaderImageOptions): Promise<DICOMLoaderIImage | Types_2.IImageFrame>;
+
+// @public (undocumented)
+export function decodeImageFrame(imageFrame: any, transferSyntax: any, pixelData: any, decodeConfig: any, options: any, callbackFn: any): Promise<any>;
 
 // @public (undocumented)
 export function decodeJPEGBaseline8BitColor(imageFrame: Types_2.IImageFrame, pixelData: ByteArray, canvas: HTMLCanvasElement): Promise<Types_2.IImageFrame>;

--- a/packages/core/src/RenderingEngine/vtkClasses/vtkStreamingOpenGLTexture.js
+++ b/packages/core/src/RenderingEngine/vtkClasses/vtkStreamingOpenGLTexture.js
@@ -56,6 +56,15 @@ function vtkStreamingOpenGLTexture(publicAPI, model) {
     );
   };
 
+  const superUpdate = publicAPI.updateVolumeInfoForGL;
+
+  publicAPI.updateVolumeInfoForGL = (dataType, numComps) => {
+    const isScalingApplied = superUpdate(dataType, numComps);
+    model.volumeInfo.dataComputedScale = [1];
+    model.volumeInfo.dataComputedOffset = [0];
+    return isScalingApplied;
+  };
+
   /**
    * This function updates the GPU texture memory to match the current
    * representation of data held in RAM.

--- a/packages/core/src/utilities/VoxelManager.ts
+++ b/packages/core/src/utilities/VoxelManager.ts
@@ -796,6 +796,11 @@ export default class VoxelManager<T> {
       for (const imageId of imageIds) {
         const image = cache.getImage(imageId);
 
+        // Skip if image not loaded yet
+        if (!image) {
+          continue;
+        }
+
         // min and max pixel value is correct, //todo this is not true
         // for dynamically changing data such as labelmaps in segmentation
         if (image.minPixelValue < minValue) {
@@ -805,6 +810,12 @@ export default class VoxelManager<T> {
           maxValue = image.maxPixelValue;
         }
       }
+
+      // If no images were loaded yet, return default range
+      if (minValue === Infinity && maxValue === -Infinity) {
+        return [0, 0];
+      }
+
       return [minValue, maxValue];
     };
 

--- a/packages/dicomImageLoader/src/decodeImageFrameWorker.js
+++ b/packages/dicomImageLoader/src/decodeImageFrameWorker.js
@@ -304,7 +304,7 @@ function scaleImageFrame(imageFrame, targetBuffer, TypedArrayConstructor) {
  * This is an async function return the result, or you can provide an optional
  * callbackFn that is called with the results.
  */
-async function decodeImageFrame(
+export async function decodeImageFrame(
   imageFrame,
   transferSyntax,
   pixelData,

--- a/packages/dicomImageLoader/src/index.ts
+++ b/packages/dicomImageLoader/src/index.ts
@@ -20,6 +20,7 @@ import { default as getPixelData } from './imageLoader/wadors/getPixelData';
 import { internal } from './imageLoader/internal/index';
 import * as constants from './constants';
 import type * as Types from './types';
+import { decodeImageFrame } from './decodeImageFrameWorker';
 
 const cornerstoneDICOMImageLoader = {
   constants,
@@ -40,6 +41,7 @@ const cornerstoneDICOMImageLoader = {
   isColorImage,
   isJPEGBaseline8BitColor,
   internal,
+  decodeImageFrame,
 };
 
 export {
@@ -61,6 +63,7 @@ export {
   isColorImage,
   isJPEGBaseline8BitColor,
   internal,
+  decodeImageFrame,
 };
 
 export type { Types };

--- a/packages/tools/src/tools/TrackballRotateTool.ts
+++ b/packages/tools/src/tools/TrackballRotateTool.ts
@@ -103,7 +103,12 @@ class TrackballRotateTool extends BaseTool {
               return;
             }
             const { viewport } = element;
+
+            const viewPresentation = viewport.getViewPresentation();
+
             viewport.resetCamera();
+
+            viewport.setViewPresentation(viewPresentation);
             viewport.render();
           });
 


### PR DESCRIPTION
fixes https://github.com/OHIF/Viewers/issues/4567
fixes https://github.com/cornerstonejs/cornerstone3D/issues/1631
fixes https://github.com/cornerstonejs/cornerstone3D/issues/1647
fixes https://github.com/cornerstonejs/cornerstone3D/issues/1650

This pull request includes several updates across different modules to enhance functionality and improve code robustness. Key changes involve adding new functions, modifying existing methods, and ensuring proper handling of uninitialized data.

### Enhancements to DICOM Image Loader:

* Added `decodeImageFrame` function to `cornerstoneDICOMImageLoader` and exported it for public use. (`common/reviews/api/dicom-image-loader.api.md`, `packages/dicomImageLoader/src/decodeImageFrameWorker.js`, `packages/dicomImageLoader/src/index.ts`) [[1]](diffhunk://#diff-4bab6ae0a84c46563720d19389ca675dce7f1a8e6d07a7e157d6b12384ed9c44R127-R136) [[2]](diffhunk://#diff-e6c4ba87a62236b35b170b4ea873880564367ff0ddff2bf0e7761db1f60affaaL307-R307) [[3]](diffhunk://#diff-ac6ba789920e6615c7ddf4d45d4a19cb87228f34480a945eb4c836b055cecae3R23) [[4]](diffhunk://#diff-ac6ba789920e6615c7ddf4d45d4a19cb87228f34480a945eb4c836b055cecae3R44) [[5]](diffhunk://#diff-ac6ba789920e6615c7ddf4d45d4a19cb87228f34480a945eb4c836b055cecae3R66)

### Improvements in VoxelManager:

* Modified `VoxelManager` to skip processing of images that are not loaded yet and to return a default range if no images are loaded. (`packages/core/src/utilities/VoxelManager.ts`) [[1]](diffhunk://#diff-28983b10d488171519cfa9360a0c3b63bd0f9d34493571a7225c4609a5215673R799-R803) [[2]](diffhunk://#diff-28983b10d488171519cfa9360a0c3b63bd0f9d34493571a7225c4609a5215673R813-R818)

### Enhancements to vtkStreamingOpenGLTexture:

* Updated `vtkStreamingOpenGLTexture` to include a new method `updateVolumeInfoForGL`, which ensures proper scaling and offset of volume data. (`packages/core/src/RenderingEngine/vtkClasses/vtkStreamingOpenGLTexture.js`)

### Improvements in TrackballRotateTool:

* Enhanced `TrackballRotateTool` to preserve the view presentation state when resetting the camera. (`packages/tools/src/tools/TrackballRotateTool.ts`)