### PR TITLE
[OHI-1588] fix(flip): return flip as part of view presentation

### DIFF
--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -4581,6 +4581,10 @@ interface ViewPresentation {
     // (undocumented)
     displayArea?: DisplayArea;
     // (undocumented)
+    flipHorizontal?: boolean;
+    // (undocumented)
+    flipVertical?: boolean;
+    // (undocumented)
     pan?: Point2;
     // (undocumented)
     rotation?: number;
@@ -4594,6 +4598,10 @@ interface ViewPresentation {
 interface ViewPresentationSelector {
     // (undocumented)
     displayArea?: boolean;
+    // (undocumented)
+    flipHorizontal?: boolean;
+    // (undocumented)
+    flipVertical?: boolean;
     // (undocumented)
     paletteLut?: boolean;
     // (undocumented)

--- a/packages/core/src/RenderingEngine/Viewport.ts
+++ b/packages/core/src/RenderingEngine/Viewport.ts
@@ -1863,8 +1863,8 @@ class Viewport {
       zoom = this.getZoom(),
       pan,
       rotation,
-      flipHorizontal,
-      flipVertical,
+      flipHorizontal = this.flipHorizontal,
+      flipVertical = this.flipVertical,
     } = viewPres;
     if (displayArea !== this.getDisplayArea()) {
       this.setDisplayArea(displayArea);
@@ -1876,12 +1876,8 @@ class Viewport {
     if (rotation >= 0) {
       this.setRotation(rotation);
     }
-    if (flipHorizontal !== undefined) {
-      this.flip({ flipHorizontal });
-    }
-    if (flipVertical !== undefined) {
-      this.flip({ flipVertical });
-    }
+
+    this.flip({ flipHorizontal, flipVertical });
   }
 
   _getCorners(bounds: number[]): number[][] {

--- a/packages/core/src/RenderingEngine/Viewport.ts
+++ b/packages/core/src/RenderingEngine/Viewport.ts
@@ -1809,11 +1809,14 @@ class Viewport {
       displayArea: true,
       zoom: true,
       pan: true,
+      flipHorizontal: true,
+      flipVertical: true,
     }
   ): ViewPresentation {
     const target: ViewPresentation = {};
 
-    const { rotation, displayArea, zoom, pan } = viewPresSel;
+    const { rotation, displayArea, zoom, pan, flipHorizontal, flipVertical } =
+      viewPresSel;
     if (rotation) {
       target.rotation = this.getRotation();
     }
@@ -1828,6 +1831,14 @@ class Viewport {
     if (pan) {
       target.pan = this.getPan();
       vec2.scale(target.pan, target.pan, 1 / initZoom);
+    }
+
+    if (flipHorizontal) {
+      target.flipHorizontal = this.flipHorizontal;
+    }
+
+    if (flipVertical) {
+      target.flipVertical = this.flipVertical;
     }
     return target;
   }
@@ -1847,7 +1858,14 @@ class Viewport {
     if (!viewPres) {
       return;
     }
-    const { displayArea, zoom = this.getZoom(), pan, rotation } = viewPres;
+    const {
+      displayArea,
+      zoom = this.getZoom(),
+      pan,
+      rotation,
+      flipHorizontal,
+      flipVertical,
+    } = viewPres;
     if (displayArea !== this.getDisplayArea()) {
       this.setDisplayArea(displayArea);
     }
@@ -1857,6 +1875,12 @@ class Viewport {
     }
     if (rotation >= 0) {
       this.setRotation(rotation);
+    }
+    if (flipHorizontal !== undefined) {
+      this.flip({ flipHorizontal });
+    }
+    if (flipVertical !== undefined) {
+      this.flip({ flipVertical });
     }
   }
 

--- a/packages/core/src/types/IViewport.ts
+++ b/packages/core/src/types/IViewport.ts
@@ -250,6 +250,16 @@ export interface ViewPresentation {
    * in zoom relative units.
    */
   pan?: Point2;
+
+  /**
+   * The flip horizontal value is true if the view is flipped horizontally.
+   */
+  flipHorizontal?: boolean;
+
+  /**
+   * The flip vertical value is true if the view is flipped vertically.
+   */
+  flipVertical?: boolean;
 }
 
 /**
@@ -279,6 +289,8 @@ export interface ViewPresentationSelector {
   displayArea?: boolean;
   zoom?: boolean;
   pan?: boolean;
+  flipHorizontal?: boolean;
+  flipVertical?: boolean;
   // Transfer function relative parameters
   windowLevel?: boolean;
   paletteLut?: boolean;

--- a/packages/core/src/utilities/actorCheck.ts
+++ b/packages/core/src/utilities/actorCheck.ts
@@ -19,7 +19,9 @@ export function actorIsA(
   actorType: actorTypes
 ): boolean {
   const actorToCheck = 'isA' in actorEntry ? actorEntry : actorEntry.actor;
-
+  if (!actorToCheck) {
+    return false;
+  }
   // @ts-expect-error
   return !!actorToCheck.isA(actorType);
 }


### PR DESCRIPTION
### Context

Flip property was being lost on new image renders, now it's returned as part of the view presentation so it's always maintained.

![CleanShot 2025-01-24 at 12 29 31](https://github.com/user-attachments/assets/e09a2dbc-655a-4510-9957-04142129eff4)

Fixes: https://github.com/OHIF/Viewers/issues/4729