### PR TITLE
fix: passing metadata to getTextLines callback in annotation tools

### DIFF
--- a/packages/tools/src/tools/segmentation/CircleROIStartEndThresholdTool.ts
+++ b/packages/tools/src/tools/segmentation/CircleROIStartEndThresholdTool.ts
@@ -881,9 +881,9 @@ class CircleROIStartEndThresholdTool extends CircleROITool {
  * target volume enclosed by the rectangle.
  *
  * @param data - The annotation tool-specific data.
- * @param targetId - The volumeId of the volume to display the stats for.
+ * @param metadata - The metadata annotation.
  */
-function defaultGetTextLines(data): string[] {
+function defaultGetTextLines(data, _metadata): string[] {
   const cachedVolumeStats = data.cachedStats.statistics;
 
   const { area, mean, max, stdDev, areaUnit, modalityUnit } = cachedVolumeStats;

--- a/packages/tools/src/tools/segmentation/CircleROIStartEndThresholdTool.ts
+++ b/packages/tools/src/tools/segmentation/CircleROIStartEndThresholdTool.ts
@@ -502,7 +502,7 @@ class CircleROIStartEndThresholdTool extends CircleROITool {
           };
           continue;
         }
-        const textLines = this.configuration.getTextLines(data, metadata);
+        const textLines = this.configuration.getTextLines(data, { metadata });
         if (!textLines || textLines.length === 0) {
           continue;
         }
@@ -881,9 +881,9 @@ class CircleROIStartEndThresholdTool extends CircleROITool {
  * target volume enclosed by the rectangle.
  *
  * @param data - The annotation tool-specific data.
- * @param metadata - The metadata annotation.
+ * @param _context - Associated data to annotation.
  */
-function defaultGetTextLines(data, _metadata): string[] {
+function defaultGetTextLines(data, _context = {}): string[] {
   const cachedVolumeStats = data.cachedStats.statistics;
 
   const { area, mean, max, stdDev, areaUnit, modalityUnit } = cachedVolumeStats;

--- a/packages/tools/src/tools/segmentation/CircleROIStartEndThresholdTool.ts
+++ b/packages/tools/src/tools/segmentation/CircleROIStartEndThresholdTool.ts
@@ -321,7 +321,7 @@ class CircleROIStartEndThresholdTool extends CircleROITool {
 
     for (let i = 0; i < annotations.length; i++) {
       const annotation = annotations[i] as CircleROIStartEndThresholdAnnotation;
-      const { annotationUID, data } = annotation;
+      const { annotationUID, data, metadata } = annotation;
       const { startCoordinate, endCoordinate } = data;
       const { points, activeHandleIndex } = data.handles;
 
@@ -502,7 +502,7 @@ class CircleROIStartEndThresholdTool extends CircleROITool {
           };
           continue;
         }
-        const textLines = this.configuration.getTextLines(data);
+        const textLines = this.configuration.getTextLines(data, metadata);
         if (!textLines || textLines.length === 0) {
           continue;
         }

--- a/packages/tools/src/tools/segmentation/RectangleROIStartEndThresholdTool.ts
+++ b/packages/tools/src/tools/segmentation/RectangleROIStartEndThresholdTool.ts
@@ -804,9 +804,9 @@ class RectangleROIStartEndThresholdTool extends RectangleROITool {
  * target volume enclosed by the rectangle.
  *
  * @param data - The annotation tool-specific data.
- * @param targetId - The volumeId of the volume to display the stats for.
+ * @param metadata - The metadata annotation.
  */
-function defaultGetTextLines(data): string[] {
+function defaultGetTextLines(data, _metadata): string[] {
   const cachedVolumeStats = data.cachedStats.statistics;
 
   const { area, mean, max, stdDev, areaUnit, modalityUnit } = cachedVolumeStats;

--- a/packages/tools/src/tools/segmentation/RectangleROIStartEndThresholdTool.ts
+++ b/packages/tools/src/tools/segmentation/RectangleROIStartEndThresholdTool.ts
@@ -541,7 +541,7 @@ class RectangleROIStartEndThresholdTool extends RectangleROITool {
       const annotation = annotations[
         i
       ] as RectangleROIStartEndThresholdAnnotation;
-      const { annotationUID, data } = annotation;
+      const { annotationUID, data, metadata } = annotation;
       const { startCoordinate, endCoordinate } = data;
       const { points, activeHandleIndex } = data.handles;
 
@@ -693,7 +693,7 @@ class RectangleROIStartEndThresholdTool extends RectangleROITool {
           continue;
         }
 
-        const textLines = this.configuration.getTextLines(data);
+        const textLines = this.configuration.getTextLines(data, metadata);
         if (!textLines || textLines.length === 0) {
           continue;
         }

--- a/packages/tools/src/tools/segmentation/RectangleROIStartEndThresholdTool.ts
+++ b/packages/tools/src/tools/segmentation/RectangleROIStartEndThresholdTool.ts
@@ -693,7 +693,7 @@ class RectangleROIStartEndThresholdTool extends RectangleROITool {
           continue;
         }
 
-        const textLines = this.configuration.getTextLines(data, metadata);
+        const textLines = this.configuration.getTextLines(data, { metadata });
         if (!textLines || textLines.length === 0) {
           continue;
         }
@@ -804,9 +804,9 @@ class RectangleROIStartEndThresholdTool extends RectangleROITool {
  * target volume enclosed by the rectangle.
  *
  * @param data - The annotation tool-specific data.
- * @param metadata - The metadata annotation.
+ * @param _context - Associated data to annotation.
  */
-function defaultGetTextLines(data, _metadata): string[] {
+function defaultGetTextLines(data, _context = {}): string[] {
   const cachedVolumeStats = data.cachedStats.statistics;
 
   const { area, mean, max, stdDev, areaUnit, modalityUnit } = cachedVolumeStats;


### PR DESCRIPTION
### Context

In nuclear medicine, some quantifications may have different normalization such as SUV lean body mass or glycaemia corrected SUV.

To implement specific quantification we previously add callback definition to override statistics computation or result rendering (stat calculator and getTextLines parameters)

Our current problem is that we want to change the rendered value SUV => SUL, to do this we need to get PatientWeight, PatientSize and PatientSex in the Metadata store.

The probleme we are facing is that the getTextLines callaback is not giving enough context about the measurement especially to retrieve the volumeId/displaySet/SeriesInstanceUID that are needed to link the measurement rendering from the Metadata Store.

So in this PR i add the metadata in the getTextLines of Circle and Rectangle start stop, it should solve our problem but now the issues is that getTextLines has different definition from a tool to another,  for instance : 

In 2D annotation we have : defaultGetTextLines(data, targetId)
in UltrasoundDirectional we have : defaultGetTextLines(data, targetId, configuration)
And now for 3D annotation we will have : defaultGetTextLines(data, _metadata)

I'm a bit afraid seeing different callback definition from a tool to another, that can be complicated to document and maintain in long term, i wonder if we shouldn't send the whole annotation object as one single param so the getTextLines call back can pickup watever needed, but this will become a breaking change 

### Changes & Results

Add more context to getTextLines params

### Testing



### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
