### PR TITLE
feat: add mode check in mouseMoveCallback for SegmentSelectTool

### DIFF
--- a/packages/tools/src/tools/segmentation/SegmentSelectTool.ts
+++ b/packages/tools/src/tools/segmentation/SegmentSelectTool.ts
@@ -18,6 +18,7 @@ import type {
   Segmentation,
   SegmentationRepresentation,
 } from '../../types/SegmentationStateTypes';
+import { ToolModes } from '../../enums';
 
 /**
  * Represents a tool used for segment selection. It is used to select a segment
@@ -49,6 +50,10 @@ class SegmentSelectTool extends BaseTool {
   }
 
   mouseMoveCallback = (evt: EventTypes.InteractionEventType): boolean => {
+    if (this.mode !== ToolModes.Active) {
+      return;
+    }
+
     if (this.hoverTimer) {
       clearTimeout(this.hoverTimer);
     }


### PR DESCRIPTION
This pull request includes changes to the `SegmentSelectTool` class in the `packages/tools/src/tools/segmentation` directory to improve its functionality and maintainability. The most important changes include importing a new enum and adding a condition to the `mouseMoveCallback` method.

Improvements to `SegmentSelectTool`:

* [`packages/tools/src/tools/segmentation/SegmentSelectTool.ts`](diffhunk://#diff-6c427f0f1049a9b52b680f86c71567a139b2f15176a15a961175bdf1ced55e1aR21): Added import for `ToolModes` enum from `../../enums` to utilize tool modes in the class.
* [`packages/tools/src/tools/segmentation/SegmentSelectTool.ts`](diffhunk://#diff-6c427f0f1049a9b52b680f86c71567a139b2f15176a15a961175bdf1ced55e1aR53-R56): Modified the `mouseMoveCallback` method to include a condition that checks if the tool mode is `ToolModes.Active` before proceeding with the rest of the method logic. This ensures that the callback only executes when the tool is active.