### PR TITLE
fix(package): use itk morphology filter and polyseg dynamically

### DIFF
--- a/common/reviews/api/ai.api.md
+++ b/common/reviews/api/ai.api.md
@@ -9,7 +9,6 @@ import { Corners } from '@kitware/vtk.js/Interaction/Widgets/OrientationMarkerWi
 import type { IColorMapPreset } from '@kitware/vtk.js/Rendering/Core/ColorTransferFunction/ColorMaps';
 import type { mat3 } from 'gl-matrix';
 import { mat4 } from 'gl-matrix';
-import { MorphologicalContourInterpolationOptions } from '@itk-wasm/morphological-contour-interpolation';
 import type { Range as Range_2 } from '@kitware/vtk.js/types';
 import { vec3 } from 'gl-matrix';
 import type vtkActor from '@kitware/vtk.js/Rendering/Core/Actor';

--- a/common/reviews/api/core.api.md
+++ b/common/reviews/api/core.api.md
@@ -483,7 +483,7 @@ interface Cornerstone3DConfig {
     // (undocumented)
     isMobile: boolean;
     // (undocumented)
-    peerImport?: (moduleId: string) => any;
+    peerImport?: (moduleId: string) => Promise<any>;
     // (undocumented)
     rendering: {
         preferSizeOverAccuracy: boolean;
@@ -2775,7 +2775,7 @@ interface PatientStudyModuleMetadata {
 }
 
 // @public (undocumented)
-export function peerImport(moduleId: string): any;
+export function peerImport(moduleId: string): Promise<any>;
 
 // @public (undocumented)
 type PixelDataTypedArray = Float32Array | Int16Array | Uint16Array | Uint8Array | Int8Array | Uint8ClampedArray;

--- a/common/reviews/api/tools.api.md
+++ b/common/reviews/api/tools.api.md
@@ -9,7 +9,6 @@ import { Corners } from '@kitware/vtk.js/Interaction/Widgets/OrientationMarkerWi
 import type { IColorMapPreset } from '@kitware/vtk.js/Rendering/Core/ColorTransferFunction/ColorMaps';
 import type { mat3 } from 'gl-matrix';
 import { mat4 } from 'gl-matrix';
-import { MorphologicalContourInterpolationOptions } from '@itk-wasm/morphological-contour-interpolation';
 import type { Range as Range_2 } from '@kitware/vtk.js/types';
 import { vec3 } from 'gl-matrix';
 import type vtkActor from '@kitware/vtk.js/Rendering/Core/Actor';

--- a/packages/core/src/init.ts
+++ b/packages/core/src/init.ts
@@ -238,7 +238,7 @@ function getWebWorkerManager() {
   return webWorkerManager;
 }
 
-function peerImport(moduleId: string) {
+async function peerImport(moduleId: string) {
   return config.peerImport(moduleId);
 }
 

--- a/packages/core/src/types/Cornerstone3DConfig.ts
+++ b/packages/core/src/types/Cornerstone3DConfig.ts
@@ -38,7 +38,7 @@ interface Cornerstone3DConfig {
    * that perform lazy imports.
    */
   // eslint-disable-next-line
-  peerImport?: (moduleId: string) => any;
+  peerImport?: (moduleId: string) => Promise<any>;
 }
 
 export type { Cornerstone3DConfig as default };

--- a/packages/tools/examples/labelmapInterpolation/index.ts
+++ b/packages/tools/examples/labelmapInterpolation/index.ts
@@ -4,8 +4,6 @@ import {
   Enums,
   setVolumesForViewports,
   volumeLoader,
-  ProgressiveRetrieveImages,
-  utilities,
 } from '@cornerstonejs/core';
 import {
   initDemo,
@@ -14,7 +12,6 @@ import {
   addDropdownToToolbar,
   addSliderToToolbar,
   setCtTransferFunctionForVolumeActor,
-  getLocalUrl,
   addButtonToToolbar,
   addManipulationBindings,
 } from '../../../../utils/demo/helpers';
@@ -85,17 +82,17 @@ content.appendChild(viewportGrid);
 
 const instructions = document.createElement('p');
 instructions.innerText = `
-  Use the labelmap tools in the normal way.  Note preview is turned off for those
+  Use the labelmap tools in the normal way. Note preview is turned off for those
   tools to simplify initial segment creation.
   <br>Segments are interpolated BETWEEN slices, so you need to create two or more
   segments of the same segment index on slices in a viewport separated by at least
   one empty segment.</b>
-  Press e for extended interpolation.  This will interpolate segments which don't
+  Use "Extended Interpolation" button to interpolate segments which don't
   overlap (assuming the segments were drawn on the same slice).
-  Press i for interpolation of overlapping segments - that is, the segment must
-  overlap if drawn on the same slice to interpolate between them.  This is a good choice
+  Use "Overlapping Interpolation" button to interpolate overlapping segments - that is, the segment must
+  overlap if drawn on the same slice to interpolate between them. This is a good choice
   for multiple segments.
-  Accept the interpolation by hitting enter, or reject with escape.
+  Accept the interpolation by hitting enter, or use the "Reject Preview/Interpolation" button.
   `;
 
 content.append(instructions);
@@ -163,12 +160,22 @@ addDropdownToToolbar({
 });
 
 addButtonToToolbar({
-  title: 'Reject Preview/Interpolation',
+  title: 'Run Extended Interpolation',
   onClick: () => {
     const toolGroup = ToolGroupManager.getToolGroup(toolGroupId);
     const activeName = toolGroup.getActivePrimaryMouseButtonTool();
     const brush = toolGroup.getToolInstance(activeName);
-    brush.rejectPreview?.(element1);
+    brush.interpolate?.(element1, { extendedConfig: true });
+  },
+});
+
+addButtonToToolbar({
+  title: 'Run Overlapping Interpolation',
+  onClick: () => {
+    const toolGroup = ToolGroupManager.getToolGroup(toolGroupId);
+    const activeName = toolGroup.getActivePrimaryMouseButtonTool();
+    const brush = toolGroup.getToolInstance(activeName);
+    brush.interpolate?.(element1, { extendedConfig: false });
   },
 });
 

--- a/packages/tools/src/workers/polySegConverters.js
+++ b/packages/tools/src/workers/polySegConverters.js
@@ -2,7 +2,6 @@ import { expose } from 'comlink';
 import { utilities } from '@cornerstonejs/core';
 import vtkImageData from '@kitware/vtk.js/Common/DataModel/ImageData';
 import vtkDataArray from '@kitware/vtk.js/Common/Core/DataArray';
-import ICRPolySeg from '@icr/polyseg-wasm';
 import vtkPlane from '@kitware/vtk.js/Common/DataModel/Plane';
 import vtkPolyData from '@kitware/vtk.js/Common/DataModel/PolyData';
 import vtkContourLoopExtraction from '@kitware/vtk.js/Filters/General/ContourLoopExtraction';
@@ -41,6 +40,17 @@ const polySegConverters = {
    * This method initializes the polySeg instance and sets it to this.polySeg
    */
   async initializePolySeg(progressCallback) {
+    let ICRPolySeg;
+    try {
+      ICRPolySeg = (await import('@icr/polyseg-wasm')).default;
+    } catch (error) {
+      console.error(error);
+      console.debug(
+        "Warning: '@icr/polyseg-wasm' module not found. Please install it separately."
+      );
+      return;
+    }
+
     if (this.polySegInitializing) {
       await this.polySegInitializingPromise;
       return;
@@ -126,10 +136,7 @@ const polySegConverters = {
    */
   async convertContourToVolumeLabelmap(args, ...callbacks) {
     const [progressCallback] = callbacks;
-    const polySeg = await new ICRPolySeg();
-    await polySeg.initialize({
-      updateProgress: progressCallback,
-    });
+    await this.initializePolySeg(progressCallback);
 
     const {
       segmentIndices,
@@ -238,10 +245,7 @@ const polySegConverters = {
    */
   async convertContourToStackLabelmap(args, ...callbacks) {
     const [progressCallback] = callbacks;
-    const polySeg = await new ICRPolySeg();
-    await polySeg.initialize({
-      updateProgress: progressCallback,
-    });
+    await this.initializePolySeg(progressCallback);
 
     const { segmentationsInfo, annotationUIDsInSegmentMap, segmentIndices } =
       args;


### PR DESCRIPTION
fixes https://github.com/cornerstonejs/cornerstone3D/issues/1792

This pull request includes several changes to improve the handling of dynamic imports and update the interpolation functionality. The most important changes include converting `peerImport` to return a `Promise`, updating the interpolation buttons and functionality, and handling dynamic imports for specific modules.

### Improvements to dynamic imports:



* [`packages/tools/src/tools/segmentation/strategies/compositions/labelmapInterpolation.ts`](diffhunk://#diff-2a2fe4d662ad7d9ee559423704f2f3fb05bf0d04827eac86e2c98e6e0b8ae273L1-R22): Replaced static imports with `peerImport` for the `morphological-contour-interpolation` module. [[1]](diffhunk://#diff-2a2fe4d662ad7d9ee559423704f2f3fb05bf0d04827eac86e2c98e6e0b8ae273L1-R22) [[2]](diffhunk://#diff-2a2fe4d662ad7d9ee559423704f2f3fb05bf0d04827eac86e2c98e6e0b8ae273L39-R67)

### Updates to interpolation functionality:

* [`packages/tools/examples/labelmapInterpolation/index.ts`](diffhunk://#diff-bab36674e0088632a18780942f0136cd81470b477b5f16b38087ae51164b1185L93-R95): Updated button titles and instructions for interpolation, and added new buttons for extended and overlapping interpolation. [[1]](diffhunk://#diff-bab36674e0088632a18780942f0136cd81470b477b5f16b38087ae51164b1185L93-R95) [[2]](diffhunk://#diff-bab36674e0088632a18780942f0136cd81470b477b5f16b38087ae51164b1185L166-R178) [[3]](diffhunk://#diff-bab36674e0088632a18780942f0136cd81470b477b5f16b38087ae51164b1185L17) [[4]](diffhunk://#diff-bab36674e0088632a18780942f0136cd81470b477b5f16b38087ae51164b1185L7-L8)

### Handling dynamic imports for specific modules:

* [`packages/tools/src/workers/polySegConverters.js`](diffhunk://#diff-75f398450f57651f535bb7eba9982c9967ae5aa04b6efea393135f41c63c06f3L5): Added dynamic import handling for the `@icr/polyseg-wasm` module and updated related methods. [[1]](diffhunk://#diff-75f398450f57651f535bb7eba9982c9967ae5aa04b6efea393135f41c63c06f3L5) [[2]](diffhunk://#diff-75f398450f57651f535bb7eba9982c9967ae5aa04b6efea393135f41c63c06f3R43-R53) [[3]](diffhunk://#diff-75f398450f57651f535bb7eba9982c9967ae5aa04b6efea393135f41c63c06f3L129-R139) [[4]](diffhunk://#diff-75f398450f57651f535bb7eba9982c9967ae5aa04b6efea393135f41c63c06f3L241-R248)

