### PR TITLE
[OHI-1544] fix(annotations): make ArrowAnnotate, CobbAngle and Angle check for visibilty status before rendering

### DIFF
--- a/packages/tools/src/tools/annotation/AngleTool.ts
+++ b/packages/tools/src/tools/annotation/AngleTool.ts
@@ -45,6 +45,7 @@ import type {
 } from '../../types';
 import type { AngleAnnotation } from '../../types/ToolSpecificAnnotationTypes';
 import type { StyleSpecifier } from '../../types/AnnotationStyle';
+import { isAnnotationVisible } from '../../stateManagement/annotation/annotationVisibility';
 
 class AngleTool extends AnnotationTool {
   static toolName;
@@ -721,6 +722,10 @@ class AngleTool extends AnnotationTool {
       if (!viewport.getRenderingEngine()) {
         console.warn('Rendering Engine has been destroyed');
         return renderStatus;
+      }
+
+      if (!isAnnotationVisible(annotationUID)) {
+        continue;
       }
 
       if (activeHandleCanvasCoords) {

--- a/packages/tools/src/tools/annotation/ArrowAnnotateTool.ts
+++ b/packages/tools/src/tools/annotation/ArrowAnnotateTool.ts
@@ -44,6 +44,7 @@ import type {
 } from '../../types';
 import type { ArrowAnnotation } from '../../types/ToolSpecificAnnotationTypes';
 import type { StyleSpecifier } from '../../types/AnnotationStyle';
+import { isAnnotationVisible } from '../../stateManagement/annotation/annotationVisibility';
 
 class ArrowAnnotateTool extends AnnotationTool {
   static toolName;
@@ -740,6 +741,16 @@ class ArrowAnnotateTool extends AnnotationTool {
         activeHandleCanvasCoords = [canvasCoordinates[activeHandleIndex]];
       }
 
+      // If rendering engine has been destroyed while rendering
+      if (!viewport.getRenderingEngine()) {
+        console.warn('Rendering Engine has been destroyed');
+        return renderStatus;
+      }
+
+      if (!isAnnotationVisible(annotationUID)) {
+        continue;
+      }
+
       if (activeHandleCanvasCoords) {
         const handleGroupUID = '0';
 
@@ -785,12 +796,6 @@ class ArrowAnnotateTool extends AnnotationTool {
       }
 
       renderStatus = true;
-
-      // If rendering engine has been destroyed while rendering
-      if (!viewport.getRenderingEngine()) {
-        console.warn('Rendering Engine has been destroyed');
-        return renderStatus;
-      }
 
       if (!text) {
         continue;

--- a/packages/tools/src/tools/annotation/CobbAngleTool.ts
+++ b/packages/tools/src/tools/annotation/CobbAngleTool.ts
@@ -47,6 +47,7 @@ import type {
 } from '../../types';
 import type { CobbAngleAnnotation } from '../../types/ToolSpecificAnnotationTypes';
 import type { StyleSpecifier } from '../../types/AnnotationStyle';
+import { isAnnotationVisible } from '../../stateManagement/annotation/annotationVisibility';
 
 class CobbAngleTool extends AnnotationTool {
   static toolName;
@@ -720,6 +721,10 @@ class CobbAngleTool extends AnnotationTool {
       if (!viewport.getRenderingEngine()) {
         console.warn('Rendering Engine has been destroyed');
         return renderStatus;
+      }
+
+      if (!isAnnotationVisible(annotationUID)) {
+        continue;
       }
 
       if (activeHandleCanvasCoords) {


### PR DESCRIPTION
### Context

A few tools were missing the implementation for visibility checking before rendering, so when they were set to hidden they were still being rendered anyway.

This has been fixed, and I added most of the measurement tools in the annotation visibility example for easier testing in the future.

Fixes OHIF-1544
Fixes #1741

### Demo

![CleanShot 2025-01-10 at 00 31 28](https://github.com/user-attachments/assets/e0ce33ec-d069-4a38-9d7d-81c955121e76)
