### PR TITLE
fix CircleROI tool for wsi

### DIFF
--- a/packages/core/src/RenderingEngine/WSIViewport.ts
+++ b/packages/core/src/RenderingEngine/WSIViewport.ts
@@ -231,8 +231,6 @@ class WSIViewport extends Viewport {
 
   public getScalarData() {
     const scalarData = null as PixelDataTypedArray;
-    //scalarData.length = 0;
-    //scarlarData = [];
     return scalarData;
   }
 

--- a/packages/core/src/RenderingEngine/WSIViewport.ts
+++ b/packages/core/src/RenderingEngine/WSIViewport.ts
@@ -10,6 +10,7 @@ import type {
   ViewportInput,
   BoundsIJK,
   CPUImageData,
+  PixelDataTypedArray,
 } from '../types';
 import uuidv4 from '../utilities/uuidv4';
 import * as metaData from '../metaData';
@@ -228,8 +229,11 @@ class WSIViewport extends Viewport {
     this.setProperties({});
   }
 
-  protected getScalarData() {
-    return null;
+  public getScalarData() {
+    const scalarData = null as PixelDataTypedArray;
+    //scalarData.length = 0;
+    //scarlarData = [];
+    return scalarData;
   }
 
   public getImageData(): CPUIImageData {
@@ -272,7 +276,7 @@ class WSIViewport extends Viewport {
       preScale: {
         scaled: false,
       },
-      scalarData: this.getScalarData(),
+      scalarData: null,
       imageData,
       // It is for the annotations to work, since all of them work on voxelManager and not on scalarData now
       voxelManager: {

--- a/packages/core/src/RenderingEngine/WSIViewport.ts
+++ b/packages/core/src/RenderingEngine/WSIViewport.ts
@@ -233,15 +233,7 @@ class WSIViewport extends Viewport {
   public resetProperties() {
     this.setProperties({});
   }
-  /*
-  protected getScalarData() {
-    // Return an empty CanvasScalarData object
-    const emptyData = new Uint8ClampedArray() as CanvasScalarData;
-    emptyData.getRange = () => [0, 255];
-    emptyData.frameNumber = -1;
-    return emptyData;
-  }
- */
+
   protected _getScalarData() {
     // Return an empty CanvasScalarData object
     const emptyData = new Uint8ClampedArray() as CanvasScalarData;

--- a/packages/core/src/RenderingEngine/WSIViewport.ts
+++ b/packages/core/src/RenderingEngine/WSIViewport.ts
@@ -615,12 +615,18 @@ class WSIViewport extends Viewport {
   protected canvasToIndex = (canvasPos: Point2): Point2 => {
     const transform = this.getTransform();
     transform.invert();
-    return transform.transformPoint(canvasPos);
+    return transform.transformPoint(
+      canvasPos.map((it) => it * devicePixelRatio) as Point2
+    );
+    // return transform.transformPoint(canvasPos);
   };
 
   protected indexToCanvas = (indexPos: Point2): Point2 => {
     const transform = this.getTransform();
-    return transform.transformPoint(indexPos);
+    return transform
+      .transformPoint(indexPos)
+      .map((it) => it / devicePixelRatio) as Point2;
+    // return transform.transformPoint(indexPos);
   };
 
   /** This can be implemented later when multi-slice WSI is supported */

--- a/packages/core/src/RenderingEngine/WSIViewport.ts
+++ b/packages/core/src/RenderingEngine/WSIViewport.ts
@@ -293,6 +293,7 @@ class WSIViewport extends Viewport {
       scalarData: this._getScalarData(),
       imageData,
       // It is for the annotations to work, since all of them work on voxelManager and not on scalarData now
+      /*
       voxelManager: {
         forEach: (
           callback: (args: {
@@ -316,6 +317,7 @@ class WSIViewport extends Viewport {
           });
         },
       },
+      */
     };
 
     // @ts-expect-error we need to fully migrate the voxelManager to the new system

--- a/packages/core/src/RenderingEngine/WSIViewport.ts
+++ b/packages/core/src/RenderingEngine/WSIViewport.ts
@@ -628,7 +628,6 @@ class WSIViewport extends Viewport {
     return transform.transformPoint(
       canvasPos.map((it) => it * devicePixelRatio) as Point2
     );
-    // return transform.transformPoint(canvasPos);
   };
 
   protected indexToCanvas = (indexPos: Point2): Point2 => {
@@ -636,7 +635,6 @@ class WSIViewport extends Viewport {
     return transform
       .transformPoint(indexPos)
       .map((it) => it / devicePixelRatio) as Point2;
-    // return transform.transformPoint(indexPos);
   };
 
   /** This can be implemented later when multi-slice WSI is supported */

--- a/packages/core/src/RenderingEngine/WSIViewport.ts
+++ b/packages/core/src/RenderingEngine/WSIViewport.ts
@@ -24,6 +24,11 @@ import { pointInShapeCallback } from '../utilities/pointInShapeCallback';
 import microscopyViewportCss from '../constants/microscopyViewportCss';
 import type { DataSetOptions } from '../types/IViewport';
 
+export type CanvasScalarData = Uint8ClampedArray & {
+  frameNumber?: number;
+  getRange?: () => [number, number];
+};
+
 const _map = Symbol.for('map');
 const EVENT_POSTRENDER = 'postrender';
 /**
@@ -229,9 +234,12 @@ class WSIViewport extends Viewport {
     this.setProperties({});
   }
 
-  public getScalarData() {
-    const scalarData = null as PixelDataTypedArray;
-    return scalarData;
+  protected getScalarData() {
+    // Return an empty CanvasScalarData object
+    const emptyData = new Uint8ClampedArray() as CanvasScalarData;
+    emptyData.getRange = () => [0, 255];
+    emptyData.frameNumber = -1;
+    return emptyData;
   }
 
   public getImageData(): CPUIImageData {
@@ -274,7 +282,7 @@ class WSIViewport extends Viewport {
       preScale: {
         scaled: false,
       },
-      scalarData: null,
+      scalarData: this.getScalarData(),
       imageData,
       // It is for the annotations to work, since all of them work on voxelManager and not on scalarData now
       voxelManager: {

--- a/packages/core/src/RenderingEngine/WSIViewport.ts
+++ b/packages/core/src/RenderingEngine/WSIViewport.ts
@@ -233,8 +233,16 @@ class WSIViewport extends Viewport {
   public resetProperties() {
     this.setProperties({});
   }
-
+  /*
   protected getScalarData() {
+    // Return an empty CanvasScalarData object
+    const emptyData = new Uint8ClampedArray() as CanvasScalarData;
+    emptyData.getRange = () => [0, 255];
+    emptyData.frameNumber = -1;
+    return emptyData;
+  }
+ */
+  protected _getScalarData() {
     // Return an empty CanvasScalarData object
     const emptyData = new Uint8ClampedArray() as CanvasScalarData;
     emptyData.getRange = () => [0, 255];
@@ -254,7 +262,7 @@ class WSIViewport extends Viewport {
       getDirection: () => metadata.direction,
       getDimensions: () => metadata.dimensions,
       getRange: () => [0, 255],
-      getScalarData: () => this.getScalarData(),
+      getScalarData: () => this._getScalarData(),
       getSpacing: () => metadata.spacing,
       worldToIndex: (point: Point3) => {
         const canvasPoint = this.worldToCanvas(point);
@@ -282,7 +290,7 @@ class WSIViewport extends Viewport {
       preScale: {
         scaled: false,
       },
-      scalarData: this.getScalarData(),
+      scalarData: this._getScalarData(),
       imageData,
       // It is for the annotations to work, since all of them work on voxelManager and not on scalarData now
       voxelManager: {

--- a/packages/core/src/RenderingEngine/WSIViewport.ts
+++ b/packages/core/src/RenderingEngine/WSIViewport.ts
@@ -27,6 +27,7 @@ export type CanvasScalarData = Uint8ClampedArray & {
   getRange?: () => [number, number];
 };
 
+const WSIUtilFunctions = null;
 const _map = Symbol.for('map');
 const EVENT_POSTRENDER = 'postrender';
 /**
@@ -634,7 +635,7 @@ class WSIViewport extends Viewport {
   protected indexToCanvas = (indexPos: Point2): Point2 => {
     const transform = this.getTransform();
     return transform
-      .transformPoint(indexPos)
+      .transformPoint([indexPos[0], indexPos[1]])
       .map((it) => it / devicePixelRatio) as Point2;
   };
 

--- a/packages/core/src/RenderingEngine/WSIViewport.ts
+++ b/packages/core/src/RenderingEngine/WSIViewport.ts
@@ -229,6 +229,10 @@ class WSIViewport extends Viewport {
 
   protected _getScalarData() {
     // Return an empty CanvasScalarData object
+    type CanvasScalarData = Uint8ClampedArray & {
+      frameNumber?: number;
+      getRange?: () => [number, number];
+    };
     const emptyData = new Uint8ClampedArray() as CanvasScalarData;
     emptyData.getRange = () => [0, 255];
     emptyData.frameNumber = -1;

--- a/packages/core/src/RenderingEngine/WSIViewport.ts
+++ b/packages/core/src/RenderingEngine/WSIViewport.ts
@@ -9,8 +9,6 @@ import type {
   CPUIImageData,
   ViewportInput,
   BoundsIJK,
-  CPUImageData,
-  PixelDataTypedArray,
 } from '../types';
 import uuidv4 from '../utilities/uuidv4';
 import * as metaData from '../metaData';
@@ -624,12 +622,13 @@ class WSIViewport extends Viewport {
 
   public getRotation = () => 0;
 
-  protected canvasToIndex = (canvasPos: Point2): Point2 => {
+  protected canvasToIndex = (canvasPos: Point2): Point3 => {
     const transform = this.getTransform();
     transform.invert();
-    return transform.transformPoint(
+    const indexPoint = transform.transformPoint(
       canvasPos.map((it) => it * devicePixelRatio) as Point2
     );
+    return [indexPoint[0], indexPoint[1], 0] as Point3;
   };
 
   protected indexToCanvas = (indexPos: Point2): Point2 => {

--- a/packages/core/src/RenderingEngine/WSIViewport.ts
+++ b/packages/core/src/RenderingEngine/WSIViewport.ts
@@ -22,12 +22,6 @@ import { pointInShapeCallback } from '../utilities/pointInShapeCallback';
 import microscopyViewportCss from '../constants/microscopyViewportCss';
 import type { DataSetOptions } from '../types/IViewport';
 
-export type CanvasScalarData = Uint8ClampedArray & {
-  frameNumber?: number;
-  getRange?: () => [number, number];
-};
-
-const WSIUtilFunctions = null;
 const _map = Symbol.for('map');
 const EVENT_POSTRENDER = 'postrender';
 /**

--- a/packages/tools/examples/wsiAnnotationTools/index.ts
+++ b/packages/tools/examples/wsiAnnotationTools/index.ts
@@ -53,9 +53,9 @@ setTitleAndDescription(
 const toolsNames = [
   LengthTool.toolName,
   // ProbeTool.toolName,
-  // RectangleROITool.toolName,
-  // EllipticalROITool.toolName,
-  // CircleROITool.toolName,
+  RectangleROITool.toolName,
+  EllipticalROITool.toolName,
+  CircleROITool.toolName,
   BidirectionalTool.toolName,
   AngleTool.toolName,
   CobbAngleTool.toolName,

--- a/packages/tools/src/tools/annotation/CircleROITool.ts
+++ b/packages/tools/src/tools/annotation/CircleROITool.ts
@@ -983,7 +983,7 @@ class CircleROITool extends AnnotationTool {
         );
 
         let pointsInShape;
-        if (imageData.getScalarValueFromWorld) {
+        if (voxelManager) {
           pointsInShape = voxelManager.forEach(
             this.configuration.statsCalculator.statsCallback,
             {

--- a/packages/tools/src/tools/annotation/CircleROITool.ts
+++ b/packages/tools/src/tools/annotation/CircleROITool.ts
@@ -996,7 +996,6 @@ class CircleROITool extends AnnotationTool {
           );
         }
         const stats = this.configuration.statsCalculator.getStatistics();
-
         cachedStats[targetId] = {
           Modality: metadata.Modality,
           area,
@@ -1030,6 +1029,14 @@ class CircleROITool extends AnnotationTool {
   };
 
   _isInsideVolume = (index1, index2, dimensions) => {
+    // for wsiViewport
+    if (index1[1] < 0) {
+      index1[1] = -index1[1];
+    }
+    if (index2[1] < 0) {
+      index2[1] = -index2[1];
+    }
+
     return (
       csUtils.indexWithinDimensions(index1, dimensions) &&
       csUtils.indexWithinDimensions(index2, dimensions)
@@ -1137,7 +1144,7 @@ function defaultGetTextLines(data, targetId): string[] {
     textLines.push(`Mean: ${csUtils.roundNumber(mean)} ${modalityUnit}`);
   }
 
-  if (max) {
+  if (max && isFinite(max)) {
     textLines.push(`Max: ${csUtils.roundNumber(max)} ${modalityUnit}`);
   }
 

--- a/packages/tools/src/tools/annotation/CircleROITool.ts
+++ b/packages/tools/src/tools/annotation/CircleROITool.ts
@@ -919,7 +919,10 @@ class CircleROITool extends AnnotationTool {
       // Check if one of the indexes are inside the volume, this then gives us
       // Some area to do stats over.
 
-      if (this._isInsideVolume(pos1Index, pos2Index, dimensions)) {
+      if (
+        this._isInsideVolume(pos1Index, pos2Index, dimensions) ||
+        viewport.type === 'wholeSlide'
+      ) {
         const iMin = Math.min(pos1Index[0], pos2Index[0]);
         const iMax = Math.max(pos1Index[0], pos2Index[0]);
 
@@ -982,17 +985,19 @@ class CircleROITool extends AnnotationTool {
           pixelUnitsOptions
         );
 
-        const pointsInShape = voxelManager.forEach(
-          this.configuration.statsCalculator.statsCallback,
-          {
-            isInObject: (pointLPS) =>
-              pointInEllipse(ellipseObj, pointLPS, { fast: true }),
-            boundsIJK,
-            imageData,
-            returnPoints: this.configuration.storePointData,
-          }
-        );
-
+        let pointsInShape;
+        if (viewport.type !== 'wholeSlide') {
+          pointsInShape = voxelManager.forEach(
+            this.configuration.statsCalculator.statsCallback,
+            {
+              isInObject: (pointLPS) =>
+                pointInEllipse(ellipseObj, pointLPS, { fast: true }),
+              boundsIJK,
+              imageData,
+              returnPoints: this.configuration.storePointData,
+            }
+          );
+        }
         const stats = this.configuration.statsCalculator.getStatistics();
 
         cachedStats[targetId] = {

--- a/packages/tools/src/tools/annotation/CircleROITool.ts
+++ b/packages/tools/src/tools/annotation/CircleROITool.ts
@@ -983,7 +983,7 @@ class CircleROITool extends AnnotationTool {
         );
 
         let pointsInShape;
-        if (image.scalarData.length > 0) {
+        if (voxelManager.length) {
           pointsInShape = voxelManager.forEach(
             this.configuration.statsCalculator.statsCallback,
             {

--- a/packages/tools/src/tools/annotation/CircleROITool.ts
+++ b/packages/tools/src/tools/annotation/CircleROITool.ts
@@ -986,7 +986,7 @@ class CircleROITool extends AnnotationTool {
         );
 
         let pointsInShape;
-        if (viewport.type !== 'wholeSlide') {
+        if (imageData.getScalarData() !== null) {
           pointsInShape = voxelManager.forEach(
             this.configuration.statsCalculator.statsCallback,
             {

--- a/packages/tools/src/tools/annotation/CircleROITool.ts
+++ b/packages/tools/src/tools/annotation/CircleROITool.ts
@@ -1030,9 +1030,6 @@ class CircleROITool extends AnnotationTool {
   };
 
   _isInsideVolume = (index1, index2, dimensions) => {
-    //console.debug(index1, index2, dimensions);
-    index1[1] = index1[1] / 2 + dimensions[1] / 2;
-    index2[1] = index2[1] / 2 + dimensions[1] / 2;
     return (
       csUtils.indexWithinDimensions(index1, dimensions) &&
       csUtils.indexWithinDimensions(index2, dimensions)

--- a/packages/tools/src/tools/annotation/CircleROITool.ts
+++ b/packages/tools/src/tools/annotation/CircleROITool.ts
@@ -919,10 +919,7 @@ class CircleROITool extends AnnotationTool {
       // Check if one of the indexes are inside the volume, this then gives us
       // Some area to do stats over.
 
-      if (
-        this._isInsideVolume(pos1Index, pos2Index, dimensions) ||
-        viewport.type === 'wholeSlide'
-      ) {
+      if (this._isInsideVolume(pos1Index, pos2Index, dimensions)) {
         const iMin = Math.min(pos1Index[0], pos2Index[0]);
         const iMax = Math.max(pos1Index[0], pos2Index[0]);
 

--- a/packages/tools/src/tools/annotation/CircleROITool.ts
+++ b/packages/tools/src/tools/annotation/CircleROITool.ts
@@ -983,7 +983,7 @@ class CircleROITool extends AnnotationTool {
         );
 
         let pointsInShape;
-        if (imageData.getScalarData() !== null) {
+        if (image.scalarData.length > 0) {
           pointsInShape = voxelManager.forEach(
             this.configuration.statsCalculator.statsCallback,
             {

--- a/packages/tools/src/tools/annotation/CircleROITool.ts
+++ b/packages/tools/src/tools/annotation/CircleROITool.ts
@@ -983,7 +983,7 @@ class CircleROITool extends AnnotationTool {
         );
 
         let pointsInShape;
-        if (voxelManager.length) {
+        if (imageData.getScalarValueFromWorld) {
           pointsInShape = voxelManager.forEach(
             this.configuration.statsCalculator.statsCallback,
             {
@@ -995,6 +995,7 @@ class CircleROITool extends AnnotationTool {
             }
           );
         }
+
         const stats = this.configuration.statsCalculator.getStatistics();
         cachedStats[targetId] = {
           Modality: metadata.Modality,

--- a/packages/tools/src/tools/annotation/CircleROITool.ts
+++ b/packages/tools/src/tools/annotation/CircleROITool.ts
@@ -1030,6 +1030,9 @@ class CircleROITool extends AnnotationTool {
   };
 
   _isInsideVolume = (index1, index2, dimensions) => {
+    //console.debug(index1, index2, dimensions);
+    index1[1] = index1[1] / 2 + dimensions[1] / 2;
+    index2[1] = index2[1] / 2 + dimensions[1] / 2;
     return (
       csUtils.indexWithinDimensions(index1, dimensions) &&
       csUtils.indexWithinDimensions(index2, dimensions)

--- a/packages/tools/src/tools/annotation/CircleROITool.ts
+++ b/packages/tools/src/tools/annotation/CircleROITool.ts
@@ -1141,15 +1141,15 @@ function defaultGetTextLines(data, targetId): string[] {
     textLines.push(areaLine);
   }
 
-  if (mean) {
+  if (AnnotationTool.isNumber(mean)) {
     textLines.push(`Mean: ${csUtils.roundNumber(mean)} ${modalityUnit}`);
   }
 
-  if (max && isFinite(max)) {
+  if (AnnotationTool.isNumber(max)) {
     textLines.push(`Max: ${csUtils.roundNumber(max)} ${modalityUnit}`);
   }
 
-  if (stdDev) {
+  if (AnnotationTool.isNumber(stdDev)) {
     textLines.push(`Std Dev: ${csUtils.roundNumber(stdDev)} ${modalityUnit}`);
   }
 

--- a/packages/tools/src/tools/annotation/EllipticalROITool.ts
+++ b/packages/tools/src/tools/annotation/EllipticalROITool.ts
@@ -1145,7 +1145,7 @@ class EllipticalROITool extends AnnotationTool {
       );
 
       let pointsInShape;
-      if (imageData.getScalarValueFromWorld) {
+      if (voxelManager) {
         pointsInShape = voxelManager.forEach(
           this.configuration.statsCalculator.statsCallback,
           {

--- a/packages/tools/src/tools/annotation/EllipticalROITool.ts
+++ b/packages/tools/src/tools/annotation/EllipticalROITool.ts
@@ -1145,7 +1145,7 @@ class EllipticalROITool extends AnnotationTool {
       );
 
       let pointsInShape;
-      if (imageData.getScalarData() !== null) {
+      if (image.scalarData.length > 0) {
         pointsInShape = voxelManager.forEach(
           this.configuration.statsCalculator.statsCallback,
           {

--- a/packages/tools/src/tools/annotation/EllipticalROITool.ts
+++ b/packages/tools/src/tools/annotation/EllipticalROITool.ts
@@ -1145,7 +1145,7 @@ class EllipticalROITool extends AnnotationTool {
       );
 
       let pointsInShape;
-      if (image.scalarData.length > 0) {
+      if (voxelManager.length) {
         pointsInShape = voxelManager.forEach(
           this.configuration.statsCalculator.statsCallback,
           {

--- a/packages/tools/src/tools/annotation/EllipticalROITool.ts
+++ b/packages/tools/src/tools/annotation/EllipticalROITool.ts
@@ -1144,17 +1144,19 @@ class EllipticalROITool extends AnnotationTool {
         pixelUnitsOptions
       );
 
-      const pointsInShape = voxelManager.forEach(
-        this.configuration.statsCalculator.statsCallback,
-        {
-          boundsIJK,
-          imageData,
-          isInObject: (pointLPS) =>
-            pointInEllipse(ellipseObj, pointLPS, { fast: true }),
-          returnPoints: this.configuration.storePointData,
-        }
-      );
-
+      let pointsInShape;
+      if (imageData.getScalarData() !== null) {
+        pointsInShape = voxelManager.forEach(
+          this.configuration.statsCalculator.statsCallback,
+          {
+            boundsIJK,
+            imageData,
+            isInObject: (pointLPS) =>
+              pointInEllipse(ellipseObj, pointLPS, { fast: true }),
+            returnPoints: this.configuration.storePointData,
+          }
+        );
+      }
       const stats = this.configuration.statsCalculator.getStatistics();
       cachedStats[targetId] = {
         Modality: metadata.Modality,
@@ -1248,7 +1250,7 @@ function defaultGetTextLines(data, targetId): string[] {
     textLines.push(`Mean: ${csUtils.roundNumber(mean)} ${modalityUnit}`);
   }
 
-  if (max) {
+  if (max && isFinite(max)) {
     textLines.push(`Max: ${csUtils.roundNumber(max)} ${modalityUnit}`);
   }
 

--- a/packages/tools/src/tools/annotation/EllipticalROITool.ts
+++ b/packages/tools/src/tools/annotation/EllipticalROITool.ts
@@ -1145,7 +1145,7 @@ class EllipticalROITool extends AnnotationTool {
       );
 
       let pointsInShape;
-      if (voxelManager.length) {
+      if (imageData.getScalarValueFromWorld) {
         pointsInShape = voxelManager.forEach(
           this.configuration.statsCalculator.statsCallback,
           {

--- a/packages/tools/src/tools/annotation/EllipticalROITool.ts
+++ b/packages/tools/src/tools/annotation/EllipticalROITool.ts
@@ -1250,7 +1250,7 @@ function defaultGetTextLines(data, targetId): string[] {
     textLines.push(`Mean: ${csUtils.roundNumber(mean)} ${modalityUnit}`);
   }
 
-  if (max && isFinite(max)) {
+  if (AnnotationTool.isNumber(max)) {
     textLines.push(`Max: ${csUtils.roundNumber(max)} ${modalityUnit}`);
   }
 

--- a/packages/tools/src/tools/annotation/LabelTool.ts
+++ b/packages/tools/src/tools/annotation/LabelTool.ts
@@ -39,6 +39,7 @@ import type {
 } from '../../types';
 import type { LabelAnnotation } from '../../types/ToolSpecificAnnotationTypes';
 import type { StyleSpecifier } from '../../types/AnnotationStyle';
+import { isAnnotationVisible } from '../../stateManagement/annotation/annotationVisibility';
 
 class LabelTool extends AnnotationTool {
   static toolName = 'Label';
@@ -596,6 +597,10 @@ class LabelTool extends AnnotationTool {
       if (!viewport.getRenderingEngine()) {
         console.warn('Rendering Engine has been destroyed');
         return renderStatus;
+      }
+
+      if (!isAnnotationVisible(annotationUID)) {
+        continue;
       }
 
       if (!data.text) {

--- a/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
+++ b/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
@@ -915,7 +915,7 @@ class PlanarFreehandROITool extends ContourSegmentationBaseTool {
     let intersections = [];
     let intersectionCounter = 0;
     let pointsInShape;
-    if (imageData.getScalarValueFromWorld) {
+    if (voxelManager) {
       pointsInShape = voxelManager.forEach(
         this.configuration.statsCalculator.statsCallback,
         {

--- a/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
+++ b/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
@@ -956,27 +956,26 @@ class PlanarFreehandROITool extends ContourSegmentationBaseTool {
           returnPoints: this.configuration.storePointData,
         }
       );
-
-      const stats = this.configuration.statsCalculator.getStatistics();
-      cachedStats[targetId] = {
-        Modality: metadata.Modality,
-        area,
-        perimeter: calculatePerimeter(canvasCoordinates, closed) / scale,
-        mean: stats.mean?.value,
-        max: stats.max?.value,
-        stdDev: stats.stdDev?.value,
-        statsArray: stats.array,
-        pointsInShape: pointsInShape,
-        /**
-         * areaUnit are sizing, eg mm^2 typically
-         * modality units are pixel value units, eg HU or other
-         * unit is linear measurement unit, eg mm
-         */
-        areaUnit,
-        modalityUnit,
-        unit,
-      };
     }
+    const stats = this.configuration.statsCalculator.getStatistics();
+    cachedStats[targetId] = {
+      Modality: metadata.Modality,
+      area,
+      perimeter: calculatePerimeter(canvasCoordinates, closed) / scale,
+      mean: stats.mean?.value,
+      max: stats.max?.value,
+      stdDev: stats.stdDev?.value,
+      statsArray: stats.array,
+      pointsInShape: pointsInShape,
+      /**
+       * areaUnit are sizing, eg mm^2 typically
+       * modality units are pixel value units, eg HU or other
+       * unit is linear measurement unit, eg mm
+       */
+      areaUnit,
+      modalityUnit,
+      unit,
+    };
   }
 
   protected updateOpenCachedStats({

--- a/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
+++ b/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
@@ -915,7 +915,7 @@ class PlanarFreehandROITool extends ContourSegmentationBaseTool {
     let intersections = [];
     let intersectionCounter = 0;
     let pointsInShape;
-    if (imageData.scalarData) {
+    if (imageData.getScalarValueFromWorld) {
       pointsInShape = voxelManager.forEach(
         this.configuration.statsCalculator.statsCallback,
         {

--- a/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
+++ b/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
@@ -914,49 +914,50 @@ class PlanarFreehandROITool extends ContourSegmentationBaseTool {
     let curRow = 0;
     let intersections = [];
     let intersectionCounter = 0;
-    const pointsInShape = voxelManager.forEach(
-      this.configuration.statsCalculator.statsCallback,
-      {
-        imageData,
-        isInObject: (pointLPS, _pointIJK) => {
-          let result = true;
-          const point = viewport.worldToCanvas(pointLPS);
-          if (point[1] != curRow) {
-            intersectionCounter = 0;
-            curRow = point[1];
-            intersections = getLineSegmentIntersectionsCoordinates(
-              canvasCoordinates,
-              point,
-              [canvasPosEnd[0], point[1]]
-            );
-            intersections.sort(
-              (function (index) {
-                return function (a, b) {
-                  return a[index] === b[index]
-                    ? 0
-                    : a[index] < b[index]
-                    ? -1
-                    : 1;
-                };
-              })(0)
-            );
-          }
-          if (intersections.length && point[0] > intersections[0][0]) {
-            intersections.shift();
-            intersectionCounter++;
-          }
-          if (intersectionCounter % 2 === 0) {
-            result = false;
-          }
-          return result;
-        },
-        boundsIJK,
-        returnPoints: this.configuration.storePointData,
-      }
-    );
-
+    let pointsInShape;
+    if (imageData.getScalarData() !== null) {
+      pointsInShape = voxelManager.forEach(
+        this.configuration.statsCalculator.statsCallback,
+        {
+          imageData,
+          isInObject: (pointLPS, _pointIJK) => {
+            let result = true;
+            const point = viewport.worldToCanvas(pointLPS);
+            if (point[1] != curRow) {
+              intersectionCounter = 0;
+              curRow = point[1];
+              intersections = getLineSegmentIntersectionsCoordinates(
+                canvasCoordinates,
+                point,
+                [canvasPosEnd[0], point[1]]
+              );
+              intersections.sort(
+                (function (index) {
+                  return function (a, b) {
+                    return a[index] === b[index]
+                      ? 0
+                      : a[index] < b[index]
+                      ? -1
+                      : 1;
+                  };
+                })(0)
+              );
+            }
+            if (intersections.length && point[0] > intersections[0][0]) {
+              intersections.shift();
+              intersectionCounter++;
+            }
+            if (intersectionCounter % 2 === 0) {
+              result = false;
+            }
+            return result;
+          },
+          boundsIJK,
+          returnPoints: this.configuration.storePointData,
+        }
+      );
+    }
     const stats = this.configuration.statsCalculator.getStatistics();
-
     cachedStats[targetId] = {
       Modality: metadata.Modality,
       area,
@@ -1085,7 +1086,7 @@ function defaultGetTextLines(data, targetId): string[] {
     textLines.push(`Mean: ${csUtils.roundNumber(mean)} ${modalityUnit}`);
   }
 
-  if (Number.isFinite(max)) {
+  if (Number.isFinite(max) && !isNaN(max)) {
     textLines.push(`Max: ${csUtils.roundNumber(max)} ${modalityUnit}`);
   }
 

--- a/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
+++ b/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
@@ -915,7 +915,7 @@ class PlanarFreehandROITool extends ContourSegmentationBaseTool {
     let intersections = [];
     let intersectionCounter = 0;
     let pointsInShape;
-    if (imageData.getScalarData() !== null) {
+    if (imageData.scalarData) {
       pointsInShape = voxelManager.forEach(
         this.configuration.statsCalculator.statsCallback,
         {
@@ -956,26 +956,27 @@ class PlanarFreehandROITool extends ContourSegmentationBaseTool {
           returnPoints: this.configuration.storePointData,
         }
       );
+
+      const stats = this.configuration.statsCalculator.getStatistics();
+      cachedStats[targetId] = {
+        Modality: metadata.Modality,
+        area,
+        perimeter: calculatePerimeter(canvasCoordinates, closed) / scale,
+        mean: stats.mean?.value,
+        max: stats.max?.value,
+        stdDev: stats.stdDev?.value,
+        statsArray: stats.array,
+        pointsInShape: pointsInShape,
+        /**
+         * areaUnit are sizing, eg mm^2 typically
+         * modality units are pixel value units, eg HU or other
+         * unit is linear measurement unit, eg mm
+         */
+        areaUnit,
+        modalityUnit,
+        unit,
+      };
     }
-    const stats = this.configuration.statsCalculator.getStatistics();
-    cachedStats[targetId] = {
-      Modality: metadata.Modality,
-      area,
-      perimeter: calculatePerimeter(canvasCoordinates, closed) / scale,
-      mean: stats.mean?.value,
-      max: stats.max?.value,
-      stdDev: stats.stdDev?.value,
-      statsArray: stats.array,
-      pointsInShape: pointsInShape,
-      /**
-       * areaUnit are sizing, eg mm^2 typically
-       * modality units are pixel value units, eg HU or other
-       * unit is linear measurement unit, eg mm
-       */
-      areaUnit,
-      modalityUnit,
-      unit,
-    };
   }
 
   protected updateOpenCachedStats({

--- a/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
+++ b/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
@@ -915,7 +915,7 @@ class PlanarFreehandROITool extends ContourSegmentationBaseTool {
     let intersections = [];
     let intersectionCounter = 0;
     let pointsInShape;
-    if (voxelManager.length) {
+    if (imageData.getScalarValueFromWorld) {
       pointsInShape = voxelManager.forEach(
         this.configuration.statsCalculator.statsCallback,
         {

--- a/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
+++ b/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
@@ -915,7 +915,7 @@ class PlanarFreehandROITool extends ContourSegmentationBaseTool {
     let intersections = [];
     let intersectionCounter = 0;
     let pointsInShape;
-    if (imageData.getScalarValueFromWorld) {
+    if (voxelManager.length) {
       pointsInShape = voxelManager.forEach(
         this.configuration.statsCalculator.statsCallback,
         {

--- a/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
+++ b/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
@@ -1,3 +1,4 @@
+import { AnnotationTool } from '../base';
 import {
   CONSTANTS,
   getEnabledElement,
@@ -1086,7 +1087,7 @@ function defaultGetTextLines(data, targetId): string[] {
     textLines.push(`Mean: ${csUtils.roundNumber(mean)} ${modalityUnit}`);
   }
 
-  if (Number.isFinite(max) && !isNaN(max)) {
+  if (AnnotationTool.isNumber(max)) {
     textLines.push(`Max: ${csUtils.roundNumber(max)} ${modalityUnit}`);
   }
 

--- a/packages/tools/src/tools/annotation/RectangleROITool.ts
+++ b/packages/tools/src/tools/annotation/RectangleROITool.ts
@@ -474,8 +474,6 @@ class RectangleROITool extends AnnotationTool {
 
     this.editData.hasMoved = true;
 
-    const enabledElement = getEnabledElement(element);
-
     triggerAnnotationRenderForViewportIds(viewportIdsToRender);
 
     if (annotation.invalidated) {
@@ -1059,13 +1057,13 @@ function defaultGetTextLines(data, targetId: string): string[] {
 
   const textLines: string[] = [];
   textLines.push(`Area: ${csUtils.roundNumber(area)} ${areaUnit}`);
-  if (isFinite(mean) && !isNaN(mean)) {
+  if (AnnotationTool.isNumber(mean)) {
     textLines.push(`Mean: ${csUtils.roundNumber(mean)} ${modalityUnit}`);
   }
-  if (isFinite(max) && !isNaN(max)) {
+  if (AnnotationTool.isNumber(max)) {
     textLines.push(`Max: ${csUtils.roundNumber(max)} ${modalityUnit}`);
   }
-  if (isFinite(stdDev) && !isNaN(stdDev)) {
+  if (AnnotationTool.isNumber(stdDev)) {
     textLines.push(`Std Dev: ${csUtils.roundNumber(stdDev)} ${modalityUnit}`);
   }
   return textLines;

--- a/packages/tools/src/tools/annotation/RectangleROITool.ts
+++ b/packages/tools/src/tools/annotation/RectangleROITool.ts
@@ -931,7 +931,7 @@ class RectangleROITool extends AnnotationTool {
         );
 
         let pointsInShape;
-        if (imageData.getScalarValueFromWorld) {
+        if (voxelManager) {
           pointsInShape = voxelManager.forEach(
             this.configuration.statsCalculator.statsCallback,
             {

--- a/packages/tools/src/tools/annotation/RectangleROITool.ts
+++ b/packages/tools/src/tools/annotation/RectangleROITool.ts
@@ -930,16 +930,18 @@ class RectangleROITool extends AnnotationTool {
           pixelUnitsOptions
         );
 
-        const pointsInShape = voxelManager.forEach(
-          this.configuration.statsCalculator.statsCallback,
-          {
-            boundsIJK,
-            imageData,
-            returnPoints: this.configuration.storePointData,
-          }
-        );
+        let pointsInShape;
+        if (imageData.getScalarData() !== null) {
+          pointsInShape = voxelManager.forEach(
+            this.configuration.statsCalculator.statsCallback,
+            {
+              boundsIJK,
+              imageData,
+              returnPoints: this.configuration.storePointData,
+            }
+          );
+        }
         const stats = this.configuration.statsCalculator.getStatistics();
-
         cachedStats[targetId] = {
           Modality: metadata.Modality,
           area,
@@ -968,6 +970,14 @@ class RectangleROITool extends AnnotationTool {
   };
 
   _isInsideVolume = (index1, index2, dimensions) => {
+    // for wsiViewport
+    if (index1[1] < 0) {
+      index1[1] = -index1[1];
+    }
+    if (index2[1] < 0) {
+      index2[1] = -index2[1];
+    }
+
     return (
       csUtils.indexWithinDimensions(index1, dimensions) &&
       csUtils.indexWithinDimensions(index2, dimensions)
@@ -1048,12 +1058,16 @@ function defaultGetTextLines(data, targetId: string): string[] {
   }
 
   const textLines: string[] = [];
-
   textLines.push(`Area: ${csUtils.roundNumber(area)} ${areaUnit}`);
-  textLines.push(`Mean: ${csUtils.roundNumber(mean)} ${modalityUnit}`);
-  textLines.push(`Max: ${csUtils.roundNumber(max)} ${modalityUnit}`);
-  textLines.push(`Std Dev: ${csUtils.roundNumber(stdDev)} ${modalityUnit}`);
-
+  if (isFinite(mean) && !isNaN(mean)) {
+    textLines.push(`Mean: ${csUtils.roundNumber(mean)} ${modalityUnit}`);
+  }
+  if (isFinite(max) && !isNaN(max)) {
+    textLines.push(`Max: ${csUtils.roundNumber(max)} ${modalityUnit}`);
+  }
+  if (isFinite(stdDev) && !isNaN(stdDev)) {
+    textLines.push(`Std Dev: ${csUtils.roundNumber(stdDev)} ${modalityUnit}`);
+  }
   return textLines;
 }
 

--- a/packages/tools/src/tools/annotation/RectangleROITool.ts
+++ b/packages/tools/src/tools/annotation/RectangleROITool.ts
@@ -931,7 +931,7 @@ class RectangleROITool extends AnnotationTool {
         );
 
         let pointsInShape;
-        if (image.scalarData.length > 0) {
+        if (voxelManager.length) {
           pointsInShape = voxelManager.forEach(
             this.configuration.statsCalculator.statsCallback,
             {

--- a/packages/tools/src/tools/annotation/RectangleROITool.ts
+++ b/packages/tools/src/tools/annotation/RectangleROITool.ts
@@ -931,7 +931,7 @@ class RectangleROITool extends AnnotationTool {
         );
 
         let pointsInShape;
-        if (voxelManager.length) {
+        if (imageData.getScalarValueFromWorld) {
           pointsInShape = voxelManager.forEach(
             this.configuration.statsCalculator.statsCallback,
             {

--- a/packages/tools/src/tools/annotation/RectangleROITool.ts
+++ b/packages/tools/src/tools/annotation/RectangleROITool.ts
@@ -931,7 +931,7 @@ class RectangleROITool extends AnnotationTool {
         );
 
         let pointsInShape;
-        if (imageData.getScalarData() !== null) {
+        if (image.scalarData.length > 0) {
           pointsInShape = voxelManager.forEach(
             this.configuration.statsCalculator.statsCallback,
             {

--- a/packages/tools/src/tools/base/AnnotationTool.ts
+++ b/packages/tools/src/tools/base/AnnotationTool.ts
@@ -732,6 +732,17 @@ abstract class AnnotationTool extends AnnotationDisplayTool {
       viewport,
     };
   }
+
+  /**
+   * @param n - array of numbers or a simple number
+   * @returns True if n or the first element of n is finite and not NaN
+   */
+  public static isNumber(n: number[] | number): boolean {
+    if (Array.isArray(n)) {
+      return this.isNumber(n[0]);
+    }
+    return isFinite(n) && !isNaN(n);
+  }
 }
 
 AnnotationTool.toolName = 'AnnotationTool';


### PR DESCRIPTION
### Context

CircleROI and other ROI tools were not generating stats for wsi viewport.  

### Changes & Results

This PR fixes the CircleROI, RectangleROI, EllipseROI and FreehandROI tool for whole slide (wsi) viewports by skipping statistics calculation that require the voxel manager. 
Key changes include:

Changing wsiViewport so that getScalarData returns an empty CanvasScalarData object instead of null.

Wrapping the voxel manager-based points collection of each tool  in a condition that bypasses the process when the  scalarData is empty.


<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
