### PR TITLE
fix(SegmentationStateManager): fix loading in segmentation labelmaps

### DIFF
--- a/packages/tools/src/stateManagement/segmentation/SegmentationStateManager.ts
+++ b/packages/tools/src/stateManagement/segmentation/SegmentationStateManager.ts
@@ -438,24 +438,31 @@ export default class SegmentationStateManager {
 
   /**
    * Helper function to update labelmap segmentation image references.
-   * @param {string} segmentationId - The ID of the segmentation representation.
-   * @param {Types.IViewport} viewport - The viewport.
-   * @param {string[]} labelmapImageIds - The labelmap image IDs.
-   * @param {Function} updateCallback - A callback to update the reference map.
+   * @param segmentationInfo - The segmentation info of the desired segment.
+   * @param viewport - The viewport.
+   * @param labelmapImageIds - The labelmap image IDs.
+   * @param updateCallback - A callback to update the reference map.
    * @returns {string | undefined} The labelmap imageId reference for the current imageId rendered on the viewport.
    */
   _updateLabelmapSegmentationReferences(
-    segmentationId,
-    viewport,
-    labelmapImageIds,
-    updateCallback
+    segmentationInfo: Segmentation,
+    viewport: Types.IStackViewport,
+    labelmapImageIds: string[],
+    updateCallback: (
+      viewport: Types.IStackViewport,
+      segmentationId: string,
+      labelmapImageIds: string[]
+    ) => void
   ): string | undefined {
     const currentImageId = viewport.getCurrentImageId();
+    const currentImageIndex = viewport.getCurrentImageIdIndex();
+    const segmentationId = segmentationInfo.segmentationId;
 
     let viewableLabelmapImageIdFound = false;
-    for (const labelmapImageId of labelmapImageIds) {
+    const labelForImageIndex = labelmapImageIds[currentImageIndex];
+    if (labelForImageIndex) {
       const viewableImageId = viewport.isReferenceViewable(
-        { referencedImageId: labelmapImageId },
+        { referencedImageId: labelForImageIndex },
         { asOverlay: true }
       );
 
@@ -463,7 +470,7 @@ export default class SegmentationStateManager {
         viewableLabelmapImageIdFound = true;
         this._stackLabelmapImageIdReferenceMap
           .get(segmentationId)
-          .set(currentImageId, labelmapImageId);
+          .set(currentImageId, labelForImageIndex);
       }
     }
 
@@ -504,7 +511,7 @@ export default class SegmentationStateManager {
     const stackViewport = enabledElement.viewport as Types.IStackViewport;
 
     return this._updateLabelmapSegmentationReferences(
-      segmentationId,
+      segmentation,
       stackViewport,
       labelmapImageIds,
       null
@@ -537,7 +544,7 @@ export default class SegmentationStateManager {
     const stackViewport = enabledElement.viewport as Types.IStackViewport;
 
     this._updateLabelmapSegmentationReferences(
-      segmentationId,
+      segmentation,
       stackViewport,
       labelmapImageIds,
       (stackViewport, segmentationId, labelmapImageIds) => {


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
Fixes loading segmentation labelmaps. Before this fix, when loading in segmentation data from a DICOM SEG file, the Segmentation State Manager would always use the last overlay image, even though that would not correspond to most of the images in a Stack viewport. After this fix, the Segmentation State Manager uses the overlay for slice 1 when viewing slice 1 of a stack viewport, overlay slice 2 for slice 2 of the viewport, etc.

For more context and to see an example of what's broken, please refer to https://github.com/OHIF/Viewers/issues/4789.

### Changes & Results
I updated the Segmentation State Manager to reference the overlay image based on a slice's index when loading a segmentation DICOM file and populating the segmentation state. Since the overlay images are stored in-order based on the order of the slices, this appears to be a safe approach.

An example video of the fixes in action are attached to this PR.

https://github.com/user-attachments/assets/1a2abf88-6754-4374-b67e-02bf0dda18ba


### Testing

To test these changes, you can open the segmentation mode for a study in the OHIF Viewers project and mark up the stack with different labels, then export the segmentation as a DICOM SEG file and save it to a backing PACS server. When reopening the study and selecting the segmentation structured report, it should load the segmentations in order.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)



#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Windows 11
- [x] "Node version: 23.5.0
- [x] "Browser: Edge 133.0.3065.69

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
