### PR TITLE
fix(rendering): fix image overflow issues by restoring data type check, and fix window level to be maintained if it was modified by the user and image data can't be reused

### DIFF
--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -1940,6 +1940,8 @@ class StackViewport extends Viewport {
       imagePlaneModule.columnCosines,
       columnCosines as Point3
     );
+    const isDataTypeMatching =
+      dataType === image.voxelManager.getScalarData().constructor.name;
 
     const result =
       isXSpacingValid &&
@@ -1947,7 +1949,8 @@ class StackViewport extends Viewport {
       isXVoxelsMatching &&
       isYVoxelsMatching &&
       isRowCosinesMatching &&
-      isColumnCosinesMatching;
+      isColumnCosinesMatching &&
+      isDataTypeMatching;
 
     return result;
   }
@@ -2540,7 +2543,7 @@ class StackViewport extends Viewport {
 
   private _getInitialVOIRange(image: IImage) {
     if (this.voiRange && this.voiUpdatedWithSetProperties) {
-      return this.globalDefaultProperties.voiRange;
+      return this.voiRange;
     }
     const { windowCenter, windowWidth, voiLUTFunction } = image;
 


### PR DESCRIPTION
### Context

Some MR images were overflowing and not rendering correctly because we were no longer checking the data type, this has been restored. A fix for the window level has been added to also maintain it if the image data can't be re-used
