### PR TITLE
feat: implement setViewReference via referencedImageId in the volumeViewport

### DIFF
--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -3297,6 +3297,10 @@ class StackViewport extends Viewport {
     return imagePlaneModule;
   }
 
+  public isInAcquisitionPlane(): boolean {
+    return true;
+  }
+
   private renderingPipelineFunctions = {
     getImageData: {
       cpu: this.getImageDataCPU,

--- a/packages/core/src/RenderingEngine/VolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/VolumeViewport.ts
@@ -481,6 +481,23 @@ class VolumeViewport extends BaseVolumeViewport {
     this.viewportProperties.slabThickness = undefined;
   }
 
+  public isInAcquisitionPlane(): boolean {
+    const imageData = this.getImageData();
+
+    if (!imageData) {
+      return false;
+    }
+
+    const { direction } = imageData;
+    const { viewPlaneNormal } = this.getCamera();
+    const normalDirection = [direction[6], direction[7], direction[8]];
+
+    const TOLERANCE = 0.99;
+    return (
+      Math.abs(vec3.dot(viewPlaneNormal, normalDirection as Point3)) > TOLERANCE
+    );
+  }
+
   /**
    * Uses the slice range information to compute the current image id index.
    * Note that this may be offset from the origin location, or opposite in

--- a/packages/core/src/RenderingEngine/VolumeViewport3D.ts
+++ b/packages/core/src/RenderingEngine/VolumeViewport3D.ts
@@ -39,6 +39,10 @@ class VolumeViewport3D extends BaseVolumeViewport {
     return 1;
   };
 
+  public isInAcquisitionPlane(): boolean {
+    return false;
+  }
+
   public resetCamera({
     resetPan = true,
     resetZoom = true,

--- a/packages/tools/src/eventListeners/mouse/mouseDownListener.ts
+++ b/packages/tools/src/eventListeners/mouse/mouseDownListener.ts
@@ -2,7 +2,6 @@ import { getEnabledElement, triggerEvent } from '@cornerstonejs/core';
 import type { Types } from '@cornerstonejs/core';
 
 import Events from '../../enums/Events';
-import { MouseBindings } from '../../enums/ToolBindings';
 import mouseMoveListener from './mouseMoveListener';
 import type { EventTypes, IPoints } from '../../types';
 import getMouseEventPoints from './getMouseEventPoints';


### PR DESCRIPTION
This pull request introduces several changes to the `BaseVolumeViewport` class and related classes in the `RenderingEngine` package. The changes include new methods, imports, and logic to handle acquisition planes and referenced image IDs.

**Key Changes:**

### Enhancements to `BaseVolumeViewport`:

* Added a new abstract method `isInAcquisitionPlane` to the `BaseVolumeViewport` class. This method is implemented in the `StackViewport`, `VolumeViewport`, and `VolumeViewport3D` subclasses to determine if the current viewport is in the acquisition plane. [[1]](diffhunk://#diff-d8f8b6f60e39bf30c7ddecc31bda70056c63091aad137431809e7cf16eadd3b9R698-R699) [[2]](diffhunk://#diff-68d9d8eea6b516148b349d78d67774d70ef1a0a0896f34f003fb3aab336802bfR3300-R3303) [[3]](diffhunk://#diff-b4f9e61259732a6dbcce1198b86f0b30fc3f14f8880f78a15c3230e0b676caeeR484-R500) [[4]](diffhunk://#diff-4ea47cb18e9621f07bd2dcd5ddf685c26ddb90a32ce0db97693e69bc5e20e838R42-R45)
* Added logic to handle `referencedImageId` in the `BaseVolumeViewport` class, ensuring the camera focal point is set correctly when the viewport is in the acquisition plane. [[1]](diffhunk://#diff-d8f8b6f60e39bf30c7ddecc31bda70056c63091aad137431809e7cf16eadd3b9R712) [[2]](diffhunk://#diff-d8f8b6f60e39bf30c7ddecc31bda70056c63091aad137431809e7cf16eadd3b9R777-R812)

### Import Adjustments:

* Updated imports in `BaseVolumeViewport.ts` to include `MetadataModules` and `metaData` for handling metadata operations. [[1]](diffhunk://#diff-d8f8b6f60e39bf30c7ddecc31bda70056c63091aad137431809e7cf16eadd3b9L15-R20) [[2]](diffhunk://#diff-d8f8b6f60e39bf30c7ddecc31bda70056c63091aad137431809e7cf16eadd3b9R69)

### Removal of Unused Imports:

* Removed the unused `MouseBindings` import from `mouseDownListener.ts` in the `tools` package.