### PR TITLE
fix(sortImageIdsAndGetSpacing): sliceThickness and spacingBetweenSlices in case of nonstrict spacing

### DIFF
--- a/packages/core/src/utilities/sortImageIdsAndGetSpacing.ts
+++ b/packages/core/src/utilities/sortImageIdsAndGetSpacing.ts
@@ -157,14 +157,14 @@ export default function sortImageIdsAndGetSpacing(
   // If possible, we use the sliceThickness, but we warn about this dicom file
   // weirdness. If sliceThickness is not available, we set to 1 just to render
   if (zSpacing === 0 && !strictZSpacingForVolumeViewport) {
-    if (!sliceThickness && spacingBetweenSlices) {
+    if (spacingBetweenSlices) {
       console.log('Could not calculate zSpacing. Using spacingBetweenSlices');
-      zSpacing = Math.abs(spacingBetweenSlices);
+      zSpacing = spacingBetweenSlices;
     } else if (sliceThickness) {
       console.log(
         'Could not calculate zSpacing and no spacingBetweenSlices. Using sliceThickness'
       );
-      zSpacing = Math.abs(sliceThickness);
+      zSpacing = sliceThickness;
     } else {
       console.log(
         'Could not calculate zSpacing. The VolumeViewport visualization is compromised. Setting zSpacing to 1 to render'

--- a/packages/core/src/utilities/sortImageIdsAndGetSpacing.ts
+++ b/packages/core/src/utilities/sortImageIdsAndGetSpacing.ts
@@ -157,14 +157,14 @@ export default function sortImageIdsAndGetSpacing(
   // If possible, we use the sliceThickness, but we warn about this dicom file
   // weirdness. If sliceThickness is not available, we set to 1 just to render
   if (zSpacing === 0 && !strictZSpacingForVolumeViewport) {
-    if (sliceThickness && spacingBetweenSlices) {
+    if (!sliceThickness && spacingBetweenSlices) {
       console.log('Could not calculate zSpacing. Using spacingBetweenSlices');
-      zSpacing = spacingBetweenSlices;
+      zSpacing = Math.abs(spacingBetweenSlices);
     } else if (sliceThickness) {
       console.log(
         'Could not calculate zSpacing and no spacingBetweenSlices. Using sliceThickness'
       );
-      zSpacing = sliceThickness;
+      zSpacing = Math.abs(sliceThickness);
     } else {
       console.log(
         'Could not calculate zSpacing. The VolumeViewport visualization is compromised. Setting zSpacing to 1 to render'


### PR DESCRIPTION
Not sure why the logic was like this, it didn't makes sense
zSpacing also should not be negative