### PR TITLE
fix: the rest of packaging issue and move from timePointIndex to dimensionGroup

### DIFF
--- a/packages/tools/src/tools/segmentation/strategies/compositions/labelmapInterpolation.ts
+++ b/packages/tools/src/tools/segmentation/strategies/compositions/labelmapInterpolation.ts
@@ -39,7 +39,10 @@ export default {
       };
       previewVoxelManager.forEach(callback);
     }
-    const inputImage = getItkImage(segmentationImageData, 'interpolation');
+    const inputImage = await getItkImage(
+      segmentationImageData,
+      'interpolation'
+    );
 
     let itkModule;
     try {

--- a/packages/tools/src/tools/segmentation/strategies/utils/getItkImage.ts
+++ b/packages/tools/src/tools/segmentation/strategies/utils/getItkImage.ts
@@ -1,19 +1,3 @@
-import type { Metadata } from 'itk-wasm';
-import { Image, ImageType, IntTypes, FloatTypes, PixelTypes } from 'itk-wasm';
-
-const dataTypesMap = {
-  Int8: IntTypes.Int8,
-  UInt8: IntTypes.UInt8,
-  Int16: IntTypes.Int16,
-  UInt16: IntTypes.UInt16,
-  Int32: IntTypes.Int32,
-  UInt32: IntTypes.UInt32,
-  Int64: IntTypes.Int64,
-  UInt64: IntTypes.UInt64,
-  Float32: FloatTypes.Float32,
-  Float64: FloatTypes.Float64,
-};
-
 /**
  * Get the ITK Image from the image data
  *
@@ -21,7 +5,27 @@ const dataTypesMap = {
  * @param imageName - Any random name that shall be set in the image
  * @returns An ITK Image that can be used as fixed or moving image
  */
-export default function getItkImage(imageData, imageName?: string): Image {
+export default async function getItkImage(
+  imageData,
+  imageName?: string
+): Promise<unknown> {
+  const { Image, ImageType, IntTypes, FloatTypes, PixelTypes } = await import(
+    'itk-wasm'
+  );
+
+  const dataTypesMap = {
+    Int8: IntTypes.Int8,
+    UInt8: IntTypes.UInt8,
+    Int16: IntTypes.Int16,
+    UInt16: IntTypes.UInt16,
+    Int32: IntTypes.Int32,
+    UInt32: IntTypes.UInt32,
+    Int64: IntTypes.Int64,
+    UInt64: IntTypes.UInt64,
+    Float32: FloatTypes.Float32,
+    Float64: FloatTypes.Float64,
+  };
+
   const { voxelManager } = imageData.get('voxelManager');
   const { numberOfComponents } = imageData.get('numberOfComponents');
   const scalarData = voxelManager.getCompleteScalarDataArray();
@@ -34,8 +38,8 @@ export default function getItkImage(imageData, imageName?: string): Image {
   const dataType = scalarData.constructor.name
     .replace(/^Ui/, 'UI')
     .replace(/Array$/, '');
-  const metadata: Metadata = undefined;
-  const imageType: ImageType = new ImageType(
+  const metadata = undefined;
+  const imageType = new ImageType(
     dimensions.length,
     dataTypesMap[dataType],
     PixelTypes.Scalar,

--- a/packages/tools/src/utilities/cine/playClip.ts
+++ b/packages/tools/src/utilities/cine/playClip.ts
@@ -510,10 +510,10 @@ function _createDynamicVolumeViewportCinePlayContext(
 ): CINETypes.CinePlayContext {
   return {
     get numScrollSteps(): number {
-      return volume.numTimePoints;
+      return volume.numDimensionGroups;
     },
     get currentStepIndex(): number {
-      return volume.timePointIndex;
+      return volume.dimensionGroupNumber;
     },
     get frameTimeVectorEnabled(): boolean {
       // Looping though time does not uses frameTimeVector


### PR DESCRIPTION
This pull request includes several changes to improve the segmentation and cine play functionalities in the project. The most important changes include updating the `getItkImage` function to be asynchronous, modifying the usage of `numTimePoints` and `timePointIndex` in the cine play context, and adding detailed documentation for the `getItkImage` function.

Improvements to segmentation functionality:

* [`packages/tools/src/tools/segmentation/strategies/compositions/labelmapInterpolation.ts`](diffhunk://#diff-2a2fe4d662ad7d9ee559423704f2f3fb05bf0d04827eac86e2c98e6e0b8ae273L42-R45): Updated the `getItkImage` function call to be asynchronous.
* [`packages/tools/src/tools/segmentation/strategies/utils/getItkImage.ts`](diffhunk://#diff-21cd09eefc1e48abb77b8b89998bd671b4328df847ef73c21dde05cfb4317479L1-R14): Converted the `getItkImage` function to an asynchronous function and added detailed documentation. [[1]](diffhunk://#diff-21cd09eefc1e48abb77b8b89998bd671b4328df847ef73c21dde05cfb4317479L1-R14) [[2]](diffhunk://#diff-21cd09eefc1e48abb77b8b89998bd671b4328df847ef73c21dde05cfb4317479L17-L24) [[3]](diffhunk://#diff-21cd09eefc1e48abb77b8b89998bd671b4328df847ef73c21dde05cfb4317479L37-R42)

Enhancements to cine play functionality:

* [`packages/tools/src/utilities/cine/playClip.ts`](diffhunk://#diff-7d179e40cf3e8d173095cb00390ee226e659dc9b71e006987d2bc49b8521c394L513-R516): Modified the cine play context to use `numDimensionGroups` and `dimensionGroupNumber` instead of `numTimePoints` and `timePointIndex`.