### PR TITLE
fix(annotation-tools): trigger annotation modified only if invalidated across multiple tools

### DIFF
--- a/packages/tools/src/tools/annotation/AngleTool.ts
+++ b/packages/tools/src/tools/annotation/AngleTool.ts
@@ -875,10 +875,13 @@ class AngleTool extends AnnotationTool {
       };
     }
 
+    const invalidated = annotation.invalidated;
     annotation.invalidated = false;
 
-    // Dispatching annotation modified
-    triggerAnnotationModified(annotation, element, ChangeTypes.StatsUpdated);
+    // Dispatching annotation modified only if it was invalidated
+    if (invalidated) {
+      triggerAnnotationModified(annotation, element, ChangeTypes.StatsUpdated);
+    }
 
     return cachedStats;
   }

--- a/packages/tools/src/tools/annotation/BidirectionalTool.ts
+++ b/packages/tools/src/tools/annotation/BidirectionalTool.ts
@@ -1396,10 +1396,13 @@ class BidirectionalTool extends AnnotationTool {
       };
     }
 
+    const invalidated = annotation.invalidated;
     annotation.invalidated = false;
 
-    // Dispatching annotation modified
-    triggerAnnotationModified(annotation, element, ChangeTypes.StatsUpdated);
+    // Dispatching annotation modified only if it was invalidated
+    if (invalidated) {
+      triggerAnnotationModified(annotation, element, ChangeTypes.StatsUpdated);
+    }
 
     return cachedStats;
   };

--- a/packages/tools/src/tools/annotation/CircleROITool.ts
+++ b/packages/tools/src/tools/annotation/CircleROITool.ts
@@ -873,6 +873,8 @@ class CircleROITool extends AnnotationTool {
     const data = annotation.data;
     const { element } = viewport;
 
+    const wasInvalidated = annotation.invalidated;
+
     const { points } = data.handles;
 
     const canvasCoordinates = points.map((p) => viewport.worldToCanvas(p));
@@ -1022,7 +1024,9 @@ class CircleROITool extends AnnotationTool {
     annotation.invalidated = false;
 
     // Dispatching annotation modified
-    triggerAnnotationModified(annotation, element, ChangeTypes.StatsUpdated);
+    if (wasInvalidated) {
+      triggerAnnotationModified(annotation, element, ChangeTypes.StatsUpdated);
+    }
 
     return cachedStats;
   };

--- a/packages/tools/src/tools/annotation/CobbAngleTool.ts
+++ b/packages/tools/src/tools/annotation/CobbAngleTool.ts
@@ -1029,10 +1029,13 @@ class CobbAngleTool extends AnnotationTool {
       };
     }
 
+    const invalidated = annotation.invalidated;
     annotation.invalidated = false;
 
-    // Dispatching annotation modified
-    triggerAnnotationModified(annotation, element, ChangeTypes.StatsUpdated);
+    // Dispatching annotation modified only if it was invalidated
+    if (invalidated) {
+      triggerAnnotationModified(annotation, element, ChangeTypes.StatsUpdated);
+    }
 
     return cachedStats;
   }

--- a/packages/tools/src/tools/annotation/EllipticalROITool.ts
+++ b/packages/tools/src/tools/annotation/EllipticalROITool.ts
@@ -1170,10 +1170,13 @@ class EllipticalROITool extends AnnotationTool {
       };
     }
 
+    const invalidated = annotation.invalidated;
     annotation.invalidated = false;
 
-    // Dispatching annotation modified
-    triggerAnnotationModified(annotation, element, ChangeTypes.StatsUpdated);
+    // Dispatching annotation modified only if it was invalidated
+    if (invalidated) {
+      triggerAnnotationModified(annotation, element, ChangeTypes.StatsUpdated);
+    }
 
     return cachedStats;
   };

--- a/packages/tools/src/tools/annotation/HeightTool.ts
+++ b/packages/tools/src/tools/annotation/HeightTool.ts
@@ -1,4 +1,4 @@
-import { Events } from '../../enums';
+import { ChangeTypes, Events } from '../../enums';
 import { getEnabledElement, utilities as csUtils } from '@cornerstonejs/core';
 import type { Types } from '@cornerstonejs/core';
 
@@ -838,10 +838,13 @@ class HeightTool extends AnnotationTool {
       };
     }
 
+    const invalidated = annotation.invalidated;
     annotation.invalidated = false;
 
-    // Dispatching annotation modified
-    triggerAnnotationModified(annotation, element);
+    // Dispatching annotation modified only if it was invalidated
+    if (invalidated) {
+      triggerAnnotationModified(annotation, element, ChangeTypes.StatsUpdated);
+    }
 
     return cachedStats;
   }

--- a/packages/tools/src/tools/annotation/LengthTool.ts
+++ b/packages/tools/src/tools/annotation/LengthTool.ts
@@ -894,10 +894,13 @@ class LengthTool extends AnnotationTool {
       };
     }
 
+    const invalidated = annotation.invalidated;
     annotation.invalidated = false;
 
-    // Dispatching annotation modified
-    triggerAnnotationModified(annotation, element, ChangeTypes.StatsUpdated);
+    // Dispatching annotation modified only if it was invalidated
+    if (invalidated) {
+      triggerAnnotationModified(annotation, element, ChangeTypes.StatsUpdated);
+    }
 
     return cachedStats;
   }

--- a/packages/tools/src/tools/annotation/LivewireContourTool.ts
+++ b/packages/tools/src/tools/annotation/LivewireContourTool.ts
@@ -1095,11 +1095,17 @@ class LivewireContourTool extends ContourSegmentationBaseTool {
       };
     }
 
-    this.triggerAnnotationModified(
-      annotation,
-      enabledElement,
-      ChangeTypes.StatsUpdated
-    );
+    const invalidated = annotation.invalidated;
+    annotation.invalidated = false;
+
+    // Dispatching annotation modified only if it was invalidated
+    if (invalidated) {
+      this.triggerAnnotationModified(
+        annotation,
+        enabledElement,
+        ChangeTypes.StatsUpdated
+      );
+    }
 
     return cachedStats;
   };

--- a/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
+++ b/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
@@ -811,13 +811,17 @@ class PlanarFreehandROITool extends ContourSegmentationBaseTool {
       }
     }
 
-    triggerAnnotationModified(
-      annotation,
-      enabledElement.viewport.element,
-      ChangeTypes.StatsUpdated
-    );
-
+    const invalidated = annotation.invalidated;
     annotation.invalidated = false;
+
+    // Dispatching annotation modified only if it was invalidated
+    if (invalidated) {
+      triggerAnnotationModified(
+        annotation,
+        enabledElement.viewport.element,
+        ChangeTypes.StatsUpdated
+      );
+    }
 
     return cachedStats;
   };

--- a/packages/tools/src/tools/annotation/ProbeTool.ts
+++ b/packages/tools/src/tools/annotation/ProbeTool.ts
@@ -653,10 +653,13 @@ class ProbeTool extends AnnotationTool {
           Modality: modality,
         };
       }
+    }
 
-      annotation.invalidated = false;
+    const invalidated = annotation.invalidated;
+    annotation.invalidated = false;
 
-      // Dispatching annotation modified
+    // Dispatching annotation modified only if it was invalidated
+    if (invalidated) {
       triggerAnnotationModified(annotation, element, changeType);
     }
 

--- a/packages/tools/src/tools/annotation/RectangleROITool.ts
+++ b/packages/tools/src/tools/annotation/RectangleROITool.ts
@@ -959,10 +959,13 @@ class RectangleROITool extends AnnotationTool {
       }
     }
 
+    const invalidated = annotation.invalidated;
     annotation.invalidated = false;
 
-    // Dispatching annotation modified
-    triggerAnnotationModified(annotation, element, ChangeTypes.StatsUpdated);
+    // Dispatching annotation modified only if it was invalidated
+    if (invalidated) {
+      triggerAnnotationModified(annotation, element, ChangeTypes.StatsUpdated);
+    }
 
     return cachedStats;
   };

--- a/packages/tools/src/tools/annotation/SplineROITool.ts
+++ b/packages/tools/src/tools/annotation/SplineROITool.ts
@@ -1225,11 +1225,17 @@ class SplineROITool extends ContourSegmentationBaseTool {
       };
     }
 
-    this.triggerAnnotationModified(
-      annotation,
-      enabledElement,
-      ChangeTypes.StatsUpdated
-    );
+    const invalidated = annotation.invalidated;
+    annotation.invalidated = false;
+
+    // Dispatching annotation modified only if it was invalidated
+    if (invalidated) {
+      this.triggerAnnotationModified(
+        annotation,
+        enabledElement,
+        ChangeTypes.StatsUpdated
+      );
+    }
 
     return cachedStats;
   };

--- a/packages/tools/src/tools/annotation/UltrasoundDirectionalTool.ts
+++ b/packages/tools/src/tools/annotation/UltrasoundDirectionalTool.ts
@@ -1,4 +1,4 @@
-import { Events } from '../../enums';
+import { ChangeTypes, Events } from '../../enums';
 import {
   getEnabledElement,
   utilities as csUtils,
@@ -876,10 +876,13 @@ class UltrasoundDirectionalTool extends AnnotationTool {
       };
     }
 
+    const invalidated = annotation.invalidated;
     annotation.invalidated = false;
 
-    // Dispatching annotation modified
-    triggerAnnotationModified(annotation, element);
+    // Dispatching annotation modified only if it was invalidated
+    if (invalidated) {
+      triggerAnnotationModified(annotation, element, ChangeTypes.StatsUpdated);
+    }
 
     return cachedStats;
   }

--- a/packages/tools/src/tools/annotation/VideoRedactionTool.ts
+++ b/packages/tools/src/tools/annotation/VideoRedactionTool.ts
@@ -437,7 +437,7 @@ class VideoRedactionTool extends AnnotationTool {
   };
 
   /**
-   * Remove event handlers for the modify event loop, and enable default event prapogation.
+   * Remove event handlers for the modify event loop, and enable default event propagation.
    */
   _deactivateModify = (element) => {
     state.isInteractingWithTool = false;

--- a/packages/tools/src/tools/annotation/VideoRedactionTool.ts
+++ b/packages/tools/src/tools/annotation/VideoRedactionTool.ts
@@ -21,7 +21,7 @@ import {
   drawRedactionRect as drawRedactionRectSvg,
 } from '../../drawingSvg';
 import { state } from '../../store/state';
-import { Events } from '../../enums';
+import { ChangeTypes, Events } from '../../enums';
 import { getViewportIdsWithToolToRender } from '../../utilities/viewportFilters';
 import * as rectangle from '../../utilities/math/rectangle';
 import {
@@ -437,7 +437,7 @@ class VideoRedactionTool extends AnnotationTool {
   };
 
   /**
-   * Remove event handlers for the modify event loop, and enable default event propagation.
+   * Remove event handlers for the modify event loop, and enable default event prapogation.
    */
   _deactivateModify = (element) => {
     state.isInteractingWithTool = false;
@@ -702,18 +702,21 @@ class VideoRedactionTool extends AnnotationTool {
       }
     }
 
-    data.invalidated = false;
+    const invalidated = annotation.invalidated;
+    annotation.invalidated = false;
 
-    // Dispatching measurement modified
-    const eventType = Events.ANNOTATION_MODIFIED;
-
-    const eventDetail = {
-      annotation,
-      viewportUID,
-      renderingEngineUID,
-      sceneUID: sceneUID,
-    };
-    triggerEvent(eventTarget, eventType, eventDetail);
+    // Dispatching measurement modified only if it was invalidated
+    if (invalidated) {
+      const eventType = Events.ANNOTATION_MODIFIED;
+      const eventDetail = {
+        annotation,
+        viewportUID,
+        renderingEngineUID,
+        sceneUID: sceneUID,
+        changeType: ChangeTypes.StatsUpdated,
+      };
+      triggerEvent(eventTarget, eventType, eventDetail);
+    }
 
     return cachedStats;
   };


### PR DESCRIPTION
fixes https://github.com/cornerstonejs/cornerstone3D/issues/1489
fixes https://github.com/cornerstonejs/cornerstone3D/issues/1491
fixes https://github.com/cornerstonejs/cornerstone3D/issues/939


This pull request includes several changes to various annotation tools to ensure that the `triggerAnnotationModified` function is only called if the annotation was invalidated. Additionally, there are some minor import updates and a typo correction.

Changes to ensure `triggerAnnotationModified` is called only if invalidated:

* [`packages/tools/src/tools/annotation/AngleTool.ts`](diffhunk://#diff-cc523708d731a68e025c3aa9101382e1df131d7f2b214c501e7937caa138b340R878-R884): Added a check to call `triggerAnnotationModified` only if the annotation was invalidated.
* [`packages/tools/src/tools/annotation/BidirectionalTool.ts`](diffhunk://#diff-c01a77cfafd8e025678b98849ada98901ef9bd7cd170944e5b3f1ecd319b6ac9R1399-R1405): Added a check to call `triggerAnnotationModified` only if the annotation was invalidated.
* [`packages/tools/src/tools/annotation/CircleROITool.ts`](diffhunk://#diff-b38e5953adb5a687ae6b22500122b180a766c9175daa90aa650dbb3b8a538167R876-R877): Added a check to call `triggerAnnotationModified` only if the annotation was invalidated. [[1]](diffhunk://#diff-b38e5953adb5a687ae6b22500122b180a766c9175daa90aa650dbb3b8a538167R876-R877) [[2]](diffhunk://#diff-b38e5953adb5a687ae6b22500122b180a766c9175daa90aa650dbb3b8a538167R1027-R1029)
* [`packages/tools/src/tools/annotation/CobbAngleTool.ts`](diffhunk://#diff-f1ce9b6784a7e00cc24bd9973fc29eeaab4c86f282444ce598b1633dcfc8569eR1032-R1038): Added a check to call `triggerAnnotationModified` only if the annotation was invalidated.
* [`packages/tools/src/tools/annotation/EllipticalROITool.ts`](diffhunk://#diff-e735f312e540093613d28d671b72e0bb6b1c229423c9970bf531b63e79e93227R1173-R1179): Added a check to call `triggerAnnotationModified` only if the annotation was invalidated.
* [`packages/tools/src/tools/annotation/HeightTool.ts`](diffhunk://#diff-ea384593960300ded59d0524415a7bb2657c31063c42987ee5c6c25ad40e7ac0R841-R847): Added a check to call `triggerAnnotationModified` only if the annotation was invalidated.
* [`packages/tools/src/tools/annotation/LengthTool.ts`](diffhunk://#diff-4bdf7112153ce30f1829f12a4e4899bcf36b964d578c23c5c0e82235f8e166f3R897-R903): Added a check to call `triggerAnnotationModified` only if the annotation was invalidated.
* [`packages/tools/src/tools/annotation/LivewireContourTool.ts`](diffhunk://#diff-3ca58cb8cc86e88283b41c4d5df0e70e6cc5cb02335a3c5f86bde188dc058ffdR1098-R1108): Added a check to call `triggerAnnotationModified` only if the annotation was invalidated.
* [`packages/tools/src/tools/annotation/PlanarFreehandROITool.ts`](diffhunk://#diff-30e53f5adb45d004036f0a67ea62e0729ce6f25b65136476867fc977ad5fabf0R814-R824): Added a check to call `triggerAnnotationModified` only if the annotation was invalidated.
* [`packages/tools/src/tools/annotation/ProbeTool.ts`](diffhunk://#diff-e8bf549b9273a829bb5ccd78f75a0233aba57e637520b2825b46fe340540aa8fR656-R662): Added a check to call `triggerAnnotationModified` only if the annotation was invalidated.
* [`packages/tools/src/tools/annotation/RectangleROITool.ts`](diffhunk://#diff-7b7c01629686a77cb93204d8cea1e3b0d27379f60411fd3530a3de5f80edab24R962-R968): Added a check to call `triggerAnnotationModified` only if the annotation was invalidated.
* [`packages/tools/src/tools/annotation/SplineROITool.ts`](diffhunk://#diff-a6d3d8b5adc48bda00b5cc45ff28a1e19dc3488d87d40798b8b9b7500d93b22dR1228-R1238): Added a check to call `triggerAnnotationModified` only if the annotation was invalidated.
* [`packages/tools/src/tools/annotation/UltrasoundDirectionalTool.ts`](diffhunk://#diff-3cc03c45684881a604332729eaecd86ada5f58b5613a94276f8393563b2bbb16R879-R885): Added a check to call `triggerAnnotationModified` only if the annotation was invalidated.
* [`packages/tools/src/tools/annotation/VideoRedactionTool.ts`](diffhunk://#diff-6d276522c8d0cc072cfb6d8f41bb4cada3ed81ff0d6ae577000ed9728b9b2a40L705-R719): Added a check to call `triggerAnnotationModified` only if the annotation was invalidated.

Minor updates:

* [`packages/tools/src/tools/annotation/HeightTool.ts`](diffhunk://#diff-ea384593960300ded59d0524415a7bb2657c31063c42987ee5c6c25ad40e7ac0L1-R1): Updated imports to include `ChangeTypes`.
* [`packages/tools/src/tools/annotation/UltrasoundDirectionalTool.ts`](diffhunk://#diff-3cc03c45684881a604332729eaecd86ada5f58b5613a94276f8393563b2bbb16L1-R1): Updated imports to include `ChangeTypes`.
* [`packages/tools/src/tools/annotation/VideoRedactionTool.ts`](diffhunk://#diff-6d276522c8d0cc072cfb6d8f41bb4cada3ed81ff0d6ae577000ed9728b9b2a40L24-R24): Updated imports to include `ChangeTypes`.
* [`packages/tools/src/tools/annotation/VideoRedactionTool.ts`](diffhunk://#diff-6d276522c8d0cc072cfb6d8f41bb4cada3ed81ff0d6ae577000ed9728b9b2a40L440-R440): Corrected a typo in the comment.