### PR TITLE
fix: Slice range was broken for key image setting on video

### DIFF
--- a/packages/core/src/RenderingEngine/VideoViewport.ts
+++ b/packages/core/src/RenderingEngine/VideoViewport.ts
@@ -812,8 +812,10 @@ class VideoViewport extends Viewport {
     let { imageURI } = options;
     const { referencedImageId, sliceIndex: sliceIndex } = viewRef;
     if (!super.isReferenceViewable(viewRef)) {
+      console.log('Video reference not viewable', viewRef);
       return false;
     }
+    console.log('Testing video reference viewable', viewRef);
 
     const imageId = this.getCurrentImageId();
     if (!imageURI) {
@@ -866,7 +868,7 @@ class VideoViewport extends Viewport {
   public getViewReference(
     viewRefSpecifier?: ViewReferenceSpecifier
   ): ViewReference {
-    let sliceIndex = viewRefSpecifier?.sliceIndex ?? this.getSliceIndex();
+    let sliceIndex = viewRefSpecifier?.sliceIndex;
     if (!sliceIndex) {
       sliceIndex = this.isPlaying
         ? [this.frameRange[0] - 1, this.frameRange[1] - 1]

--- a/packages/core/src/RenderingEngine/VideoViewport.ts
+++ b/packages/core/src/RenderingEngine/VideoViewport.ts
@@ -812,10 +812,8 @@ class VideoViewport extends Viewport {
     let { imageURI } = options;
     const { referencedImageId, sliceIndex: sliceIndex } = viewRef;
     if (!super.isReferenceViewable(viewRef)) {
-      console.log('Video reference not viewable', viewRef);
       return false;
     }
-    console.log('Testing video reference viewable', viewRef);
 
     const imageId = this.getCurrentImageId();
     if (!imageURI) {


### PR DESCRIPTION
### Context

When applying a key image to a video range, the playback/selection was broken and the key image only applied to a single image.

### Changes & Results

Calculate the correct slice range if it isn't provided directly.

### Testing

Run example videoRange, apply a key image to a range of images and ensure it displays on all the images in that range.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
