### PR TITLE
Check cache when prefetching wadouri images for volume

### DIFF
--- a/packages/core/src/loaders/cornerstoneStreamingImageVolumeLoader.ts
+++ b/packages/core/src/loaders/cornerstoneStreamingImageVolumeLoader.ts
@@ -1,3 +1,4 @@
+import cache from '../cache/cache';
 import StreamingImageVolume from '../cache/classes/StreamingImageVolume';
 import { RequestType } from '../enums';
 import imageLoadPoolManager from '../requestPool/imageLoadPoolManager';
@@ -52,6 +53,10 @@ function cornerstoneStreamingImageVolumeLoader(
       const indexesToPrefetch = [0, middleImageIndex, lastImageIndex];
       await Promise.all(
         indexesToPrefetch.map((index) => {
+          // check if image is cached
+          if (cache.isLoaded(options.imageIds[index])) {
+            return Promise.resolve(true);
+          }
           return new Promise((resolve, reject) => {
             const imageId = options.imageIds[index];
             imageLoadPoolManager.addRequest(


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
When using wadouri: scheme with streaming image volume loader, the first, middle and possibly last images must be cached so that the volume can be constructed from metadata. Even when the needed images are cached, it seems that re-requesting them via the loadpoolmanager takes pretty long.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
This change first checks if the required images are already in the cache before getting the loadPoolManager involved, and skips it if so. This will only noticeably speed up volume creation when all the needed images are already cached, for instance when converting a stack to a volume.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
