### PR TITLE
fix(VolumeViewport) fix viewportProperties on VolumeViewport setOrientation

### DIFF
--- a/packages/core/src/RenderingEngine/VolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/VolumeViewport.ts
@@ -192,6 +192,7 @@ class VolumeViewport extends BaseVolumeViewport {
       this.viewportProperties.orientation = orientation;
       this.resetCamera();
     } else {
+      this.viewportProperties.orientation = undefined;
       ({ viewPlaneNormal, viewUp } = orientation);
       this.applyViewOrientation(orientation);
     }


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

We have an OHIF extension where we display MRI on volume viewports. 

We align the camera's viewPlaneNormal with the volume direction cosine that most fit the axial orientation. On some images, the volume orientation will match the patient orientation (eg [0,0,1]), but sometimes won't (eg. image has been co-registered).

When changing volumes in the same viewport (one of which has a non patient-aligned direction cosine), cornerstone will enter a recursive call stack that end up in a stack overflow and crashing the tab. 

_I can see it happens only because there is a warning (about CrossHair on volume viewport not being enabled) that gets printed on the console +10k times before it crashes._

---

I'm having a hard time coming up with a minimal reproducible example (volume viewports in the OHIF demo are aligned with the patient axis and do not trigger this issue), but I can point down where it's happening:

When changing volumes in a viewport, the following function stack is invoked:
```
setViewReference (BaseVolumeViewport.js:520)
_setPositionPresentation (CornerstoneViewportService.ts:1144)
setPresentations (CornerstoneViewportService.ts:222)
setVolumesForViewport (CornerstoneViewportService.ts:852)
await in setVolumesForViewport
_setVolumeViewport (CornerstoneViewportService.ts:798)
_setDisplaySets (CornerstoneViewportService.ts:972)
setViewportData (CornerstoneViewportService.ts:459)
loadViewportData (OHIFCornerstoneViewport.tsx:280)
...
```

In `setViewReference`, when the new view reference normal is not aligned with the previous one, [a call to `setOrientation` followed by `setViewReference` is done ](https://github.com/cornerstonejs/cornerstone3D/blob/c31c5a2c61b257926e6331d319198110820fc5fa/packages/core/src/RenderingEngine/BaseVolumeViewport.ts#L743)

The main issue seems to be that `setOrientation` fails to actually update the orientation and therefore start recursively calling setViewReference.

`setOrientation` will change the orientation for some `OrientationVectors` but does not remove the `viewportProperties.orientation` value (which is some case can be defined, such as `axial` from the previous volume). 

This  will ultimately lead to [`applyViewOrientation`, where the call to `resetCamera` reverts back the orientation because `viewportProperties.orientation === 'axial'`](https://github.com/cornerstonejs/cornerstone3D/blob/c31c5a2c61b257926e6331d319198110820fc5fa/packages/core/src/RenderingEngine/BaseVolumeViewport.ts#L154)


<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

I am resetting the `viewportProperties.orientation` value to `undefined` when `setOrientation` is called with `OrientationVectors`. This will prevent the `applyViewOrientation ... resetCamera` calls to revert the orientation back.

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [ ] My code has been well-documented (function documentation, inline comments,
  etc.)

- [x] I have run the `yarn build:update-api` to update the API documentation, and have
  committed the changes to this PR. (Read more here https://www.cornerstonejs.org/docs/contribute/update-api)


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [ ] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"--> Linux 6.13.2-arch1-1
- [x] "Node version: <!--[e.g. 16.14.0]"--> v20.18
- [x] "Browser: Chrome 133
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
