### PR TITLE
[OHI-1065] [OHI-1090] fix(probeTool): Implement isPointNearTool so EraserTool can detect probe measurements and delete them, use line width value from config for drawing the probe circle

### DIFF
--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -4464,7 +4464,7 @@ export class ProbeTool extends AnnotationTool {
     // (undocumented)
     isHandleOutsideImage: boolean;
     // (undocumented)
-    isPointNearTool(): boolean;
+    isPointNearTool(element: HTMLDivElement, annotation: ProbeAnnotation, canvasCoords: Types_2.Point2, proximity: number): boolean;
     // (undocumented)
     static probeDefaults: {
         supportedInteractionTypes: string[];

--- a/packages/tools/src/tools/annotation/ProbeTool.ts
+++ b/packages/tools/src/tools/annotation/ProbeTool.ts
@@ -126,10 +126,20 @@ class ProbeTool extends AnnotationTool {
     );
   }
 
-  // Not necessary for this tool but needs to be defined since it's an abstract
-  // method from the parent class.
-  isPointNearTool(): boolean {
-    return false;
+  isPointNearTool(
+    element: HTMLDivElement,
+    annotation: ProbeAnnotation,
+    canvasCoords: Types.Point2,
+    proximity: number
+  ): boolean {
+    const enabledElement = getEnabledElement(element);
+    const { viewport } = enabledElement;
+
+    const { data } = annotation;
+    const point = data.handles.points[0];
+    const annotationCanvasCoordinate = viewport.worldToCanvas(point);
+
+    return vec2.distance(canvasCoords, annotationCanvasCoordinate) < proximity;
   }
 
   toolSelectedCallback() {}
@@ -471,7 +481,10 @@ class ProbeTool extends AnnotationTool {
 
       styleSpecifier.annotationUID = annotationUID;
 
-      const { color } = this.getAnnotationStyle({ annotation, styleSpecifier });
+      const { color, lineWidth } = this.getAnnotationStyle({
+        annotation,
+        styleSpecifier,
+      });
 
       if (!data.cachedStats) {
         data.cachedStats = {};
@@ -545,7 +558,7 @@ class ProbeTool extends AnnotationTool {
         annotationUID,
         handleGroupUID,
         [canvasCoordinates],
-        { color }
+        { color, lineWidth }
       );
 
       renderStatus = true;


### PR DESCRIPTION
### Context

The measurement eraser tool was not deleting probe measurements due to ProbeTool not having a isPointNearTool implementation. I have implemented the function so measurements can be detected and deleted.

The probe tool was also not using the line width set by users in the annotation configuration, it has now been fixed to use the value provided from the config.

Eraser fix:

![CleanShot 2024-12-20 at 01 35 02](https://github.com/user-attachments/assets/5fae7dcd-d187-44cf-bee1-a969bce9663b)

Line width fix:

![CleanShot 2024-12-20 at 01 36 03@2x](https://github.com/user-attachments/assets/d519420b-c4f0-4c3d-9dff-31d5fffb70c1)

Closes OHI-1065 and OHI-1090
Closes #1304, #1181

