### PR TITLE
fix: magnify tool rotation

### DIFF
--- a/packages/tools/src/tools/MagnifyTool.ts
+++ b/packages/tools/src/tools/MagnifyTool.ts
@@ -1,19 +1,17 @@
 import { BaseTool } from './base';
 import { Events } from '../enums';
 
-import { getEnabledElement, StackViewport } from '@cornerstonejs/core';
+import { getEnabledElement, StackViewport, Enums } from '@cornerstonejs/core';
 import type { Types } from '@cornerstonejs/core';
-import type { EventTypes, PublicToolProps, ToolProps } from '../types';
+import type { EventTypes, PublicToolProps, ToolProps, IPoints } from '../types';
 import { getViewportIdsWithToolToRender } from '../utilities/viewportFilters';
 import triggerAnnotationRenderForViewportIds from '../utilities/triggerAnnotationRenderForViewportIds';
 import { state } from '../store/state';
-import { Enums } from '@cornerstonejs/core';
 
 import {
   hideElementCursor,
   resetElementCursor,
 } from '../cursors/elementCursor';
-import type { IPoints } from '../types';
 
 const MAGNIFY_VIEWPORT_ID = 'magnify-viewport';
 
@@ -115,6 +113,8 @@ class MagnifyTool extends BaseTool {
     const { viewport } = enabledElement;
     const { element } = viewport;
     const viewportProperties = viewport.getProperties();
+    const { rotation: originalViewportRotation } =
+      viewport.getViewPresentation();
 
     const { canvas: canvasPos, world: worldPos } = currentPoints;
 
@@ -162,6 +162,11 @@ class MagnifyTool extends BaseTool {
       }
       // match the original viewport voi range
       magnifyViewport.setProperties(viewportProperties);
+
+      // match the original viewport's rotation
+      magnifyViewport.setViewPresentation({
+        rotation: originalViewportRotation,
+      });
 
       // Use the original viewport for the base for parallelScale
       const { parallelScale } = viewport.getCamera();


### PR DESCRIPTION
### Context

Addresses: https://github.com/cornerstonejs/cornerstone3D/issues/1926

### Changes & Results

Before:
Magnify viewport wouldn't match original viewport's rotation
![image](https://github.com/user-attachments/assets/992be208-d236-4474-b692-8f94c509789a)


After:
Magnify viewport matches original viewport's rotation
![image](https://github.com/user-attachments/assets/a442a768-c7fc-412b-a11c-e0f01bda385a)


### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)



#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
