### PR TITLE
fix(StackViewport): Fix patient position calculation in StackViewport CPU mode.

### DIFF
--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -2861,8 +2861,8 @@ class StackViewport extends Viewport {
     const jVector = direction.slice(3, 6) as Point3;
 
     // Calculate the world coordinate of the pixel
-    vec3.scaleAndAdd(worldPos, origin, iVector, px * spacing[0]);
-    vec3.scaleAndAdd(worldPos, worldPos, jVector, py * spacing[1]);
+    vec3.scaleAndAdd(worldPos, origin, iVector, py * spacing[0]);
+    vec3.scaleAndAdd(worldPos, worldPos, jVector, px * spacing[1]);
 
     return worldPos;
   };


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

### Context

I believe there is an error in the ImagePositionPatient calculations in the StackViewport CPU mode. The current code multiplies X coordinates (columns) with row cosines and vice versa. Because of this, in StackViewport CPU mode on non-axial volumes, my patient coordinate positioning seems to be off.

Unfortunately my cornerstone3D build fails, so I haven't been able to verify this fix.

### Changes & Results

Fix the output of the `canvasToWorldCPU`.

### Testing

My cornerstone3D build fails on my Mac and I don't have another machine handy to check my fixes, so this will be more of a theoretical fix.

I have a volume containing a coronal view. For this volume, the ImageOrientationPatient is `[0, 0, -1, 1, 0, 0]` i.e. rows are increasing towards the feet of the patient, and columns are increasing towards the left of the patient.

I've set up an image `onClick` which shows the canvas locations and world coordinates calculated by the Stack viewport in CPU mode on this volume. If I click one location on the volume, and then move a bit to the right and click again, then the X position of the canvas is slightly higher. Since higher column (X) values are increasing towards the left, I would expect the world coordinate to be slightly increasing towards the left (a higher [0] value), too.

However, because of this bug, the stack viewport accidentally takes the row cosine instead of the column cosine, so the world coordinate is instead slightly increasing towards the feet (a lower [2] value).

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: macOS"
- [x] "Node version: v23.5.0"
- [x] "Browser: Chrome 131"
