### PR TITLE
fix(ArrowAnnotate): use svg marker to draw the arrow

### DIFF
--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -2107,6 +2107,8 @@ function drawPolyline(svgDrawingHelper: SVGDrawingHelper, annotationUID: string,
     lineWidth?: number;
     lineDash?: string;
     closePath?: boolean;
+    markerStartId?: string;
+    markerEndId?: string;
 }): void;
 
 // @public (undocumented)

--- a/packages/tools/examples/stackAnnotationTools/index.ts
+++ b/packages/tools/examples/stackAnnotationTools/index.ts
@@ -240,7 +240,9 @@ async function run() {
   toolGroup.addTool(BidirectionalTool.toolName);
   toolGroup.addTool(AngleTool.toolName);
   toolGroup.addTool(CobbAngleTool.toolName);
-  toolGroup.addTool(ArrowAnnotateTool.toolName);
+  toolGroup.addTool(ArrowAnnotateTool.toolName, {
+    arrowHeadStyle: 'standard',
+  });
   toolGroup.addTool(PlanarFreehandROITool.toolName);
   toolGroup.addTool(EraserTool.toolName);
   toolGroup.addTool(KeyImageTool.toolName);

--- a/packages/tools/src/drawingSvg/drawArrow.ts
+++ b/packages/tools/src/drawingSvg/drawArrow.ts
@@ -106,7 +106,7 @@ function legacyDrawArrow(
   }
 ): void {
   const { color = 'rgb(0, 255, 0)', width = 2, lineWidth, lineDash } = options;
-  debugger;
+
   // Drawing the head arrow with two lines
   // Variables to be used when creating the arrow
   const headLength = 10;

--- a/packages/tools/src/drawingSvg/drawArrow.ts
+++ b/packages/tools/src/drawingSvg/drawArrow.ts
@@ -2,6 +2,13 @@ import type { Types } from '@cornerstonejs/core';
 import type { SVGDrawingHelper } from '../types';
 import drawLine from './drawLine';
 
+const svgns = 'http://www.w3.org/2000/svg';
+
+/**
+ * Draws an arrow annotation using SVG elements. The arrow can be drawn in two ways:
+ * 1. Using a marker element (via markerEndId) - better for consistent arrowheads.
+ * 2. Using two additional lines for the arrowhead - the older "legacy" method.
+ */
 export default function drawArrow(
   svgDrawingHelper: SVGDrawingHelper,
   annotationUID: string,
@@ -10,27 +17,150 @@ export default function drawArrow(
   end: Types.Point2,
   options = {}
 ): void {
-  // if length is NaN return
   if (isNaN(start[0]) || isNaN(start[1]) || isNaN(end[0]) || isNaN(end[1])) {
     return;
   }
 
-  const { color, width, lineWidth, lineDash } = Object.assign(
-    {
-      color: 'rgb(0, 255, 0)',
-      width: 2,
-      lineWidth: undefined,
-      lineDash: undefined,
-    },
-    options
-  );
+  const {
+    viaMarker = false,
+    color = 'rgb(0, 255, 0)',
+    markerSize = 10,
+  } = options as {
+    viaMarker?: boolean;
+    color?: string;
+    markerSize?: number;
+    markerEndId?: string;
+  };
 
-  // The line itself
+  // If NOT using the marker-based approach, fall back to your two-line "legacy" approach:
+  if (!viaMarker) {
+    legacyDrawArrow(
+      svgDrawingHelper,
+      annotationUID,
+      arrowUID,
+      start,
+      end,
+      options as {
+        color?: string;
+        width?: number;
+        lineWidth?: number;
+        lineDash?: string;
+      }
+    );
+    return;
+  }
+  const layerId = svgDrawingHelper.svgLayerElement.id;
+  const markerBaseId = `arrow-${annotationUID}`;
+  const markerFullId = `${markerBaseId}-${layerId}`;
+
+  const defs = svgDrawingHelper.svgLayerElement.querySelector('defs');
+  let arrowMarker = defs.querySelector(`#${markerFullId}`);
+
+  if (!arrowMarker) {
+    // Marker doesn't exist for this annotationUID, so create it
+    arrowMarker = document.createElementNS(svgns, 'marker');
+    arrowMarker.setAttribute('id', markerFullId);
+
+    // Basic marker attributes
+    arrowMarker.setAttribute('viewBox', '0 0 10 10');
+    arrowMarker.setAttribute('refX', '8');
+    arrowMarker.setAttribute('refY', '5');
+    arrowMarker.setAttribute('markerWidth', `${markerSize}`);
+    arrowMarker.setAttribute('markerHeight', `${markerSize}`);
+    arrowMarker.setAttribute('orient', 'auto');
+
+    // Create the <path> for the arrowhead shape
+    const arrowPath = document.createElementNS(svgns, 'path');
+    arrowPath.setAttribute('d', 'M 0 0 L 10 5 L 0 10 z');
+    arrowPath.setAttribute('fill', color);
+
+    arrowMarker.appendChild(arrowPath);
+    defs.appendChild(arrowMarker);
+  } else {
+    // Marker already exists for this annotationUID; update color & size
+    arrowMarker.setAttribute('markerWidth', `${markerSize}`);
+    arrowMarker.setAttribute('markerHeight', `${markerSize}`);
+
+    const arrowPath = arrowMarker.querySelector('path');
+    if (arrowPath) {
+      arrowPath.setAttribute('fill', color);
+    }
+  }
+
+  (options as { markerEndId?: string }).markerEndId = markerFullId;
+
+  drawLine(svgDrawingHelper, annotationUID, arrowUID, start, end, options);
+}
+
+function legacyDrawArrow(
+  svgDrawingHelper: SVGDrawingHelper,
+  annotationUID: string,
+  arrowUID: string,
+  start: Types.Point2,
+  end: Types.Point2,
+  options = {} as {
+    color?: string;
+    width?: number;
+    lineWidth?: number;
+    lineDash?: string;
+  }
+): void {
+  const { color = 'rgb(0, 255, 0)', width = 2, lineWidth, lineDash } = options;
+  debugger;
+  // Drawing the head arrow with two lines
+  // Variables to be used when creating the arrow
+  const headLength = 10;
+  const angle = Math.atan2(end[1] - start[1], end[0] - start[0]);
+
+  const firstLine = {
+    start: [
+      end[0] - headLength * Math.cos(angle - Math.PI / 7),
+      end[1] - headLength * Math.sin(angle - Math.PI / 7),
+    ] as Types.Point2,
+    end: end,
+  };
+
+  const secondLine = {
+    start: [
+      end[0] - headLength * Math.cos(angle + Math.PI / 7),
+      end[1] - headLength * Math.sin(angle + Math.PI / 7),
+    ] as Types.Point2,
+    end: end,
+  };
+
+  // the main line
   drawLine(svgDrawingHelper, annotationUID, arrowUID, start, end, {
     color,
     width,
     lineWidth,
     lineDash,
-    markerEndId: 'arrow',
   });
+
+  drawLine(
+    svgDrawingHelper,
+    annotationUID,
+    '2',
+    firstLine.start,
+    firstLine.end,
+    {
+      color,
+      width,
+      lineWidth,
+      lineDash,
+    }
+  );
+
+  drawLine(
+    svgDrawingHelper,
+    annotationUID,
+    '3',
+    secondLine.start,
+    secondLine.end,
+    {
+      color,
+      width,
+      lineWidth,
+      lineDash,
+    }
+  );
 }

--- a/packages/tools/src/drawingSvg/drawArrow.ts
+++ b/packages/tools/src/drawingSvg/drawArrow.ts
@@ -18,7 +18,7 @@ export default function drawArrow(
   const { color, width, lineWidth, lineDash } = Object.assign(
     {
       color: 'rgb(0, 255, 0)',
-      width: '2',
+      width: 2,
       lineWidth: undefined,
       lineDash: undefined,
     },
@@ -31,52 +31,6 @@ export default function drawArrow(
     width,
     lineWidth,
     lineDash,
+    markerEndId: 'arrow',
   });
-
-  // Drawing the head arrow with two lines
-  // Variables to be used when creating the arrow
-  const headLength = 10;
-  const angle = Math.atan2(end[1] - start[1], end[0] - start[0]);
-
-  const firstLine = {
-    start: [
-      end[0] - headLength * Math.cos(angle - Math.PI / 7),
-      end[1] - headLength * Math.sin(angle - Math.PI / 7),
-    ] as Types.Point2,
-    end: end,
-  };
-
-  const secondLine = {
-    start: [
-      end[0] - headLength * Math.cos(angle + Math.PI / 7),
-      end[1] - headLength * Math.sin(angle + Math.PI / 7),
-    ] as Types.Point2,
-    end: end,
-  };
-
-  drawLine(
-    svgDrawingHelper,
-    annotationUID,
-    '2',
-    firstLine.start,
-    firstLine.end,
-    {
-      color,
-      width,
-      lineWidth,
-    }
-  );
-
-  drawLine(
-    svgDrawingHelper,
-    annotationUID,
-    '3',
-    secondLine.start,
-    secondLine.end,
-    {
-      color,
-      width,
-      lineWidth,
-    }
-  );
 }

--- a/packages/tools/src/drawingSvg/drawHeight.ts
+++ b/packages/tools/src/drawingSvg/drawHeight.ts
@@ -57,6 +57,7 @@ export default function drawHeight(
       color,
       width,
       lineWidth,
+      lineDash,
     }
   );
 
@@ -71,6 +72,7 @@ export default function drawHeight(
       color,
       width,
       lineWidth,
+      lineDash,
     }
   );
 
@@ -85,6 +87,7 @@ export default function drawHeight(
       color,
       width,
       lineWidth,
+      lineDash,
     }
   );
 }

--- a/packages/tools/src/drawingSvg/drawLine.ts
+++ b/packages/tools/src/drawingSvg/drawLine.ts
@@ -11,15 +11,7 @@ export default function drawLine(
   lineUID: string,
   start: Types.Point2,
   end: Types.Point2,
-  options: {
-    color?: string;
-    width?: number;
-    lineWidth?: number;
-    lineDash?: string;
-    markerStartId?: string;
-    markerEndId?: string;
-    shadow?: boolean;
-  },
+  options = {},
   dataId = ''
 ): void {
   // if length is NaN return
@@ -35,7 +27,15 @@ export default function drawLine(
     markerStartId = null,
     markerEndId = null,
     shadow = false,
-  } = options;
+  } = options as {
+    color?: string;
+    width?: string;
+    lineWidth?: string;
+    lineDash?: string;
+    markerStartId?: string;
+    markerEndId?: string;
+    shadow?: boolean;
+  };
 
   // for supporting both lineWidth and width options
   const strokeWidth = lineWidth || width;
@@ -45,16 +45,6 @@ export default function drawLine(
   const existingLine = svgDrawingHelper.getSvgNode(svgNodeHash);
   const layerId = svgDrawingHelper.svgLayerElement.id;
   const dropShadowStyle = shadow ? `filter:url(#shadow-${layerId});` : '';
-  const arrow = svgDrawingHelper.svgLayerElement.querySelector(
-    `#${markerEndId}-${layerId}`
-  );
-
-  if (arrow) {
-    arrow.setAttribute('fill', color);
-    const newstrokeWidth = strokeWidth >= 4 ? 3 : 6;
-    arrow.setAttribute('markerWidth', `${newstrokeWidth}`);
-    arrow.setAttribute('markerHeight', `${newstrokeWidth}`);
-  }
 
   const attributes = {
     x1: `${start[0]}`,
@@ -65,8 +55,8 @@ export default function drawLine(
     style: dropShadowStyle,
     'stroke-width': strokeWidth,
     'stroke-dasharray': lineDash,
-    'marker-start': markerStartId ? `url(#${markerStartId}-${layerId})` : '',
-    'marker-end': markerEndId ? `url(#${markerEndId}-${layerId})` : '',
+    'marker-start': markerStartId ? `url(#${markerStartId})` : '',
+    'marker-end': markerEndId ? `url(#${markerEndId})` : '',
   };
 
   if (existingLine) {

--- a/packages/tools/src/drawingSvg/drawLine.ts
+++ b/packages/tools/src/drawingSvg/drawLine.ts
@@ -11,7 +11,15 @@ export default function drawLine(
   lineUID: string,
   start: Types.Point2,
   end: Types.Point2,
-  options = {},
+  options: {
+    color?: string;
+    width?: number;
+    lineWidth?: number;
+    lineDash?: string;
+    markerStartId?: string;
+    markerEndId?: string;
+    shadow?: boolean;
+  },
   dataId = ''
 ): void {
   // if length is NaN return
@@ -19,16 +27,15 @@ export default function drawLine(
     return;
   }
 
-  const { color, width, lineWidth, lineDash, shadow } = Object.assign(
-    {
-      color: 'rgb(0, 255, 0)',
-      width: '2',
-      lineWidth: undefined,
-      lineDash: undefined,
-      shadow: undefined,
-    },
-    options
-  );
+  const {
+    color = 'rgb(0, 255, 0)',
+    width = 10,
+    lineWidth,
+    lineDash,
+    markerStartId = null,
+    markerEndId = null,
+    shadow = false,
+  } = options;
 
   // for supporting both lineWidth and width options
   const strokeWidth = lineWidth || width;
@@ -36,9 +43,18 @@ export default function drawLine(
   const svgns = 'http://www.w3.org/2000/svg';
   const svgNodeHash = _getHash(annotationUID, 'line', lineUID);
   const existingLine = svgDrawingHelper.getSvgNode(svgNodeHash);
-  const dropShadowStyle = shadow
-    ? `filter:url(#shadow-${svgDrawingHelper.svgLayerElement.id});`
-    : '';
+  const layerId = svgDrawingHelper.svgLayerElement.id;
+  const dropShadowStyle = shadow ? `filter:url(#shadow-${layerId});` : '';
+  const arrow = svgDrawingHelper.svgLayerElement.querySelector(
+    `#${markerEndId}-${layerId}`
+  );
+
+  if (arrow) {
+    arrow.setAttribute('fill', color);
+    const newstrokeWidth = strokeWidth >= 4 ? 3 : 6;
+    arrow.setAttribute('markerWidth', `${newstrokeWidth}`);
+    arrow.setAttribute('markerHeight', `${newstrokeWidth}`);
+  }
 
   const attributes = {
     x1: `${start[0]}`,
@@ -49,6 +65,8 @@ export default function drawLine(
     style: dropShadowStyle,
     'stroke-width': strokeWidth,
     'stroke-dasharray': lineDash,
+    'marker-start': markerStartId ? `url(#${markerStartId}-${layerId})` : '',
+    'marker-end': markerEndId ? `url(#${markerEndId}-${layerId})` : '',
   };
 
   if (existingLine) {

--- a/packages/tools/src/drawingSvg/drawPolyline.ts
+++ b/packages/tools/src/drawingSvg/drawPolyline.ts
@@ -23,6 +23,8 @@ export default function drawPolyline(
     lineWidth?: number;
     lineDash?: string;
     closePath?: boolean;
+    markerStartId?: string;
+    markerEndId?: string;
   }
 ): void {
   if (points.length < 2) {
@@ -37,6 +39,8 @@ export default function drawPolyline(
     lineWidth,
     lineDash,
     closePath = false,
+    markerStartId = null,
+    markerEndId = null,
   } = options;
 
   // for supporting both lineWidth and width options
@@ -65,6 +69,8 @@ export default function drawPolyline(
     'fill-opacity': fillOpacity,
     'stroke-width': strokeWidth,
     'stroke-dasharray': lineDash,
+    'marker-start': markerStartId ? `url(#${markerStartId})` : '',
+    'marker-end': markerEndId ? `url(#${markerEndId})` : '',
   };
 
   if (existingPolyLine) {

--- a/packages/tools/src/stateManagement/annotation/config/ToolStyle.ts
+++ b/packages/tools/src/stateManagement/annotation/config/ToolStyle.ts
@@ -46,6 +46,7 @@ class ToolStyle {
       textBoxLinkLineWidth: '1',
       textBoxLinkLineDash: '2,3',
       textBoxShadow: true,
+      markerSize: '10',
     };
 
     this._initializeConfig(defaultConfig);

--- a/packages/tools/src/store/addEnabledElement.ts
+++ b/packages/tools/src/store/addEnabledElement.ts
@@ -108,25 +108,10 @@ function _createSvgAnnotationLayer(viewportId: string): SVGElement {
   feBlend.setAttribute('in2', 'matrixOut');
   feBlend.setAttribute('mode', 'normal');
 
-  // arrow marker
-  const arrowMarker = document.createElementNS(svgns, 'marker');
-  arrowMarker.setAttribute('id', `arrow-${svgLayerId}`);
-  arrowMarker.setAttribute('viewBox', '0 0 10 10');
-  arrowMarker.setAttribute('refX', '8');
-  arrowMarker.setAttribute('refY', '5');
-  arrowMarker.setAttribute('markerWidth', '5');
-  arrowMarker.setAttribute('markerHeight', '5');
-  arrowMarker.setAttribute('orient', 'auto');
-  arrowMarker.setAttribute('stroke', 'none');
-  const arrowPath = document.createElementNS(svgns, 'path');
-  arrowPath.setAttribute('d', 'M 0 0 L 10 5 L 0 10 z');
-  arrowMarker.appendChild(arrowPath);
-
   filter.appendChild(feOffset);
   filter.appendChild(feColorMatrix);
   filter.appendChild(feBlend);
   defs.appendChild(filter);
-  defs.appendChild(arrowMarker);
   svgLayer.appendChild(defs);
 
   return svgLayer;

--- a/packages/tools/src/store/addEnabledElement.ts
+++ b/packages/tools/src/store/addEnabledElement.ts
@@ -108,10 +108,25 @@ function _createSvgAnnotationLayer(viewportId: string): SVGElement {
   feBlend.setAttribute('in2', 'matrixOut');
   feBlend.setAttribute('mode', 'normal');
 
+  // arrow marker
+  const arrowMarker = document.createElementNS(svgns, 'marker');
+  arrowMarker.setAttribute('id', `arrow-${svgLayerId}`);
+  arrowMarker.setAttribute('viewBox', '0 0 10 10');
+  arrowMarker.setAttribute('refX', '8');
+  arrowMarker.setAttribute('refY', '5');
+  arrowMarker.setAttribute('markerWidth', '5');
+  arrowMarker.setAttribute('markerHeight', '5');
+  arrowMarker.setAttribute('orient', 'auto');
+  arrowMarker.setAttribute('stroke', 'none');
+  const arrowPath = document.createElementNS(svgns, 'path');
+  arrowPath.setAttribute('d', 'M 0 0 L 10 5 L 0 10 z');
+  arrowMarker.appendChild(arrowPath);
+
   filter.appendChild(feOffset);
   filter.appendChild(feColorMatrix);
   filter.appendChild(feBlend);
   defs.appendChild(filter);
+  defs.appendChild(arrowMarker);
   svgLayer.appendChild(defs);
 
   return svgLayer;

--- a/packages/tools/src/tools/annotation/ArrowAnnotateTool.ts
+++ b/packages/tools/src/tools/annotation/ArrowAnnotateTool.ts
@@ -70,6 +70,10 @@ class ArrowAnnotateTool extends AnnotationTool {
         changeTextCallback,
         preventHandleOutsideImage: false,
         arrowFirst: true,
+        // there are two styles for the arrow head, legacy and standard,
+        // where legacy uses two separate lines and standard uses a single line
+        // with a marker at the end.
+        arrowHeadStyle: 'legacy',
       },
     }
   ) {
@@ -722,10 +726,11 @@ class ArrowAnnotateTool extends AnnotationTool {
 
       styleSpecifier.annotationUID = annotationUID;
 
-      const { color, lineWidth, lineDash } = this.getAnnotationStyle({
-        annotation,
-        styleSpecifier,
-      });
+      const { color, lineWidth, lineDash, markerSize } =
+        this.getAnnotationStyle({
+          annotation,
+          styleSpecifier,
+        });
 
       const canvasCoordinates = points.map((p) => viewport.worldToCanvas(p));
 
@@ -767,6 +772,8 @@ class ArrowAnnotateTool extends AnnotationTool {
             color,
             width: lineWidth,
             lineDash: lineDash,
+            viaMarker: this.configuration.arrowHeadStyle !== 'legacy',
+            markerSize,
           }
         );
       } else {
@@ -780,6 +787,8 @@ class ArrowAnnotateTool extends AnnotationTool {
             color,
             width: lineWidth,
             lineDash: lineDash,
+            viaMarker: this.configuration.arrowHeadStyle !== 'legacy',
+            markerSize,
           }
         );
       }

--- a/packages/tools/src/tools/base/AnnotationTool.ts
+++ b/packages/tools/src/tools/base/AnnotationTool.ts
@@ -415,9 +415,10 @@ abstract class AnnotationTool extends AnnotationDisplayTool {
     const visibility = isAnnotationVisible(annotationUID);
     const locked = isAnnotationLocked(annotationUID);
 
-    const lineWidth = getStyle('lineWidth') as number;
+    const lineWidth = getStyle('lineWidth') as string;
     const lineDash = getStyle('lineDash') as string;
     const color = getStyle('color') as string;
+    const markerSize = getStyle('markerSize') as string;
     const shadow = getStyle('shadow') as boolean;
     const textboxStyle = this.getLinkedTextBoxStyle(styleSpecifier, annotation);
 
@@ -432,6 +433,7 @@ abstract class AnnotationTool extends AnnotationDisplayTool {
       fillOpacity: 0,
       shadow,
       textbox: textboxStyle,
+      markerSize,
     } as AnnotationStyle;
   }
 

--- a/packages/tools/src/types/AnnotationStyle.ts
+++ b/packages/tools/src/types/AnnotationStyle.ts
@@ -18,7 +18,8 @@ type Properties =
   | 'fillOpacity'
   | 'textbox'
   | 'shadow'
-  | 'visibility';
+  | 'visibility'
+  | 'markerSize';
 
 export type AnnotationStyle = {
   [key in `${Properties}${States}${Modes}`]?:


### PR DESCRIPTION
### Context
fix #1671




### Changes & Results

Using `marker` html def instead of two separate arrows for better control over arrow

| size 1 |  size 2 |  size 3 |  size 4 |
|---|---|---|---|
|![1](https://github.com/user-attachments/assets/189c7828-7275-479a-b57e-4a828581c8ea)|![2](https://github.com/user-attachments/assets/d26afa7d-78cc-40f7-be35-8612dd2105ca)|![3](https://github.com/user-attachments/assets/7b1557f0-1465-4321-a033-2060bc747021)|![4](https://github.com/user-attachments/assets/76d894f2-7598-4222-babd-a56808d64b04)|

By default, ArrowAnnotateTool uses the previous version, but you can opt for the new one by using the following code: 
```js
toolGroup.addTool(ArrowAnnotateTool.toolName, {
  arrowHeadStyle: 'standard',
});
```
To change the marker head size, you can use the ToolStyle API. For example, you can do something like this:
```js
const newStyles = {
  global: {
    ...cornerstoneTools.annotation.config.style.getDefaultToolStyles().global,
    markerSize: 20,
  },
};

cornerstoneTools.annotation.config.style.setDefaultToolStyles(newStyles);
```


### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
