### PR TITLE
fix: avoid NaN Z spacing if possible

### DIFF
--- a/packages/core/src/utilities/calculateSpacingBetweenImageIds.ts
+++ b/packages/core/src/utilities/calculateSpacingBetweenImageIds.ts
@@ -129,7 +129,7 @@ export default function calculateSpacingBetweenImageIds(
   // position for each frame, leading to incorrect calculation of spacing = 0
   // If possible, we use the sliceThickness, but we warn about this dicom file
   // weirdness. If sliceThickness is not available, we set to 1 just to render
-  if (spacing === 0 && !strictZSpacingForVolumeViewport) {
+  if ((spacing === 0 || isNaN(spacing)) && !strictZSpacingForVolumeViewport) {
     if (spacingBetweenSlices) {
       console.debug('Could not calculate spacing. Using spacingBetweenSlices');
       spacing = spacingBetweenSlices;


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

The code that calculates Z spacing:
```typescript
    spacing =
      Math.abs(
        distanceImagePairs[numImages - 1].distance -
          distanceImagePairs[0].distance
      ) /
      (numImages - 1);
```
causes a division by 0 when `numImages === 1`.

The NaN ends up in some vtk shader and throws a syntax error.

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

Reuse existing fallback for spacing === 0
