### PR TITLE
[OHI-1579] fix(window-level): prevent window level from being reset after modified by user

### DIFF
--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -1940,8 +1940,6 @@ class StackViewport extends Viewport {
       imagePlaneModule.columnCosines,
       columnCosines as Point3
     );
-    const isDataTypeMatching =
-      dataType === image.voxelManager.getScalarData().constructor.name;
 
     const result =
       isXSpacingValid &&
@@ -1949,8 +1947,7 @@ class StackViewport extends Viewport {
       isXVoxelsMatching &&
       isYVoxelsMatching &&
       isRowCosinesMatching &&
-      isColumnCosinesMatching &&
-      isDataTypeMatching;
+      isColumnCosinesMatching;
 
     return result;
   }
@@ -2423,6 +2420,7 @@ class StackViewport extends Viewport {
 
     // const activeCamera = this.getRenderer().getActiveCamera();
     const viewPresentation = this.getViewPresentation();
+    console.debug(viewPresentation);
 
     // Cache camera props so we can trigger one camera changed event after
     // The full transition.

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -2420,7 +2420,6 @@ class StackViewport extends Viewport {
 
     // const activeCamera = this.getRenderer().getActiveCamera();
     const viewPresentation = this.getViewPresentation();
-    console.debug(viewPresentation);
 
     // Cache camera props so we can trigger one camera changed event after
     // The full transition.


### PR DESCRIPTION
### Context

Window level was getting reset after being modified by the user, specifically on MR series. This fixes the issue

### Demo

Before:

![CleanShot 2025-01-31 at 11 40 07](https://github.com/user-attachments/assets/e26a5c2a-8d52-47ca-8687-37e986b34a4e)


After:

![CleanShot 2025-01-31 at 11 31 54](https://github.com/user-attachments/assets/e3762489-efe5-43f7-9a2c-b9b0e33e87b3)

Fixes #1770
Fixes OHI-1579
