### PR TITLE
fix(worker): should not change type of input

### DIFF
--- a/packages/core/src/webWorkerManager/webWorkerManager.js
+++ b/packages/core/src/webWorkerManager/webWorkerManager.js
@@ -52,7 +52,6 @@ class CentralizedWorkerManager {
       autoTerminateOnIdle: autoTerminateOnIdle.enabled,
       idleCheckIntervalId: null,
       idleTimeThreshold: autoTerminateOnIdle.idleTimeThreshold,
-      options: options,
     };
 
     workerProperties.loadCounters = Array(maxWorkerInstances).fill(0);
@@ -157,8 +156,6 @@ class CentralizedWorkerManager {
 
           workerProperties.processing = true;
 
-          // augment args with options
-          args = { ...args, ...workerProperties.options };
           const results = await api[methodName](args, ...finalCallbacks);
 
           workerProperties.processing = false;

--- a/packages/tools/examples/labelmapStatistics/index.ts
+++ b/packages/tools/examples/labelmapStatistics/index.ts
@@ -107,7 +107,6 @@ function displayStat(stat) {
 }
 
 async function calculateStatistics(id, indices) {
-  const viewport = renderingEngine.getViewport(viewportId);
   const stats = await segmentationUtils.getStatistics({
     segmentationId: 'SEGMENTATION_ID',
     segmentIndices: indices,


### PR DESCRIPTION
This pull request includes several changes to improve the efficiency and performance of the `CentralizedWorkerManager` class and to clean up the `displayStat` function. The most important changes include removing unused options and redundant code.

Improvements to `CentralizedWorkerManager`:

* Removed the `options` property from the worker initialization as it was not being used. (`packages/core/src/webWorkerManager/webWorkerManager.js`)
* Removed the augmentation of `args` with `workerProperties.options` in the worker method call, as this was unnecessary. (`packages/core/src/webWorkerManager/webWorkerManager.js`)

Code cleanup in `displayStat` function:

* Removed the unused `viewport` variable from the `calculateStatistics` function. (`packages/tools/examples/labelmapStatistics/index.ts`)