### PR TITLE
[OHI-1443] feat(nifti-loader): Add custom header support to nifti loader to support auth headers or any custom headers

### DIFF
--- a/common/reviews/api/nifti-volume-loader.api.md
+++ b/common/reviews/api/nifti-volume-loader.api.md
@@ -48,6 +48,9 @@ declare namespace helpers {
 export { helpers }
 
 // @public (undocumented)
+export function init(options?: LoaderOptions): void;
+
+// @public (undocumented)
 function makeVolumeMetadata(niftiHeader: any, orientation: any, pixelRepresentation: any): {
     volumeMetadata: Types.Metadata;
     dimensions: Types.Point3;

--- a/packages/nifti-volume-loader/README.md
+++ b/packages/nifti-volume-loader/README.md
@@ -1,3 +1,20 @@
 # @cornerstonejs/nifti-volume-loader
 
 Nifti volume loader for the cornerstone3D framework.
+
+# Injecting headers
+
+You can inject custom headers to the requests made by the loader. This is useful for authentication purposes.
+
+```js
+import { init } from '@cornerstonejs/nifti-volume-loader';
+
+niftiInit({
+  beforeSend: (xhr, headers, url) => {
+    headers['Cornerstone3D-Is-Awesome'] = 'True';
+    return headers;
+  },
+});
+```
+
+Now, every request made by the loader will have the `Cornerstone3D-Is-Awesome` header with the value `True`.

--- a/packages/nifti-volume-loader/examples/niftiWithTools/index.ts
+++ b/packages/nifti-volume-loader/examples/niftiWithTools/index.ts
@@ -12,7 +12,6 @@ import {
   Enums as NiftiEnums,
   cornerstoneNiftiImageLoader,
   createNiftiImageIdsAndCacheMetadata,
-  init as niftiInit,
 } from '@cornerstonejs/nifti-volume-loader';
 
 import { addDropdownToToolbar, initDemo } from '../../../../utils/demo/helpers';
@@ -131,13 +130,6 @@ const niftiURL =
   'https://ohif-assets.s3.us-east-2.amazonaws.com/nifti/CTACardio.nii.gz';
 const volumeLoaderScheme = 'cornerstoneStreamingImageVolume'; // Loader id which defines which volume loader to use
 const volumeId = `${volumeLoaderScheme}:${niftiURL}`; // VolumeId with loader id + volume id
-
-niftiInit({
-  beforeSend: (xhr, headers, url) => {
-    headers['Cornerstone3D-Is-Awesome'] = 'True';
-    return headers;
-  },
-});
 
 async function setup() {
   await initDemo();

--- a/packages/nifti-volume-loader/examples/niftiWithTools/index.ts
+++ b/packages/nifti-volume-loader/examples/niftiWithTools/index.ts
@@ -12,6 +12,7 @@ import {
   Enums as NiftiEnums,
   cornerstoneNiftiImageLoader,
   createNiftiImageIdsAndCacheMetadata,
+  init as niftiInit,
 } from '@cornerstonejs/nifti-volume-loader';
 
 import { addDropdownToToolbar, initDemo } from '../../../../utils/demo/helpers';
@@ -130,6 +131,13 @@ const niftiURL =
   'https://ohif-assets.s3.us-east-2.amazonaws.com/nifti/CTACardio.nii.gz';
 const volumeLoaderScheme = 'cornerstoneStreamingImageVolume'; // Loader id which defines which volume loader to use
 const volumeId = `${volumeLoaderScheme}:${niftiURL}`; // VolumeId with loader id + volume id
+
+niftiInit({
+  beforeSend: (xhr, headers, url) => {
+    headers['Cornerstone3D-Is-Awesome'] = 'True';
+    return headers;
+  },
+});
 
 async function setup() {
   await initDemo();

--- a/packages/nifti-volume-loader/src/cornerstoneNiftiImageLoader.ts
+++ b/packages/nifti-volume-loader/src/cornerstoneNiftiImageLoader.ts
@@ -15,6 +15,7 @@ import {
 import * as NiftiReader from 'nifti-reader-js';
 import { Events } from './enums';
 import { modalityScaleNifti } from './helpers';
+import { getOptions } from './internal';
 
 type NiftiDataFetchState =
   | {
@@ -39,7 +40,22 @@ function fetchArrayBuffer({
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
     xhr.open('GET', url, true);
+
+    const defaultHeaders = {} as Record<string, string>;
+    const options = getOptions();
+
+    const beforeSendHeaders = options.beforeSend(xhr, defaultHeaders, url);
+
+    const headers = Object.assign({}, defaultHeaders, beforeSendHeaders);
+
     xhr.responseType = 'arraybuffer';
+
+    Object.keys(headers).forEach(function (key) {
+      if (headers[key] === null) {
+        return;
+      }
+      xhr.setRequestHeader(key, headers[key]);
+    });
 
     const onLoadHandler = function (e) {
       if (onload && typeof onload === 'function') {

--- a/packages/nifti-volume-loader/src/createNiftiImageIdsAndCacheMetadata.ts
+++ b/packages/nifti-volume-loader/src/createNiftiImageIdsAndCacheMetadata.ts
@@ -6,6 +6,7 @@ import Events from './enums/Events';
 import { NIFTI_LOADER_SCHEME } from './constants';
 import makeVolumeMetadata from './helpers/makeVolumeMetadata';
 import { getArrayConstructor } from './helpers/dataTypeCodeHelper';
+import { getOptions } from './internal';
 
 export const urlsMap = new Map();
 const NIFTI1_HEADER_SIZE = 348;
@@ -34,8 +35,20 @@ export async function fetchArrayBuffer({
   const receivedLength = 0;
   const signal = controller.signal;
 
+  const options = getOptions();
+  const defaultHeaders = {} as Record<string, string>;
+  const beforeSendHeaders = options.beforeSend?.(null, defaultHeaders, url);
+
+  const headers = Object.assign({}, defaultHeaders, beforeSendHeaders);
+
+  Object.keys(headers).forEach(function (key) {
+    if (headers[key] === null) {
+      headers[key] = undefined;
+    }
+  });
+
   try {
-    const response = await fetch(url, { signal });
+    const response = await fetch(url, { signal, headers });
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }

--- a/packages/nifti-volume-loader/src/index.ts
+++ b/packages/nifti-volume-loader/src/index.ts
@@ -2,10 +2,12 @@ import cornerstoneNiftiImageLoader from './cornerstoneNiftiImageLoader';
 import * as helpers from './helpers';
 import * as Enums from './enums';
 import { createNiftiImageIdsAndCacheMetadata } from './createNiftiImageIdsAndCacheMetadata';
+import init from './init';
 
 export {
   cornerstoneNiftiImageLoader,
   helpers,
   Enums,
   createNiftiImageIdsAndCacheMetadata,
+  init,
 };

--- a/packages/nifti-volume-loader/src/init.ts
+++ b/packages/nifti-volume-loader/src/init.ts
@@ -1,0 +1,8 @@
+import { setOptions } from './internal';
+import type { LoaderOptions } from './types';
+
+function init(options: LoaderOptions = {}): void {
+  setOptions(options);
+}
+
+export default init;

--- a/packages/nifti-volume-loader/src/internal/index.ts
+++ b/packages/nifti-volume-loader/src/internal/index.ts
@@ -1,0 +1,3 @@
+import { setOptions, getOptions } from './options';
+
+export { setOptions, getOptions };

--- a/packages/nifti-volume-loader/src/internal/options.ts
+++ b/packages/nifti-volume-loader/src/internal/options.ts
@@ -1,0 +1,16 @@
+import type { LoaderOptions } from '../types';
+
+let options: LoaderOptions = {
+  // callback allowing customization of the xhr (e.g. adding custom auth headers, cors, etc)
+  beforeSend() {
+    // before send code
+  },
+};
+
+export function setOptions(newOptions: LoaderOptions): void {
+  options = Object.assign(options, newOptions);
+}
+
+export function getOptions(): LoaderOptions {
+  return options;
+}

--- a/packages/nifti-volume-loader/src/types/LoaderOptions.ts
+++ b/packages/nifti-volume-loader/src/types/LoaderOptions.ts
@@ -1,0 +1,7 @@
+export interface LoaderOptions {
+  beforeSend?: (
+    xhr: XMLHttpRequest,
+    defaultHeaders: Record<string, string>,
+    url: string
+  ) => Record<string, string> | void;
+}

--- a/packages/nifti-volume-loader/src/types/index.ts
+++ b/packages/nifti-volume-loader/src/types/index.ts
@@ -1,0 +1,3 @@
+import type { LoaderOptions } from './LoaderOptions';
+
+export type { LoaderOptions };


### PR DESCRIPTION
### Context

fixes https://github.com/cornerstonejs/cornerstone3D/issues/1688
fixes https://github.com/cornerstonejs/cornerstone3D/issues/1403

Adds custom header support to nifti image loader, this will allow people to use auth headers or any headers of their choosing, works for fetches and xhrs.

Closes OHI-1443

![CleanShot 2024-12-12 at 23 46 37@2x](https://github.com/user-attachments/assets/5e4b3129-9faf-4b63-9c00-e3bf97c15cfa)
