### PR TITLE
fix(imageLoader): Resolve TypeError when canceling image load requests

### DIFF
--- a/packages/core/src/loaders/imageLoader.ts
+++ b/packages/core/src/loaders/imageLoader.ts
@@ -607,6 +607,10 @@ export function cancelLoadAll(): void {
 
     Object.keys(requests).forEach((priority) => {
       const requestDetails = requests[priority].pop();
+      if (!requestDetails) {
+        return;
+      }
+
       const additionalDetails = requestDetails.additionalDetails;
       const { imageId, volumeId } = additionalDetails;
 


### PR DESCRIPTION
fixes https://github.com/cornerstonejs/cornerstone3D/issues/1747

This pull request includes a small but important change to the `cancelLoadAll` function in the `imageLoader.ts` file. The change adds a check to ensure that `requestDetails` is not null before proceeding with further operations.

* [`packages/core/src/loaders/imageLoader.ts`](diffhunk://#diff-39af41f333474ee0ab1e58aebc1c81f24defca55daaa984c625b2fc0489e348cR610-R613): Added a null check for `requestDetails` in the `cancelLoadAll` function to prevent potential runtime errors.