### PR TITLE
fix: Scrolling sometimes set NaN and won't loop backwards

### DIFF
--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -2166,6 +2166,10 @@ class StackViewport extends Viewport {
   }
 
   private _loadAndDisplayImageGPU(imageId: string, imageIdIndex: number) {
+    if (!imageId) {
+      console.warn('No image id set yet to load');
+      return;
+    }
     const eventDetail: EventTypes.PreStackNewImageEventDetail = {
       imageId,
       imageIdIndex,
@@ -2613,18 +2617,22 @@ class StackViewport extends Viewport {
   public scroll(delta: number, debounce = true, loop = false): void {
     const imageIds = this.imageIds;
 
+    if (isNaN(this.targetImageIdIndex)) {
+      // Scrolling before things are ready to display or on empty viewport
+      return;
+    }
     const currentTargetImageIdIndex = this.targetImageIdIndex;
     const numberOfFrames = imageIds.length;
 
     let newTargetImageIdIndex = currentTargetImageIdIndex + delta;
-    newTargetImageIdIndex = Math.max(0, newTargetImageIdIndex);
 
     if (loop) {
-      newTargetImageIdIndex = newTargetImageIdIndex % numberOfFrames;
+      newTargetImageIdIndex =
+        (newTargetImageIdIndex + numberOfFrames) % numberOfFrames;
     } else {
-      newTargetImageIdIndex = Math.min(
-        numberOfFrames - 1,
-        newTargetImageIdIndex
+      newTargetImageIdIndex = Math.max(
+        0,
+        Math.min(numberOfFrames - 1, newTargetImageIdIndex)
       );
     }
 


### PR DESCRIPTION
### Context

Scrolling before the viewport is ready or on a blank viewport can cause NPEs when trying to fetch undefined imageIds.  Also, scrolling backwards should be able to loop, but can't.

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)



#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
