### PR TITLE
fix(viewport): Prevent flickering during viewport flip operations

### DIFF
--- a/packages/core/src/RenderingEngine/Viewport.ts
+++ b/packages/core/src/RenderingEngine/Viewport.ts
@@ -1877,7 +1877,13 @@ class Viewport {
       this.setRotation(rotation);
     }
 
-    this.flip({ flipHorizontal, flipVertical });
+    // flip operation requires another re-render to take effect, so unfortunately
+    // right now if the view presentation requires a flip, it will flicker. The
+    // correct way to handle this is to wait for camera and flip together and then
+    // do one render
+    if (flipHorizontal || flipVertical) {
+      this.flip({ flipHorizontal, flipVertical });
+    }
   }
 
   _getCorners(bounds: number[]): number[][] {


### PR DESCRIPTION
fyi @IbrahimCSAE 

The change addresses the handling of flip operations to reduce flickering during rendering.

Rendering improvements:

* [`packages/core/src/RenderingEngine/Viewport.ts`](diffhunk://#diff-820bdf434bace4e9e622da846acb70b98bf9fd157b6392bc2b3a78d03bdcea76R1880-R1887): Added a check for `flipHorizontal` or `flipVertical` to ensure the view presentation requires a flip, which triggers another re-render to take effect. This aims to reduce flickering by waiting for the camera and flip operations to complete together before rendering.