### PR TITLE
docs(webLoader): Adding usingDefaultValues to hardcodedMetaDataProvider

### DIFF
--- a/packages/core/examples/webLoader/hardcodedMetaDataProvider.ts
+++ b/packages/core/examples/webLoader/hardcodedMetaDataProvider.ts
@@ -42,6 +42,9 @@ export default function hardcodedMetaDataProvider(type, imageId, imageIds) {
       rows: 1216,
       rowCosines: [1, 0, 0],
       columnCosines: [0, 1, 0],
+      // setting useDefaultValues to true signals the calibration values above cannot be trusted
+      // and units should be displayed in pixels
+      usingDefaultValues: true,
     };
 
     return imagePlaneModule;


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->
Users that base a web image metadata provider off the `hardcodedMetaDataProvider` in the examples will find measurements are always displayed in mm, even if `pixelSpacing` is removed. `usingDefaultValues` must also be set.

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->
Added `usingDefaultValues` to `hardcodedMetaDataProvider` and brief explanation

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->
Run ` yarn run example webLoader` to run the webLoader example that uses the `hardcodedMetaDataProvider`

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: macOS 15.2<!--[e.g. Windows 10, macOS 10.15.4]"-->
- [x] "Node version: v22.12.0 <!--[e.g. 16.14.0]"-->
- [x] "Browser: Chromem 132.0.6834.83
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
