### PR TITLE
fix: Color rendering in node

### DIFF
--- a/packages/core/src/RenderingEngine/helpers/cpuFallback/rendering/renderColorImage.ts
+++ b/packages/core/src/RenderingEngine/helpers/cpuFallback/rendering/renderColorImage.ts
@@ -11,6 +11,7 @@ import type {
   CPUFallbackViewport,
   CPUFallbackEnabledElement,
 } from '../../../../types';
+import { createCanvas } from '../../getOrCreateCanvas';
 
 /**
  * Generates an appropriate Look Up Table to render the given image with the given window width and level (specified in the viewport)
@@ -64,8 +65,11 @@ function getRenderCanvas(
   const canvasWasColor = enabledElement.renderingTools.lastRenderedIsColor;
 
   if (!enabledElement.renderingTools.renderCanvas || !canvasWasColor) {
-    enabledElement.renderingTools.renderCanvas =
-      document.createElement('canvas');
+    enabledElement.renderingTools.renderCanvas = createCanvas(
+      null,
+      image.width,
+      image.height
+    ) as unknown as HTMLCanvasElement;
   }
 
   const renderCanvas = enabledElement.renderingTools.renderCanvas;
@@ -93,6 +97,7 @@ function getRenderCanvas(
   // NOTE: This might be inefficient if we are updating multiple images of different
   // Sizes frequently.
   if (
+    !enabledElement.renderingTools.renderCanvasContext ||
     renderCanvas.width !== image.width ||
     renderCanvas.height !== image.height
   ) {

--- a/packages/core/src/RenderingEngine/helpers/cpuFallback/rendering/renderPseudoColorImage.ts
+++ b/packages/core/src/RenderingEngine/helpers/cpuFallback/rendering/renderPseudoColorImage.ts
@@ -9,6 +9,7 @@ import storedPixelDataToCanvasImageDataPseudocolorLUTPET from './storedPixelData
 import * as colors from '../colors/index';
 import type { IImage, CPUFallbackEnabledElement } from '../../../../types';
 import { clamp } from '../../../../utilities/clamp';
+import { createCanvas } from '../../getOrCreateCanvas';
 
 /**
  * Returns an appropriate canvas to render the Image. If the canvas available in the cache is appropriate
@@ -26,8 +27,11 @@ function getRenderCanvas(
   invalidated: boolean
 ): HTMLCanvasElement {
   if (!enabledElement.renderingTools.renderCanvas) {
-    enabledElement.renderingTools.renderCanvas =
-      document.createElement('canvas');
+    enabledElement.renderingTools.renderCanvas = createCanvas(
+      null,
+      image.width,
+      image.height
+    ) as unknown as HTMLCanvasElement;
   }
 
   const renderCanvas = enabledElement.renderingTools.renderCanvas;
@@ -62,6 +66,7 @@ function getRenderCanvas(
   // NOTE: This might be inefficient if we are updating multiple images of different
   // Sizes frequently.
   if (
+    !enabledElement.renderingTools.renderCanvasContext ||
     renderCanvas.width !== image.width ||
     renderCanvas.height !== image.height
   ) {

--- a/packages/core/src/RenderingEngine/helpers/cpuFallback/rendering/storedColorPixelDataToCanvasImageData.ts
+++ b/packages/core/src/RenderingEngine/helpers/cpuFallback/rendering/storedColorPixelDataToCanvasImageData.ts
@@ -38,8 +38,7 @@ export default function (
       canvasImageDataData[canvasImageDataIndex++] =
         lut[pixelData[storedPixelDataIndex++] + -minPixelValue]; // Green
       canvasImageDataData[canvasImageDataIndex] =
-        lut[pixelData[storedPixelDataIndex] + -minPixelValue]; // Blue
-      storedPixelDataIndex += 2;
+        lut[pixelData[storedPixelDataIndex++] + -minPixelValue]; // Blue
       canvasImageDataIndex += 2;
     }
   } else {
@@ -49,8 +48,7 @@ export default function (
       canvasImageDataData[canvasImageDataIndex++] =
         lut[pixelData[storedPixelDataIndex++]]; // Green
       canvasImageDataData[canvasImageDataIndex] =
-        lut[pixelData[storedPixelDataIndex]]; // Blue
-      storedPixelDataIndex += 2;
+        lut[pixelData[storedPixelDataIndex++]]; // Blue
       canvasImageDataIndex += 2;
     }
   }

--- a/packages/core/src/RenderingEngine/helpers/cpuFallback/rendering/storedColorPixelDataToCanvasImageData.ts
+++ b/packages/core/src/RenderingEngine/helpers/cpuFallback/rendering/storedColorPixelDataToCanvasImageData.ts
@@ -37,9 +37,9 @@ export default function (
         lut[pixelData[storedPixelDataIndex++] + -minPixelValue]; // Red
       canvasImageDataData[canvasImageDataIndex++] =
         lut[pixelData[storedPixelDataIndex++] + -minPixelValue]; // Green
-      canvasImageDataData[canvasImageDataIndex] =
+      canvasImageDataData[canvasImageDataIndex++] =
         lut[pixelData[storedPixelDataIndex++] + -minPixelValue]; // Blue
-      canvasImageDataIndex += 2;
+      canvasImageDataData[canvasImageDataIndex++] = 255;
     }
   } else {
     while (storedPixelDataIndex < numPixels) {
@@ -47,9 +47,9 @@ export default function (
         lut[pixelData[storedPixelDataIndex++]]; // Red
       canvasImageDataData[canvasImageDataIndex++] =
         lut[pixelData[storedPixelDataIndex++]]; // Green
-      canvasImageDataData[canvasImageDataIndex] =
+      canvasImageDataData[canvasImageDataIndex++] =
         lut[pixelData[storedPixelDataIndex++]]; // Blue
-      canvasImageDataIndex += 2;
+      canvasImageDataData[canvasImageDataIndex++] = 255;
     }
   }
   image.stats.lastStoredPixelDataToCanvasImageDataTime = now() - start;


### PR DESCRIPTION
### Context

Color CPU rendering in node or from an RGB array buffer is broken, as is palette color CPU rendering.

### Changes & Results

Use the new createCanvas to allow node rendering of color images
Fix the offsets for storing array to color image

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)



#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
