### PR TITLE
Fix(removeAllSegmentations): a bug to ensure all segmentations are removed

### DIFF
--- a/packages/tools/src/stateManagement/segmentation/removeSegmentation.ts
+++ b/packages/tools/src/stateManagement/segmentation/removeSegmentation.ts
@@ -42,8 +42,11 @@ export function removeAllSegmentations(): void {
   const segmentations = segmentationStateManager.getState().segmentations;
 
   // Remove each segmentation
-  segmentations.forEach((segmentation) => {
-    removeSegmentation(segmentation.segmentationId);
+  const segmentationIds = segmentations.map(
+    (segmentation) => segmentation.segmentationId
+  );
+  segmentationIds.forEach((segmentationId) => {
+    removeSegmentation(segmentationId);
   });
 
   // Clear the state


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

The `removeAllSegmentations` function doesn't remove all segmentations properly due to a reference problem in iteration.
The simple examples below demonstrate why the current implementation doesn't work.

#### Incorrect
```ts
const list = [0, 1, 2]

list.forEach((x, index) => {
    console.log("----")
    console.log(list)
    console.log(x)
    if (index === 0) {
        list.shift()
    }
})

// "----" 
// [0, 1, 2] 
// 0 
// "----" 
// [1, 2] 
// 2 
```

#### Correct

```ts
const list = [0, 1, 2]

list.map(x => x).forEach((x, index) => {
    console.log("----")
    console.log(list)
    console.log(x)
    if (index === 0) {
        list.shift()
    }
})

// "----" 
// [0, 1, 2] 
// 0 
// "----" 
// [1, 2] 
// 1 
// "----" 
// [1, 2] 
// 2 
```

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
- Create `segmentationIds`, an array containing segmentation IDs
- Iterate over `segmentationIds` to call  `removeSegmentation` for each ID.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [x] "Node version: <!--[e.g. 16.14.0]"-->
- [x] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
