### PR TITLE
fix(labelmap): apply styles based on active segment index

### DIFF
--- a/packages/tools/src/tools/displayTools/Labelmap/labelmapDisplay.ts
+++ b/packages/tools/src/tools/displayTools/Labelmap/labelmapDisplay.ts
@@ -238,10 +238,15 @@ function _setLabelmapColorAndOpacity(
 
     const segmentSpecificLabelmapConfig = perSegmentStyle;
 
+    const isActive =
+      activeSegmentation.segmentationId === segmentationId &&
+      segmentIndex in activeSegmentation.segments &&
+      activeSegmentation.segments[segmentIndex].active;
+
     const { fillAlpha, outlineWidth, renderFill, renderOutline } =
       _getLabelmapConfig(
         labelmapStyle as LabelmapStyle,
-        isActiveLabelmap,
+        isActive,
         segmentSpecificLabelmapConfig
       );
 


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

While rendering, segment styles such as opacity, fill etc do not consider active segment based on its index.
This issue was partly fixed via https://github.com/cornerstonejs/cornerstone3D/pull/1833, but only for Contour, so I’ve made some updates for Labelmap.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
Active segmentationId along with the segmentIndex should determine whether a segment is active or not.


https://github.com/user-attachments/assets/0c793336-80c1-400c-b552-e15031a1c78d



<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

- [] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
