### PR TITLE
Updating proper values for ChangeType parameter in AnnotationModifiedEventDetail.

### DIFF
--- a/packages/tools/src/enums/ChangeTypes.ts
+++ b/packages/tools/src/enums/ChangeTypes.ts
@@ -42,6 +42,10 @@ enum ChangeTypes {
    * so as to cause it to be drawn on the change, or removed if it is no longer visible.
    */
   MetadataReferenceModified = 'MetadataReferenceModified',
+  /**
+   * Occurs when an annotation label is updated.
+   */
+  LabelChange = 'LabelChange',
 }
 
 export default ChangeTypes;

--- a/packages/tools/src/tools/SculptorTool.ts
+++ b/packages/tools/src/tools/SculptorTool.ts
@@ -10,7 +10,12 @@ import type {
   ContourAnnotation,
 } from '../types';
 import { point } from '../utilities/math';
-import { Events, ToolModes, AnnotationStyleStates } from '../enums';
+import {
+  Events,
+  ToolModes,
+  AnnotationStyleStates,
+  ChangeTypes,
+} from '../enums';
 import { triggerAnnotationRenderForViewportIds } from '../utilities/triggerAnnotationRenderForViewportIds';
 import {
   hideElementCursor,
@@ -428,7 +433,11 @@ class SculptorTool extends BaseTool {
       activeAnnotation.invalidated = true;
     }
 
-    triggerAnnotationModified(activeAnnotation, element);
+    triggerAnnotationModified(
+      activeAnnotation,
+      element,
+      ChangeTypes.HandlesUpdated
+    );
   };
 
   /**

--- a/packages/tools/src/tools/annotation/AngleTool.ts
+++ b/packages/tools/src/tools/annotation/AngleTool.ts
@@ -1,4 +1,4 @@
-import { Events } from '../../enums';
+import { ChangeTypes, Events } from '../../enums';
 import {
   getEnabledElement,
   utilities as csUtils,
@@ -477,6 +477,14 @@ class AngleTool extends AnnotationTool {
     const { renderingEngine } = enabledElement;
 
     triggerAnnotationRenderForViewportIds(viewportIdsToRender);
+
+    if (annotation.invalidated) {
+      triggerAnnotationModified(
+        annotation,
+        element,
+        ChangeTypes.HandlesUpdated
+      );
+    }
   };
 
   cancel = (element: HTMLDivElement) => {
@@ -874,7 +882,7 @@ class AngleTool extends AnnotationTool {
     annotation.invalidated = false;
 
     // Dispatching annotation modified
-    triggerAnnotationModified(annotation, element);
+    triggerAnnotationModified(annotation, element, ChangeTypes.StatsUpdated);
 
     return cachedStats;
   }

--- a/packages/tools/src/tools/annotation/ArrowAnnotateTool.ts
+++ b/packages/tools/src/tools/annotation/ArrowAnnotateTool.ts
@@ -45,6 +45,7 @@ import type {
 import type { ArrowAnnotation } from '../../types/ToolSpecificAnnotationTypes';
 import type { StyleSpecifier } from '../../types/AnnotationStyle';
 import { isAnnotationVisible } from '../../stateManagement/annotation/annotationVisibility';
+import { setAnnotationLabel } from '../../utilities';
 
 class ArrowAnnotateTool extends AnnotationTool {
   static toolName = 'ArrowAnnotate';
@@ -394,6 +395,7 @@ class ArrowAnnotateTool extends AnnotationTool {
         triggerAnnotationCompleted(annotation);
         // This is only new if it wasn't already memoed
         this.createMemo(element, annotation, { newAnnotation: !!this.memo });
+        setAnnotationLabel(annotation, element, text);
 
         triggerAnnotationRenderForViewportIds(viewportIdsToRender);
       });

--- a/packages/tools/src/tools/annotation/ArrowAnnotateTool.ts
+++ b/packages/tools/src/tools/annotation/ArrowAnnotateTool.ts
@@ -1,4 +1,4 @@
-import { Events } from '../../enums';
+import { ChangeTypes, Events } from '../../enums';
 import {
   getEnabledElement,
   utilities as csUtils,
@@ -352,8 +352,13 @@ class ArrowAnnotateTool extends AnnotationTool {
     const eventDetail = evt.detail;
     const { element } = eventDetail;
 
-    const { annotation, viewportIdsToRender, newAnnotation, hasMoved } =
-      this.editData;
+    const {
+      annotation,
+      viewportIdsToRender,
+      newAnnotation,
+      hasMoved,
+      movingTextBox,
+    } = this.editData;
     const { data } = annotation;
 
     if (newAnnotation && !hasMoved) {
@@ -392,8 +397,12 @@ class ArrowAnnotateTool extends AnnotationTool {
 
         triggerAnnotationRenderForViewportIds(viewportIdsToRender);
       });
-    } else {
-      triggerAnnotationModified(annotation, element);
+    } else if (!movingTextBox) {
+      triggerAnnotationModified(
+        annotation,
+        element,
+        ChangeTypes.HandlesUpdated
+      );
     }
 
     this.doneEditMemo();

--- a/packages/tools/src/tools/annotation/BidirectionalTool.ts
+++ b/packages/tools/src/tools/annotation/BidirectionalTool.ts
@@ -22,7 +22,7 @@ import {
   drawLinkedTextBox as drawLinkedTextBoxSvg,
 } from '../../drawingSvg';
 import { state } from '../../store/state';
-import { Events } from '../../enums';
+import { ChangeTypes, Events } from '../../enums';
 import { getViewportIdsWithToolToRender } from '../../utilities/viewportFilters';
 import * as lineSegment from '../../utilities/math/line';
 import { getTextBoxCoordsCanvas } from '../../utilities/drawing';
@@ -568,6 +568,7 @@ class BidirectionalTool extends AnnotationTool {
     annotation.invalidated = true;
     triggerAnnotationRenderForViewportIds(viewportIdsToRender);
 
+    triggerAnnotationModified(annotation, element, ChangeTypes.HandlesUpdated);
     this.editData.hasMoved = true;
   };
 
@@ -620,6 +621,14 @@ class BidirectionalTool extends AnnotationTool {
     }
 
     triggerAnnotationRenderForViewportIds(viewportIdsToRender);
+
+    if (annotation.invalidated) {
+      triggerAnnotationModified(
+        annotation,
+        element,
+        ChangeTypes.HandlesUpdated
+      );
+    }
   };
 
   /**
@@ -1313,7 +1322,7 @@ class BidirectionalTool extends AnnotationTool {
     annotation.invalidated = false;
 
     // Dispatching annotation modified
-    triggerAnnotationModified(annotation, element);
+    triggerAnnotationModified(annotation, element, ChangeTypes.StatsUpdated);
 
     return cachedStats;
   };

--- a/packages/tools/src/tools/annotation/CircleROITool.ts
+++ b/packages/tools/src/tools/annotation/CircleROITool.ts
@@ -30,7 +30,7 @@ import {
   drawLinkedTextBox as drawLinkedTextBoxSvg,
 } from '../../drawingSvg';
 import { state } from '../../store/state';
-import { Events } from '../../enums';
+import { ChangeTypes, Events } from '../../enums';
 import { getViewportIdsWithToolToRender } from '../../utilities/viewportFilters';
 import { getTextBoxCoordsCanvas } from '../../utilities/drawing';
 import getWorldWidthAndHeightFromTwoPoints from '../../utilities/planar/getWorldWidthAndHeightFromTwoPoints';
@@ -431,6 +431,8 @@ class CircleROITool extends AnnotationTool {
     this.editData.hasMoved = true;
 
     triggerAnnotationRenderForViewportIds(viewportIdsToRender);
+
+    triggerAnnotationModified(annotation, element, ChangeTypes.HandlesUpdated);
   };
 
   _dragModifyCallback = (evt: EventTypes.InteractionEventType): void => {
@@ -482,6 +484,14 @@ class CircleROITool extends AnnotationTool {
     const { renderingEngine } = enabledElement;
 
     triggerAnnotationRenderForViewportIds(viewportIdsToRender);
+
+    if (annotation.invalidated) {
+      triggerAnnotationModified(
+        annotation,
+        element,
+        ChangeTypes.HandlesUpdated
+      );
+    }
   };
 
   _dragHandle = (evt: EventTypes.InteractionEventType): void => {
@@ -1012,7 +1022,7 @@ class CircleROITool extends AnnotationTool {
     annotation.invalidated = false;
 
     // Dispatching annotation modified
-    triggerAnnotationModified(annotation, element);
+    triggerAnnotationModified(annotation, element, ChangeTypes.StatsUpdated);
 
     return cachedStats;
   };

--- a/packages/tools/src/tools/annotation/CobbAngleTool.ts
+++ b/packages/tools/src/tools/annotation/CobbAngleTool.ts
@@ -1,5 +1,5 @@
 import { vec3 } from 'gl-matrix';
-import { Events } from '../../enums';
+import { ChangeTypes, Events } from '../../enums';
 import { getEnabledElement } from '@cornerstonejs/core';
 import type { Types } from '@cornerstonejs/core';
 
@@ -477,6 +477,14 @@ class CobbAngleTool extends AnnotationTool {
     const { renderingEngine } = enabledElement;
 
     triggerAnnotationRenderForViewportIds(viewportIdsToRender);
+
+    if (annotation.invalidated) {
+      triggerAnnotationModified(
+        annotation,
+        element,
+        ChangeTypes.HandlesUpdated
+      );
+    }
   };
 
   cancel = (element: HTMLDivElement) => {
@@ -1024,7 +1032,7 @@ class CobbAngleTool extends AnnotationTool {
     annotation.invalidated = false;
 
     // Dispatching annotation modified
-    triggerAnnotationModified(annotation, element);
+    triggerAnnotationModified(annotation, element, ChangeTypes.StatsUpdated);
 
     return cachedStats;
   }

--- a/packages/tools/src/tools/annotation/EllipticalROITool.ts
+++ b/packages/tools/src/tools/annotation/EllipticalROITool.ts
@@ -28,7 +28,7 @@ import {
   drawLinkedTextBox as drawLinkedTextBoxSvg,
 } from '../../drawingSvg';
 import { state } from '../../store/state';
-import { Events } from '../../enums';
+import { ChangeTypes, Events } from '../../enums';
 import { getViewportIdsWithToolToRender } from '../../utilities/viewportFilters';
 import { getTextBoxCoordsCanvas } from '../../utilities/drawing';
 import getWorldWidthAndHeightFromTwoPoints from '../../utilities/planar/getWorldWidthAndHeightFromTwoPoints';
@@ -550,6 +550,7 @@ class EllipticalROITool extends AnnotationTool {
     this.editData.hasMoved = true;
 
     triggerAnnotationRenderForViewportIds(viewportIdsToRender);
+    triggerAnnotationModified(annotation, element, ChangeTypes.HandlesUpdated);
   };
 
   _dragModifyCallback = (evt: EventTypes.InteractionEventType): void => {
@@ -601,6 +602,14 @@ class EllipticalROITool extends AnnotationTool {
     const { renderingEngine } = enabledElement;
 
     triggerAnnotationRenderForViewportIds(viewportIdsToRender);
+
+    if (annotation.invalidated) {
+      triggerAnnotationModified(
+        annotation,
+        element,
+        ChangeTypes.HandlesUpdated
+      );
+    }
   };
 
   _dragHandle = (evt: EventTypes.InteractionEventType): void => {
@@ -1163,7 +1172,7 @@ class EllipticalROITool extends AnnotationTool {
     annotation.invalidated = false;
 
     // Dispatching annotation modified
-    triggerAnnotationModified(annotation, element);
+    triggerAnnotationModified(annotation, element, ChangeTypes.StatsUpdated);
 
     return cachedStats;
   };

--- a/packages/tools/src/tools/annotation/LengthTool.ts
+++ b/packages/tools/src/tools/annotation/LengthTool.ts
@@ -1,4 +1,4 @@
-import { Events } from '../../enums';
+import { Events, ChangeTypes } from '../../enums';
 import {
   getEnabledElement,
   utilities as csUtils,
@@ -703,7 +703,12 @@ class LengthTool extends AnnotationTool {
           unit: null,
         };
 
-        this._calculateCachedStats(annotation, renderingEngine, enabledElement);
+        this._calculateCachedStats(
+          annotation,
+          renderingEngine,
+          enabledElement,
+          ChangeTypes.StatsUpdated
+        );
       } else if (annotation.invalidated) {
         this._throttledCalculateCachedStats(
           annotation,
@@ -836,7 +841,12 @@ class LengthTool extends AnnotationTool {
     return Math.sqrt(dx * dx + dy * dy + dz * dz);
   }
 
-  _calculateCachedStats(annotation, renderingEngine, enabledElement) {
+  _calculateCachedStats(
+    annotation,
+    renderingEngine,
+    enabledElement,
+    changeType
+  ) {
     const data = annotation.data;
     const { element } = enabledElement.viewport;
 
@@ -888,7 +898,7 @@ class LengthTool extends AnnotationTool {
     annotation.invalidated = false;
 
     // Dispatching annotation modified
-    triggerAnnotationModified(annotation, element);
+    triggerAnnotationModified(annotation, element, changeType);
 
     return cachedStats;
   }

--- a/packages/tools/src/tools/annotation/LengthTool.ts
+++ b/packages/tools/src/tools/annotation/LengthTool.ts
@@ -481,6 +481,14 @@ class LengthTool extends AnnotationTool {
     this.editData.hasMoved = true;
 
     triggerAnnotationRenderForViewportIds(viewportIdsToRender);
+
+    if (annotation.invalidated) {
+      triggerAnnotationModified(
+        annotation,
+        element,
+        ChangeTypes.HandlesUpdated
+      );
+    }
   };
 
   cancel = (element: HTMLDivElement) => {
@@ -703,12 +711,7 @@ class LengthTool extends AnnotationTool {
           unit: null,
         };
 
-        this._calculateCachedStats(
-          annotation,
-          renderingEngine,
-          enabledElement,
-          ChangeTypes.StatsUpdated
-        );
+        this._calculateCachedStats(annotation, renderingEngine, enabledElement);
       } else if (annotation.invalidated) {
         this._throttledCalculateCachedStats(
           annotation,
@@ -841,12 +844,7 @@ class LengthTool extends AnnotationTool {
     return Math.sqrt(dx * dx + dy * dy + dz * dz);
   }
 
-  _calculateCachedStats(
-    annotation,
-    renderingEngine,
-    enabledElement,
-    changeType
-  ) {
+  _calculateCachedStats(annotation, renderingEngine, enabledElement) {
     const data = annotation.data;
     const { element } = enabledElement.viewport;
 
@@ -898,7 +896,7 @@ class LengthTool extends AnnotationTool {
     annotation.invalidated = false;
 
     // Dispatching annotation modified
-    triggerAnnotationModified(annotation, element, changeType);
+    triggerAnnotationModified(annotation, element, ChangeTypes.StatsUpdated);
 
     return cachedStats;
   }

--- a/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
+++ b/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
@@ -685,7 +685,7 @@ class PlanarFreehandROITool extends ContourSegmentationBaseTool {
       const { data } = annotation;
       if (
         !data.cachedStats[targetId] ||
-        data.cachedStats[targetId].areaUnit == null
+        data.cachedStats[targetId].areaUnit === null
       ) {
         data.cachedStats[targetId] = {
           Modality: null,

--- a/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
+++ b/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
@@ -684,10 +684,7 @@ class PlanarFreehandROITool extends ContourSegmentationBaseTool {
     if (!this.commonData?.movingTextBox) {
       const { data } = annotation;
       const { closed } = data.contour;
-      if (
-        !data.cachedStats[targetId] ||
-        (closed && !data.cachedStats[targetId]?.areaUnit)
-      ) {
+      if (!data.cachedStats[targetId] || !data.cachedStats[targetId]?.unit) {
         data.cachedStats[targetId] = {
           Modality: null,
           area: null,
@@ -695,6 +692,7 @@ class PlanarFreehandROITool extends ContourSegmentationBaseTool {
           mean: null,
           stdDev: null,
           areaUnit: null,
+          unit: null,
         };
 
         this._calculateCachedStats(

--- a/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
+++ b/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
@@ -683,8 +683,7 @@ class PlanarFreehandROITool extends ContourSegmentationBaseTool {
 
     if (!this.commonData?.movingTextBox) {
       const { data } = annotation;
-      const { closed } = data.contour;
-      if (!data.cachedStats[targetId] || !data.cachedStats[targetId]?.unit) {
+      if (!data.cachedStats[targetId]?.unit) {
         data.cachedStats[targetId] = {
           Modality: null,
           area: null,

--- a/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
+++ b/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
@@ -683,9 +683,10 @@ class PlanarFreehandROITool extends ContourSegmentationBaseTool {
 
     if (!this.commonData?.movingTextBox) {
       const { data } = annotation;
+      const { closed } = data.contour;
       if (
         !data.cachedStats[targetId] ||
-        data.cachedStats[targetId].areaUnit === null
+        (closed && !data.cachedStats[targetId]?.areaUnit)
       ) {
         data.cachedStats[targetId] = {
           Modality: null,

--- a/packages/tools/src/tools/annotation/RectangleROITool.ts
+++ b/packages/tools/src/tools/annotation/RectangleROITool.ts
@@ -27,7 +27,7 @@ import {
   drawRectByCoordinates as drawRectSvg,
 } from '../../drawingSvg';
 import { state } from '../../store/state';
-import { Events } from '../../enums';
+import { ChangeTypes, Events } from '../../enums';
 import { getViewportIdsWithToolToRender } from '../../utilities/viewportFilters';
 import * as rectangle from '../../utilities/math/rectangle';
 import { getTextBoxCoordsCanvas } from '../../utilities/drawing';
@@ -477,6 +477,14 @@ class RectangleROITool extends AnnotationTool {
     const enabledElement = getEnabledElement(element);
 
     triggerAnnotationRenderForViewportIds(viewportIdsToRender);
+
+    if (annotation.invalidated) {
+      triggerAnnotationModified(
+        annotation,
+        element,
+        ChangeTypes.HandlesUpdated
+      );
+    }
   };
 
   cancel = (element: HTMLDivElement) => {
@@ -954,7 +962,7 @@ class RectangleROITool extends AnnotationTool {
     annotation.invalidated = false;
 
     // Dispatching annotation modified
-    triggerAnnotationModified(annotation, element);
+    triggerAnnotationModified(annotation, element, ChangeTypes.StatsUpdated);
 
     return cachedStats;
   };

--- a/packages/tools/src/tools/annotation/planarFreehandROITool/drawLoop.ts
+++ b/packages/tools/src/tools/annotation/planarFreehandROITool/drawLoop.ts
@@ -3,7 +3,7 @@ import {
   resetElementCursor,
   hideElementCursor,
 } from '../../../cursors/elementCursor';
-import { Events } from '../../../enums';
+import { ChangeTypes, Events } from '../../../enums';
 import type { EventTypes } from '../../../types';
 import { state } from '../../../store/state';
 import { vec3 } from 'gl-matrix';
@@ -13,7 +13,10 @@ import {
 } from '../../../utilities/planarFreehandROITool/smoothPoints';
 import getMouseModifierKey from '../../../eventDispatchers/shared/getMouseModifier';
 import triggerAnnotationRenderForViewportIds from '../../../utilities/triggerAnnotationRenderForViewportIds';
-import { triggerContourAnnotationCompleted } from '../../../stateManagement/annotation/helpers/state';
+import {
+  triggerAnnotationModified,
+  triggerContourAnnotationCompleted,
+} from '../../../stateManagement/annotation/helpers/state';
 import type { PlanarFreehandROIAnnotation } from '../../../types/ToolSpecificAnnotationTypes';
 import findOpenUShapedContourVectorToPeak from './findOpenUShapedContourVectorToPeak';
 import { polyline } from '../../../utilities/math';
@@ -170,9 +173,13 @@ function mouseDragDrawCallback(evt: EventTypes.InteractionEventType): void {
 
       this.drawData.polylineIndex = polylineIndex + numPointsAdded;
     }
+    annotation.invalidated = true;
   }
 
   triggerAnnotationRenderForViewportIds(viewportIdsToRender);
+  if (annotation.invalidated) {
+    triggerAnnotationModified(annotation, element, ChangeTypes.HandlesUpdated);
+  }
 }
 
 /**

--- a/packages/tools/src/types/AnnotationTypes.ts
+++ b/packages/tools/src/types/AnnotationTypes.ts
@@ -53,7 +53,7 @@ type Annotation = {
    */
   data: {
     /** Annotation handles that are grabbable for manipulation */
-    handles?: handles;
+    handles?: Handles;
     [key: string]: unknown;
     /** Cached Annotation statistics which is specific to the tool */
     cachedStats?: Record<string, unknown>;
@@ -84,7 +84,7 @@ type AnnotationState = {
   [key: string]: GroupSpecificAnnotations;
 };
 
-type handles = {
+type Handles = {
   /** world location of the handles in the space */
   points?: Types.Point3[];
   /** index of the active handle being manipulated */
@@ -115,4 +115,5 @@ export type {
   Annotations,
   GroupSpecificAnnotations,
   AnnotationState,
+  Handles,
 };

--- a/packages/tools/src/types/AnnotationTypes.ts
+++ b/packages/tools/src/types/AnnotationTypes.ts
@@ -53,31 +53,7 @@ type Annotation = {
    */
   data: {
     /** Annotation handles that are grabbable for manipulation */
-    handles?: {
-      /** world location of the handles in the space */
-      points?: Types.Point3[];
-      /** index of the active handle being manipulated */
-      activeHandleIndex?: number | null;
-      /** annotation text box information */
-      textBox?: {
-        /** whether the text box has moved */
-        hasMoved?: boolean;
-        /** the world location of the text box */
-        worldPosition?: Types.Point3;
-        /** text box bounding box information */
-        worldBoundingBox?: {
-          /** Top left location of the text box in the world space */
-          topLeft: Types.Point3;
-          /** Top right location of the text box in the world space */
-          topRight: Types.Point3;
-          /** Bottom left location of the text box in the world space */
-          bottomLeft: Types.Point3;
-          /** Bottom right location of the text box in the world space */
-          bottomRight: Types.Point3;
-        };
-      };
-      [key: string]: unknown;
-    };
+    handles?: handles;
     [key: string]: unknown;
     /** Cached Annotation statistics which is specific to the tool */
     cachedStats?: Record<string, unknown>;
@@ -106,6 +82,32 @@ type AnnotationState = {
    * that works for a different use case and use a different key.
    */
   [key: string]: GroupSpecificAnnotations;
+};
+
+type handles = {
+  /** world location of the handles in the space */
+  points?: Types.Point3[];
+  /** index of the active handle being manipulated */
+  activeHandleIndex?: number | null;
+  /** annotation text box information */
+  textBox?: {
+    /** whether the text box has moved */
+    hasMoved?: boolean;
+    /** the world location of the text box */
+    worldPosition?: Types.Point3;
+    /** text box bounding box information */
+    worldBoundingBox?: {
+      /** Top left location of the text box in the world space */
+      topLeft: Types.Point3;
+      /** Top right location of the text box in the world space */
+      topRight: Types.Point3;
+      /** Bottom left location of the text box in the world space */
+      bottomLeft: Types.Point3;
+      /** Bottom right location of the text box in the world space */
+      bottomRight: Types.Point3;
+    };
+  };
+  [key: string]: unknown;
 };
 
 export type {

--- a/packages/tools/src/types/AnnotationTypes.ts
+++ b/packages/tools/src/types/AnnotationTypes.ts
@@ -81,6 +81,8 @@ type Annotation = {
     [key: string]: unknown;
     /** Cached Annotation statistics which is specific to the tool */
     cachedStats?: Record<string, unknown>;
+    /** Label of an annotation */
+    label?: string;
   };
 };
 

--- a/packages/tools/src/types/ToolSpecificAnnotationTypes.ts
+++ b/packages/tools/src/types/ToolSpecificAnnotationTypes.ts
@@ -12,6 +12,7 @@ export interface ROICachedStats {
     max: number;
     mean: number;
     stdDev: number;
+    unit?: number;
   };
 }
 

--- a/packages/tools/src/utilities/index.ts
+++ b/packages/tools/src/utilities/index.ts
@@ -55,6 +55,7 @@ import {
   getPixelValueUnitsImageId,
 } from './getPixelValueUnits';
 import * as geometricSurfaceUtils from './geometricSurfaceUtils';
+import setAnnotationLabel from './setAnnotationLabel';
 
 export {
   math,
@@ -102,4 +103,5 @@ export {
   normalizeViewportPlane,
   IslandRemoval,
   geometricSurfaceUtils,
+  setAnnotationLabel,
 };

--- a/packages/tools/src/utilities/setAnnotationLabel.ts
+++ b/packages/tools/src/utilities/setAnnotationLabel.ts
@@ -1,0 +1,12 @@
+import type { Annotation } from '../types/AnnotationTypes';
+import { triggerAnnotationModified } from '../stateManagement/annotation/helpers/state';
+import { ChangeTypes } from '../enums';
+
+export default function setAnnotationLabel(
+  annotation: Annotation,
+  element: HTMLDivElement,
+  updatedLabel: string
+) {
+  annotation.data.label = updatedLabel;
+  triggerAnnotationModified(annotation, element, ChangeTypes.LabelChange);
+}


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
--> 
Updated ChangeType parameter value in AnnotationModifiedEventDetail for LengthTool
### Changes & Results
The ```ChangeType```parameter in ```AnnotationModifiedEventDetail``` now returns ```StatsUpdated``` following the execution of the ```_calculateCachedStats``` function, it returns ```HandlesUpdated``` when the handle position is modified.

The ```initialSetup``` change type can be fired from addNewAnnotation(), we currently left it out. Please let us know if you think it should be there as cs3d already has a annotation created event for it. Should we remove the change type InitialSetup ?

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
