### PR TITLE
fix(nifti-volume-loader): add decache function to cornerstoneNiftiImageLoader

### DIFF
--- a/packages/nifti-volume-loader/src/cornerstoneNiftiImageLoader.ts
+++ b/packages/nifti-volume-loader/src/cornerstoneNiftiImageLoader.ts
@@ -145,6 +145,9 @@ export default function cornerstoneNiftiImageLoader(
   return {
     promise: promise as Promise<Types.IImage>,
     cancelFn: undefined,
+    decache: () => {
+      dataFetchStateMap.delete(url);
+    },
   };
 }
 


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->
Fixes #1911


### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->
Add `decache` function to returned `ImageLoadObject` in `cornerstoneNiftiImageLoader` to remove nifti file from `nifti-volume-loader` internal cache on `purgeCache` call.

Now `purgeCache` cleans up the internal cache of `nifti-volume-loader`.

Memory usage before:
![image](https://github.com/user-attachments/assets/fe4fedb3-e729-4533-8a9e-ae4a6a52e9ff)

Memory usage after:
![image](https://github.com/user-attachments/assets/c875c533-06b9-4435-bf17-c803bc791b49)

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->
Steps to reproduce:
1. Add file with next content to nifti-volume-loader examples at packages/nifti-volume-loader/examples/niftiMemoryLeak/index.ts
```javascript
import {
  RenderingEngine,
  Enums,
  imageLoader,
  cache,
  resetInitialization,
} from '@cornerstonejs/core';
import {
  cornerstoneNiftiImageLoader,
  createNiftiImageIdsAndCacheMetadata,
} from '@cornerstonejs/nifti-volume-loader';
import { initDemo } from '../../../../utils/demo/helpers';

// This is for debugging purposes
console.warn(
  'Click on index.ts to open source code for this example --------->'
);

const size = '500px';

const content = document.getElementById('content');

const reloadButton = document.createElement('button');
reloadButton.innerText = 'Reload scan';
reloadButton.onclick = (_ev) => {
  // Clean cache before new scan load
  cache.purgeCache();
  cache.purgeVolumeCache();
  resetInitialization();

  // Load next scan
  setup().then();
};

const viewportGrid = document.createElement('div');
viewportGrid.style.display = 'flex';
viewportGrid.style.display = 'flex';
viewportGrid.style.flexDirection = 'row';

const element1 = document.createElement('div');
const element2 = document.createElement('div');
const element3 = document.createElement('div');
element1.style.width = size;
element1.style.height = size;
element2.style.width = size;
element2.style.height = size;
element3.style.width = size;
element3.style.height = size;

viewportGrid.appendChild(element1);
viewportGrid.appendChild(element2);
viewportGrid.appendChild(element3);

content.appendChild(reloadButton);
content.appendChild(viewportGrid);

const viewportId1 = 'CT_NIFTI_AXIAL';

const niftiURL =
  'https://ohif-assets.s3.us-east-2.amazonaws.com/nifti/CTACardio.nii.gz';

// Counter for unique url
let i = 0;

async function setup() {
  await initDemo();

  imageLoader.registerImageLoader('nifti', cornerstoneNiftiImageLoader);

  // Create unique url per setup call
  const url = `${niftiURL}?id=${i}`;
  const imageIds = await createNiftiImageIdsAndCacheMetadata({ url });

  const renderingEngineId = 'myRenderingEngine';
  const renderingEngine = new RenderingEngine(renderingEngineId);

  const viewportInputArray = [
    {
      viewportId: viewportId1,
      type: Enums.ViewportType.STACK,
      element: element1,
    },
  ];

  renderingEngine.setViewports(viewportInputArray);

  const vps = renderingEngine.getStackViewports();
  const viewport = vps[0];

  await viewport.setStack(imageIds);

  renderingEngine.render();
  i += 1;
}

setup().then();
```
2. Run yarn run build-and-serve-static-examples
3. Open http://localhost:3333/niftiMemoryLeak
4. Take first memory snapshot after loading of scan
5. Click Reload scan button
6. Take second memory snapshot after loading of scan

Expected result:
Memory usage should not increase significantly.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [ ] My code has been well-documented (function documentation, inline comments,
  etc.)



#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [ ] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Windows 11<!--[e.g. Windows 10, macOS 10.15.4]"-->
- [x] "Node version: v22.14.0<!--[e.g. 16.14.0]"-->
- [x] "Browser: Chrome 134.0.6998.89
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
