### PR TITLE
fix(label-tool): add visibility check for annotations in rendering

### DIFF
--- a/packages/tools/src/tools/annotation/LabelTool.ts
+++ b/packages/tools/src/tools/annotation/LabelTool.ts
@@ -39,6 +39,7 @@ import type {
 } from '../../types';
 import type { LabelAnnotation } from '../../types/ToolSpecificAnnotationTypes';
 import type { StyleSpecifier } from '../../types/AnnotationStyle';
+import { isAnnotationVisible } from '../../stateManagement/annotation/annotationVisibility';
 
 class LabelTool extends AnnotationTool {
   static toolName = 'Label';
@@ -596,6 +597,10 @@ class LabelTool extends AnnotationTool {
       if (!viewport.getRenderingEngine()) {
         console.warn('Rendering Engine has been destroyed');
         return renderStatus;
+      }
+
+      if (!isAnnotationVisible(annotationUID)) {
+        continue;
       }
 
       if (!data.text) {


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

Fixes #1937

The label tool was incorrectly rendering annotations even when visibility was disabled.

This PR ensures that annotations are only displayed when their visibility flag is set to true.

### Changes & Results

Added a visibility check in the label tool's rendering logic.
Modified the annotation rendering function to respect the visible flag.

Before: Labels were visible even when visibility is set to false.
After: Labels now respect visibility settings.

### Testing

### Checklist

#### PR
fix(label-tool): add visibility check for annotations in rendering

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->
 
- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Ubuntu 24.04.2
- [x] "Node version: 22.14.0
- [x] "Browser: chrome 133.0.6943.126 (Official Build) (64-bit)

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
