### PR TITLE
Wip - fix(rendering): allow users to define x num of offscreen canvas to support viewports that exceed 16384 in width

### DIFF
--- a/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
@@ -1568,7 +1568,7 @@ abstract class BaseVolumeViewport extends Viewport {
     const renderer = this.getRenderer();
     const displayCoords = this.getVtkDisplayCoords(canvasPos);
     const offscreenMultiRenderWindow =
-      this.getRenderingEngine().offscreenMultiRenderWindow;
+      this.getRenderingEngine().getOffScreenMultiRenderWindow(this.id);
     const openGLRenderWindow =
       offscreenMultiRenderWindow.getOpenGLRenderWindow();
     const worldCoord = openGLRenderWindow.displayToWorld(
@@ -1597,7 +1597,7 @@ abstract class BaseVolumeViewport extends Viewport {
       canvasPos[1] * devicePixelRatio,
     ];
     const offscreenMultiRenderWindow =
-      this.getRenderingEngine().offscreenMultiRenderWindow;
+      this.getRenderingEngine().getOffScreenMultiRenderWindow(this.id);
     const openGLRenderWindow =
       offscreenMultiRenderWindow.getOpenGLRenderWindow();
     const size = openGLRenderWindow.getSize();
@@ -1647,7 +1647,7 @@ abstract class BaseVolumeViewport extends Viewport {
 
     const renderer = this.getRenderer();
     const offscreenMultiRenderWindow =
-      this.getRenderingEngine().offscreenMultiRenderWindow;
+      this.getRenderingEngine().getOffScreenMultiRenderWindow(this.id);
     const openGLRenderWindow =
       offscreenMultiRenderWindow.getOpenGLRenderWindow();
     const size = openGLRenderWindow.getSize();

--- a/packages/core/src/RenderingEngine/RenderingEngine.ts
+++ b/packages/core/src/RenderingEngine/RenderingEngine.ts
@@ -85,18 +85,18 @@ class RenderingEngine {
   private _animationFrameSet = false;
   private _animationFrameHandle: number | null = null;
   private useCPURendering: boolean;
-  private numOfScreenCanvases: number;
+  private numOffScreenCanvases: number;
 
   /**
    * @param uid - Unique identifier for RenderingEngine
-   * @param numOfScreenCanvases - Optional number of offscreen canvases to distribute rendering (default: 1),
+   * @param numOffScreenCanvases - Optional number of offscreen canvases to distribute rendering (default: 1),
    * This is useful for high resolution rendering where viewports are expected to exceed the maximum offscreen canvas width for the browser.
    * An example is 16k on Chrome.
    */
-  constructor(id?: string, numOfScreenCanvases = 1) {
+  constructor(id?: string, numOffScreenCanvases = 1) {
     this.id = id ? id : uuidv4();
     this.useCPURendering = getShouldUseCPURendering();
-    this.numOfScreenCanvases = numOfScreenCanvases;
+    this.numOffScreenCanvases = numOffScreenCanvases;
 
     renderingEngineCache.set(this);
 
@@ -110,7 +110,7 @@ class RenderingEngine {
       this.offscreenMultiRenderWindows = [];
       this.offScreenCanvasContainers = [];
 
-      for (let i = 0; i < numOfScreenCanvases; i++) {
+      for (let i = 0; i < numOffScreenCanvases; i++) {
         const offscreenMultiRenderWindow =
           vtkOffscreenMultiRenderWindow.newInstance();
         const offScreenCanvasContainer = document.createElement('div');
@@ -1569,12 +1569,12 @@ class RenderingEngine {
 
   // Add new method to determine which offscreen canvas to use for a new viewport
   private _getOffscreenCanvasIndexForViewport(): number {
-    if (this.numOfScreenCanvases === 1) {
+    if (this.numOffScreenCanvases === 1) {
       return 0;
     }
 
     // Count viewports per canvas
-    const viewportsPerCanvas = new Array(this.numOfScreenCanvases).fill(0);
+    const viewportsPerCanvas = new Array(this.numOffScreenCanvases).fill(0);
     this._viewportToOffscreenCanvasIndex.forEach((canvasIndex) => {
       viewportsPerCanvas[canvasIndex]++;
     });

--- a/packages/core/src/RenderingEngine/RenderingEngine.ts
+++ b/packages/core/src/RenderingEngine/RenderingEngine.ts
@@ -25,6 +25,7 @@ import type {
 } from '../types/IViewport';
 import { OrientationAxis } from '../enums';
 import VolumeViewport3D from './VolumeViewport3D';
+import type vtkRenderer from '@kitware/vtk.js/Rendering/Core/Renderer';
 
 interface ViewportDisplayCoords {
   sxStartDisplayCoords: number;
@@ -573,7 +574,7 @@ class RenderingEngine {
    * @param viewportId - The ID of the viewport
    * @returns The renderer for the viewport
    */
-  public getRenderer(viewportId: string): unknown {
+  public getRenderer(viewportId: string): vtkRenderer {
     const offscreenMultiRenderWindow =
       this.getOffScreenMultiRenderWindow(viewportId);
     return offscreenMultiRenderWindow.getRenderer(viewportId);

--- a/packages/core/src/RenderingEngine/RenderingEngine.ts
+++ b/packages/core/src/RenderingEngine/RenderingEngine.ts
@@ -512,8 +512,8 @@ class RenderingEngine {
       }
 
       // Make sure all references go stale and are garbage collected.
-      this.offscreenMultiRenderWindows = null;
-      this.offScreenCanvasContainers = null;
+      delete this.offscreenMultiRenderWindows;
+      delete this.offScreenCanvasContainers;
     }
 
     this._reset();
@@ -547,6 +547,36 @@ class RenderingEngine {
     // wait for the next stack to load
     ctx.fillStyle = fillStyle;
     ctx.fillRect(0, 0, canvas.width, canvas.height);
+  }
+
+  /**
+   * Gets the offscreen multi render window for a specific viewport
+   *
+   * @param viewportId - The ID of the viewport
+   * @returns The offscreen multi render window for the viewport
+   */
+  public getOffScreenMultiRenderWindow(
+    viewportId: string
+  ): typeof vtkOffscreenMultiRenderWindow {
+    const canvasIndex = this._viewportToOffscreenCanvasIndex.get(viewportId);
+    if (canvasIndex === undefined) {
+      throw new Error(
+        `Viewport ${viewportId} not found in any offscreen canvas`
+      );
+    }
+    return this.offscreenMultiRenderWindows[canvasIndex];
+  }
+
+  /**
+   * Gets the renderer for a specific viewport
+   *
+   * @param viewportId - The ID of the viewport
+   * @returns The renderer for the viewport
+   */
+  public getRenderer(viewportId: string): unknown {
+    const offscreenMultiRenderWindow =
+      this.getOffScreenMultiRenderWindow(viewportId);
+    return offscreenMultiRenderWindow.getRenderer(viewportId);
   }
 
   private _normalizeViewportInputEntry(
@@ -1557,36 +1587,6 @@ class RenderingEngine {
     }
 
     return minIndex;
-  }
-
-  /**
-   * Gets the offscreen multi render window for a specific viewport
-   *
-   * @param viewportId - The ID of the viewport
-   * @returns The offscreen multi render window for the viewport
-   */
-  public getOffScreenMultiRenderWindow(
-    viewportId: string
-  ): typeof vtkOffscreenMultiRenderWindow {
-    const canvasIndex = this._viewportToOffscreenCanvasIndex.get(viewportId);
-    if (canvasIndex === undefined) {
-      throw new Error(
-        `Viewport ${viewportId} not found in any offscreen canvas`
-      );
-    }
-    return this.offscreenMultiRenderWindows[canvasIndex];
-  }
-
-  /**
-   * Gets the renderer for a specific viewport
-   *
-   * @param viewportId - The ID of the viewport
-   * @returns The renderer for the viewport
-   */
-  public getRenderer(viewportId: string): unknown {
-    const offscreenMultiRenderWindow =
-      this.getOffScreenMultiRenderWindow(viewportId);
-    return offscreenMultiRenderWindow.getRenderer(viewportId);
   }
 }
 

--- a/packages/core/src/RenderingEngine/RenderingEngine.ts
+++ b/packages/core/src/RenderingEngine/RenderingEngine.ts
@@ -26,7 +26,7 @@ import type {
 import { OrientationAxis } from '../enums';
 import VolumeViewport3D from './VolumeViewport3D';
 import type vtkRenderer from '@kitware/vtk.js/Rendering/Core/Renderer';
-import type { VtkOffscreenMultiRenderWindow } from '../types/vtkOffscreenMultiRenderWindow';
+import type { VtkOffscreenMultiRenderWindow } from '../types/VtkOffscreenMultiRenderWindow';
 
 interface ViewportDisplayCoords {
   sxStartDisplayCoords: number;

--- a/packages/core/src/RenderingEngine/RenderingEngine.ts
+++ b/packages/core/src/RenderingEngine/RenderingEngine.ts
@@ -26,6 +26,7 @@ import type {
 import { OrientationAxis } from '../enums';
 import VolumeViewport3D from './VolumeViewport3D';
 import type vtkRenderer from '@kitware/vtk.js/Rendering/Core/Renderer';
+import type { VtkOffscreenMultiRenderWindow } from '../types/vtkOffscreenMultiRenderWindow';
 
 interface ViewportDisplayCoords {
   sxStartDisplayCoords: number;
@@ -88,7 +89,9 @@ class RenderingEngine {
 
   /**
    * @param uid - Unique identifier for RenderingEngine
-   * @param numOfScreenCanvases - Optional number of offscreen canvases to distribute rendering (default: 1)
+   * @param numOfScreenCanvases - Optional number of offscreen canvases to distribute rendering (default: 1),
+   * This is useful for high resolution rendering where viewports are expected to exceed the maximum offscreen canvas width for the browser.
+   * An example is 16k on Chrome.
    */
   constructor(id?: string, numOfScreenCanvases = 1) {
     this.id = id ? id : uuidv4();
@@ -558,7 +561,7 @@ class RenderingEngine {
    */
   public getOffScreenMultiRenderWindow(
     viewportId: string
-  ): typeof vtkOffscreenMultiRenderWindow {
+  ): VtkOffscreenMultiRenderWindow {
     const canvasIndex = this._viewportToOffscreenCanvasIndex.get(viewportId);
     if (canvasIndex === undefined) {
       throw new Error(

--- a/packages/core/src/RenderingEngine/RenderingEngine.ts
+++ b/packages/core/src/RenderingEngine/RenderingEngine.ts
@@ -1567,7 +1567,10 @@ class RenderingEngine {
     return dataURLs;
   }
 
-  // Add new method to determine which offscreen canvas to use for a new viewport
+  /**
+   * Returns the index of the offscreen canvas that should be used for a new viewport.
+   * @returns The index of the offscreen canvas that should be used for a new viewport.
+   */
   private _getOffscreenCanvasIndexForViewport(): number {
     if (this.numOffScreenCanvases === 1) {
       return 0;

--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -2829,7 +2829,7 @@ class StackViewport extends Viewport {
     vtkCamera.setClippingRange(distance, distance + 0.1);
 
     const offscreenMultiRenderWindow =
-      this.getRenderingEngine().offscreenMultiRenderWindow;
+      this.getRenderingEngine().getOffScreenMultiRenderWindow(this.id);
     const openGLRenderWindow =
       offscreenMultiRenderWindow.getOpenGLRenderWindow();
     const size = openGLRenderWindow.getSize();
@@ -2874,7 +2874,7 @@ class StackViewport extends Viewport {
     vtkCamera.setClippingRange(distance, distance + 0.1);
 
     const offscreenMultiRenderWindow =
-      this.getRenderingEngine().offscreenMultiRenderWindow;
+      this.getRenderingEngine().getOffScreenMultiRenderWindow(this.id);
     const openGLRenderWindow =
       offscreenMultiRenderWindow.getOpenGLRenderWindow();
     const size = openGLRenderWindow.getSize();

--- a/packages/core/src/RenderingEngine/Viewport.ts
+++ b/packages/core/src/RenderingEngine/Viewport.ts
@@ -248,7 +248,7 @@ class Viewport {
       throw new Error('Rendering engine has been destroyed');
     }
 
-    return renderingEngine.offscreenMultiRenderWindow?.getRenderer(this.id);
+    return renderingEngine.getRenderer(this.id);
   }
 
   /**

--- a/packages/core/src/types/VtkOffscreenMultiRenderWindow.ts
+++ b/packages/core/src/types/VtkOffscreenMultiRenderWindow.ts
@@ -1,0 +1,45 @@
+import type { vtkObject } from '@kitware/vtk.js/interfaces';
+import type vtkStreamingOpenGLRenderWindow from '../RenderingEngine/vtkClasses/vtkStreamingOpenGLRenderWindow';
+import type vtkRenderer from '@kitware/vtk.js/Rendering/Core/Renderer';
+import type vtkRenderWindow from '@kitware/vtk.js/Rendering/Core/RenderWindow';
+import type vtkRenderWindowInteractor from '@kitware/vtk.js/Rendering/Core/RenderWindowInteractor';
+
+import '@kitware/vtk.js/Common/Core/Points';
+import '@kitware/vtk.js/Common/Core/DataArray';
+import '@kitware/vtk.js/Common/DataModel/PolyData';
+import '@kitware/vtk.js/Rendering/Core/Actor';
+import '@kitware/vtk.js/Rendering/Core/Mapper';
+
+type Viewport = [number, number, number, number];
+
+interface RendererConfig {
+  id: string;
+  viewport: Viewport;
+  background?: [number, number, number];
+}
+
+export interface VtkOffscreenMultiRenderWindow extends vtkObject {
+  renderWindow: vtkRenderWindow;
+  getRenderWindow: () => vtkRenderWindow;
+
+  openGLRenderWindow: ReturnType<
+    typeof vtkStreamingOpenGLRenderWindow.newInstance
+  >;
+  getOpenGLRenderWindow: () => ReturnType<
+    typeof vtkStreamingOpenGLRenderWindow.newInstance
+  >;
+
+  interactor: vtkRenderWindowInteractor;
+  getInteractor: () => vtkRenderWindowInteractor;
+
+  container: HTMLDivElement | null;
+  getContainer: () => HTMLDivElement | null;
+
+  addRenderer: (config: RendererConfig) => void;
+  removeRenderer: (id: string) => void;
+  getRenderer: (id: string) => vtkRenderer;
+  getRenderers: () => Array<{ id: string; renderer: vtkRenderer }>;
+  resize: () => void;
+  setContainer: (el: HTMLDivElement) => void;
+  destroy: () => void;
+}

--- a/packages/tools/src/tools/OrientationMarkerTool.ts
+++ b/packages/tools/src/tools/OrientationMarkerTool.ts
@@ -257,7 +257,8 @@ class OrientationMarkerTool extends BaseTool {
 
       const renderWindow = viewport
         .getRenderingEngine()
-        .offscreenMultiRenderWindow.getRenderWindow();
+        .getOffScreenMultiRenderWindow(viewport.id)
+        .getRenderWindow();
       renderWindow.render();
       viewport.getRenderingEngine().render();
 
@@ -314,7 +315,8 @@ class OrientationMarkerTool extends BaseTool {
       const renderer = viewport.getRenderer();
       const renderWindow = viewport
         .getRenderingEngine()
-        .offscreenMultiRenderWindow.getRenderWindow();
+        .getOffScreenMultiRenderWindow(viewport.id)
+        .getRenderWindow();
 
       const {
         enabled,


### PR DESCRIPTION
### Context

Cornerstone3D handles rendering and image processing using a single offscreen canvas. This canvas expands horizontally as more viewports are added. At display time, Cornerstone3D copies the relevant portions of this large offscreen canvas into each individual viewport.

The issue is, Chrome has a maximum canvas size of 16,384 x 16,384. If the total width of the offscreen canvas exceeds this limit, because too many viewports are laid out horizontally, some of the viewports get cropped in the offscreen canvas.

As a result, the data copied from the offscreen canvas to the screen becomes misaligned, causing rendering issues.
I've attached screenshots showing:



Viewports + offscreen canvas before hitting the size threshold:

![image](https://github.com/user-attachments/assets/35da47c9-977b-47c5-89ef-207132becc3b)

![image](https://github.com/user-attachments/assets/251fe68c-88d6-4dcd-baff-e0406aa18205)


Viewports + offscreen canvas after exceeding the threshold:

![image](https://github.com/user-attachments/assets/a26cf2fe-e9ba-4250-b82e-a2f2c7c84b0e)

![image](https://github.com/user-attachments/assets/182be1f5-eb25-4d89-89e8-14e2b7fb7f3e)


### Goal

The goal of this PR is to allow users who expect their use case to exceed 16K resolution to initilize the renderEngine with more than one off screen canvas, and the renderEngine can distribute the viewports evenly across them.

There are more robust solutions like packing or dynamic allocation, but I have kept it simple for this PR due to time constraints.
