### PR TITLE
fix(wsi scaling): adjust canvas-to-index and index-to-canvas transfor…

### DIFF
--- a/packages/core/src/RenderingEngine/WSIViewport.ts
+++ b/packages/core/src/RenderingEngine/WSIViewport.ts
@@ -615,12 +615,16 @@ class WSIViewport extends Viewport {
   protected canvasToIndex = (canvasPos: Point2): Point2 => {
     const transform = this.getTransform();
     transform.invert();
-    return transform.transformPoint(canvasPos);
+    return transform.transformPoint(
+      canvasPos.map((it) => it * devicePixelRatio) as Point2
+    );
   };
 
   protected indexToCanvas = (indexPos: Point2): Point2 => {
     const transform = this.getTransform();
-    return transform.transformPoint(indexPos);
+    return transform
+      .transformPoint(indexPos)
+      .map((it) => it / devicePixelRatio) as Point2;
   };
 
   /** This can be implemented later when multi-slice WSI is supported */


### PR DESCRIPTION


### Context

wsi measurements  are a little off when comparing to the scale at the bottom right.

 
![image](https://github.com/user-attachments/assets/df49763d-2f4e-4b32-bcf6-ab78711a4434)


### Changes & Results

Added devicePixelRatio to transformation functions indexToCanvas and canvasToIndex.

### Testing

![image](https://github.com/user-attachments/assets/561a4ce4-8267-46a7-9211-37b0bfc47e42)


<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
