### PR TITLE
feat(viewport): add getScale function

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -4292,6 +4292,8 @@ export class Viewport {
     // (undocumented)
     getRotation: () => number;
     // (undocumented)
+    getScale(): number;
+    // (undocumented)
     getSliceIndex(): number;
     // (undocumented)
     getSliceViewInfo(): {

--- a/packages/core/src/RenderingEngine/Viewport.ts
+++ b/packages/core/src/RenderingEngine/Viewport.ts
@@ -2011,7 +2011,7 @@ class Viewport {
   getScale() {
     const imageData = this.getDefaultImageData();
     if (!imageData) {
-        return;
+      return;
     }
 
     const dimensions = imageData.getDimensions();
@@ -2020,21 +2020,21 @@ class Viewport {
 
     const worldZero = imageData.indexToWorld([0, 0, 0]);
     const worldEdge = imageData.indexToWorld([
-        dimensions[0] - 1,
-        dimensions[1] - 1,
-        dimensions[2],
+      dimensions[0] - 1,
+      dimensions[1] - 1,
+      dimensions[2],
     ]);
 
     const canvasZero = this.worldToCanvas([
-        worldZero[0],
-        worldZero[1],
-        worldZero[2]
+      worldZero[0],
+      worldZero[1],
+      worldZero[2],
     ] as [number, number, number]);
 
     const canvasEdge = this.worldToCanvas([
-        worldEdge[0],
-        worldEdge[1],
-        worldEdge[2]
+      worldEdge[0],
+      worldEdge[1],
+      worldEdge[2],
     ] as [number, number, number]);
 
     const renderedWidth = Math.abs(canvasEdge[0] - canvasZero[0]);
@@ -2044,7 +2044,12 @@ class Viewport {
     const scaleY = renderedHeight / originalHeight;
 
     if (Math.abs(scaleX - scaleY) > 0.01) {
-        console.warn('Non-uniform scaling detected in viewport. X scale:', scaleX, 'Y scale:', scaleY);
+      console.warn(
+        'Non-uniform scaling detected in viewport. X scale:',
+        scaleX,
+        'Y scale:',
+        scaleY
+      );
     }
 
     return scaleX;

--- a/packages/core/src/RenderingEngine/Viewport.ts
+++ b/packages/core/src/RenderingEngine/Viewport.ts
@@ -2018,12 +2018,24 @@ class Viewport {
     const originalWidth = dimensions[0];
     const originalHeight = dimensions[1];
 
-    const canvasZero = this.worldToCanvas(imageData.indexToWorld([0, 0, 0]));
-    const canvasEdge = this.worldToCanvas(imageData.indexToWorld([
+    const worldZero = imageData.indexToWorld([0, 0, 0]);
+    const worldEdge = imageData.indexToWorld([
         dimensions[0] - 1,
         dimensions[1] - 1,
         dimensions[2],
-    ]));
+    ]);
+
+    const canvasZero = this.worldToCanvas([
+        worldZero[0],
+        worldZero[1],
+        worldZero[2]
+    ] as [number, number, number]);
+
+    const canvasEdge = this.worldToCanvas([
+        worldEdge[0],
+        worldEdge[1],
+        worldEdge[2]
+    ] as [number, number, number]);
 
     const renderedWidth = Math.abs(canvasEdge[0] - canvasZero[0]);
     const renderedHeight = Math.abs(canvasEdge[1] - canvasZero[1]);
@@ -2035,7 +2047,7 @@ class Viewport {
         console.warn('Non-uniform scaling detected in viewport. X scale:', scaleX, 'Y scale:', scaleY);
     }
 
-    return scaleX; // Or scaleY - they should be the same
+    return scaleX;
   }
 }
 

--- a/packages/core/src/RenderingEngine/Viewport.ts
+++ b/packages/core/src/RenderingEngine/Viewport.ts
@@ -1996,6 +1996,47 @@ class Viewport {
   public setDataIds(_imageIds: string[], _options?: DataSetOptions) {
     throw new Error('Unsupported operatoin setDataIds');
   }
+
+  /**
+   * Returns the scaling factor of the rendered image compared to its original dimensions.
+   * Scale of 1 means the image is rendered at its original size.
+   *
+   * @returns {number|undefined} The scale factor of the rendered image, or undefined if no image data is available.
+   * Assumes uniform scaling - will log a warning if x and y scales differ by more than 0.01.
+   *
+   * @example
+   * const scale = viewport.getScale();
+   * // scale = 0.5 means a 1000x1000 image is rendered as 500x500
+   */
+  getScale() {
+    const imageData = this.getDefaultImageData();
+    if (!imageData) {
+        return;
+    }
+
+    const dimensions = imageData.getDimensions();
+    const originalWidth = dimensions[0];
+    const originalHeight = dimensions[1];
+
+    const canvasZero = this.worldToCanvas(imageData.indexToWorld([0, 0, 0]));
+    const canvasEdge = this.worldToCanvas(imageData.indexToWorld([
+        dimensions[0] - 1,
+        dimensions[1] - 1,
+        dimensions[2],
+    ]));
+
+    const renderedWidth = Math.abs(canvasEdge[0] - canvasZero[0]);
+    const renderedHeight = Math.abs(canvasEdge[1] - canvasZero[1]);
+
+    const scaleX = renderedWidth / originalWidth;
+    const scaleY = renderedHeight / originalHeight;
+
+    if (Math.abs(scaleX - scaleY) > 0.01) {
+        console.warn('Non-uniform scaling detected in viewport. X scale:', scaleX, 'Y scale:', scaleY);
+    }
+
+    return scaleX; // Or scaleY - they should be the same
+  }
 }
 
 export default Viewport;


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
Adding a getScale function would be useful to compare original and rendered image size.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
Added a getScale method to the Viewport class to calculate the scaling ratio between the rendered image size and its original dimensions. This is useful for understanding how an image is being displayed relative to its original size.
Makes it easy to verify correct image scaling behavior, helps troubleshoot display issues and identifies unexpected non-uniform scaling that could distort the image

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
