### PR TITLE
fix: SegmentBidirectionalTool hydration type error

### DIFF
--- a/packages/tools/src/tools/segmentation/SegmentBidirectionalTool.ts
+++ b/packages/tools/src/tools/segmentation/SegmentBidirectionalTool.ts
@@ -38,7 +38,6 @@ import type { StyleSpecifier } from '../../types/AnnotationStyle';
 import BidirectionalTool from '../annotation/BidirectionalTool';
 import { getSegmentIndexColor } from '../../stateManagement/segmentation/config/segmentationColor';
 
-// @ts-expect-error
 class SegmentBidirectionalTool extends BidirectionalTool {
   static toolName = 'SegmentBidirectional';
 

--- a/packages/tools/src/types/ToolSpecificAnnotationTypes.ts
+++ b/packages/tools/src/types/ToolSpecificAnnotationTypes.ts
@@ -201,7 +201,7 @@ export interface BidirectionalAnnotation extends Annotation {
         };
       };
     };
-    label: string;
+    label?: string;
     cachedStats: {
       [targetId: string]: {
         length: number;


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

Fixes type errors occurring on the class SegmentBidirectionalTool.

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

Updated the `BidirectionalAnnotation` to make label optional since its used in `SegmentBidirectionalTool` where and the label doesn't exits in the `SegmentBidirectionalAnnotation` type.

Making the label optional fixes type errors when building and running using cornerstone:
![image](https://github.com/user-attachments/assets/67810935-73bc-46a0-9e24-ab69019a22c3)

Full error
```
Error: node_modules/@cornerstonejs/tools/dist/esm/tools/segmentation/SegmentBidirectionalTool.d.ts:5:15 - error TS2417: Class static side 'typeof SegmentBidirectionalTool' incorrectly extends base class static side 'typeof BidirectionalTool'.
  The types of 'hydrate(...).data' are incompatible between these types.
    Property 'label' is missing in type '{ cachedStats: { [targetId: string]: { length: number; width: number; unit: string; }; }; handles: { points: Point3[]; activeHandleIndex: number; textBox: { hasMoved: boolean; worldPosition: Point3; worldBoundingBox: { ...; }; }; }; }' but required in type '{ handles: { points: Point3[]; activeHandleIndex: number; textBox: { hasMoved: boolean; worldPosition: Point3; worldBoundingBox: { topLeft: Point3; topRight: Point3; bottomLeft: Point3; bottomRight: Point3; }; }; }; label: string; cachedStats: { ...; }; }'.

5 declare class SegmentBidirectionalTool extends BidirectionalTool {
                ~~~~~~~~~~~~~~~~~~~~~~~~

  node_modules/@cornerstonejs/tools/dist/esm/types/ToolSpecificAnnotationTypes.d.ts:185:9
    185         label: string;
                ~~~~~
    'label' is declared here.
```

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

Running the [angular cornerstone template](https://github.com/cornerstonejs/angular-cornerstone3d) with the latest cornerstone release and this `tsconfig.json`

```
{
  "compileOnSave": false,
  "compilerOptions": {
    "baseUrl": "./",
    "outDir": "./dist/out-tsc",
    "sourceMap": true,
    "declaration": false,
    "downlevelIteration": true,
    "experimentalDecorators": true,
    "module": "esnext",
    "moduleResolution": "node",
    "importHelpers": true,
    "target": "ES2022",
    "typeRoots": ["node_modules/@types"],
    "lib": ["es2018", "dom"],
    "useDefineForClassFields": false
  },
  "angularCompilerOptions": {
    "strictInjectionParameters": true,
    "strictTemplates": true
  }
}
```
### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)



#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: macOS 15.3.2
- [x] "Node version: v22.13.1
- [x] "Browser: Chrome 134.0.6998.117
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
