### PR TITLE
fix(cpu): broken CPU fallback renderer & example fix

### DIFF
--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -1937,8 +1937,8 @@ class StackViewport extends Viewport {
 
         if (pixelData instanceof Float32Array && scaledWithNonIntegers) {
           const floatMinMax = {
-            min: image.maxPixelValue,
-            max: image.minPixelValue,
+            min: image.minPixelValue,
+            max: image.maxPixelValue,
           };
           const floatRange = Math.abs(floatMinMax.max - floatMinMax.min);
           const intRange = 65535;
@@ -1966,7 +1966,12 @@ class StackViewport extends Viewport {
           image.maxPixelValue = max;
           image.slope = slope;
           image.intercept = intercept;
-          image.getPixelData = () => intPixelData;
+          // voxelManager, when present, overrides getPixelData()
+          if (image.voxelManager) {
+            image.voxelManager.getScalarData = () => intPixelData;
+          } else {
+            image.getPixelData = () => intPixelData;
+          }
 
           image.preScale = {
             ...image.preScale,

--- a/packages/tools/examples/localCPU/index.ts
+++ b/packages/tools/examples/localCPU/index.ts
@@ -67,6 +67,7 @@ document
 async function run() {
   // Init Cornerstone and related libraries
   await initVolumeLoader();
+  cornerstoneDICOMImageLoader.init();
   await initProviders();
 
   setUseCPURendering(true);


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

In our infra we are using the `2.x` branch (latest release, currently 2.19.16), recently updated from `1.x`. We rely on the CPU fallback renderer as in our use case GPU rendering is not possible. Shortly after the 2.0 upgrade, we started receiving feedback about certain DICOMs not rendering correctly, the issue is captured in #1916.

Initial investigation pointed to the CPU fallback renderer being broken, as the [local viewer](https://www.cornerstonejs.org/live-examples/local.html) did not have any trouble displaying the image. While further investigating, I have discovered that the example that uses forced CPU rendering doesn't work, this is captured in #1907 and the PR also addresses this issue.

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

After fixing the CPU fallback example I have managed to trace the source of the breakage to `StackView.ts` which seems to have had typos in the min/max value calculation and was not playing nice with the `voxelManager`.

With the above changes the broken rendering is fixed in our systems.

Depending on the exact source of OP's issues, this fix might also apply to #1875.


### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

With these changes, the [localCPU](https://www.cornerstonejs.org/live-examples/localcpu.html) example should start working again, and the example DICOM attached in #1916 should display correctly.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)



#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals. *(Note: as far as I'm aware this PR does not touch the public API surface, no updates deemed necessary)*

#### Tested Environment

- [x] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"--> Linux Mint 23
- [x] "Node version: <!--[e.g. 16.14.0]"--> N/A
- [x] "Browser: Firefox 136.0.1 (64-bit)
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->

#### Uplift request

I am requesting that the changes below are uplifted to the `2.x` branch as well, this functionality I believe affects (m)any other users of the 2.x branch as well. The changes should apply cleanly so it shouldn't be much trouble.