### PR TITLE
test: add coverage

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,5 +1,9 @@
 name: Format Check
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     branches: [ '*' ]

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -58,7 +58,7 @@ jobs:
           pattern: blob-report
           merge-multiple: true
       - name: Merge into HTML Report
-        run: bun x playwright merge-reports --reporter html ./all-blob-reports -o packages/docs/static/playwright-report
+        run: bun x playwright merge-reports --reporter html ./all-blob-reports packages/docs/static/playwright-report
       - name: Upload HTML report
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,6 +4,11 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   playwright-tests:
     timeout-minutes: 60
@@ -13,8 +18,6 @@ jobs:
       matrix:
         node-version: [20]
     steps:
-      - name: Cancel Previous Runs Actions
-        uses: LarchLiu/cancel_previous_runs@V1.1.0
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
       - uses: actions/setup-node@v4
@@ -41,8 +44,6 @@ jobs:
     needs: [playwright-tests]
     runs-on: self-hosted
     steps:
-      - name: Cancel Previous Runs Actions
-        uses: LarchLiu/cancel_previous_runs@V1.1.0
       - uses: oven-sh/setup-bun@v2
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -53,10 +53,10 @@ jobs:
           pattern: blob-report
           merge-multiple: true
       - name: Merge into HTML Report
-        run: bun x playwright merge-reports --reporter html ./all-blob-reports
+        run: bun x playwright merge-reports --reporter html ./all-blob-reports -o packages/docs/static/playwright-report
       - name: Upload HTML report
         uses: actions/upload-artifact@v4
         with:
           name: html-report--attempt-${{ github.run_attempt }}
-          path: playwright-report
+          path: packages/docs/static/playwright-report
           retention-days: 14

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -13,6 +13,8 @@ jobs:
       matrix:
         node-version: [20]
     steps:
+      - name: Cancel Previous Runs Actions
+        uses: LarchLiu/cancel_previous_runs@V1.1.0
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
       - uses: actions/setup-node@v4
@@ -39,6 +41,8 @@ jobs:
     needs: [playwright-tests]
     runs-on: self-hosted
     steps:
+      - name: Cancel Previous Runs Actions
+        uses: LarchLiu/cancel_previous_runs@V1.1.0
       - uses: oven-sh/setup-bun@v2
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/packages/docs/netlify.toml
+++ b/packages/docs/netlify.toml
@@ -26,6 +26,12 @@
   to = "/index.html"
   status = 200
 
+# Redirect for Playwright coverage report
+[[redirects]]
+  from = "/coverage"
+  to = "/playwright-report/index.html"
+  status = 200
+
 # Attempt to speed up docusaurus builds by persisting the webpack cache
 # across deploys. This is done in the main docusaurus repo: https://github.com/facebook/docusaurus/blob/cc0bceab9c1678303f6237f5526753edc1b12fc3/website/netlify.toml#L22
 [[plugins]]

--- a/packages/docs/sidebars.js
+++ b/packages/docs/sidebars.js
@@ -291,6 +291,11 @@ module.exports = {
         'migration-guides/legacy-to-3d',
       ],
     },
+    {
+      type: 'link',
+      label: 'Test Coverage',
+      href: '/coverage',
+    },
     'faq',
     'help',
     'examples',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 3 : 0,
-  workers: process.env.CI ? 4 : undefined,
+  workers: process.env.CI ? 8 : undefined,
   timeout: 120 * 1000,
   snapshotPathTemplate:
     'tests/screenshots{/projectName}/{testFilePath}/{arg}{ext}',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   reporter: [
     [
       process.env.CI ? 'blob' : 'html',
-      { outputFolder: './tests/playwright-report' },
+      { outputFolder: './packages/docs/static/playwright-report' },
     ],
   ],
   use: {


### PR DESCRIPTION
This pull request includes changes to the Playwright testing setup and documentation configuration. The most important changes involve updating the paths for the HTML report output and adding a redirect for the Playwright coverage report.

Updates to Playwright testing setup:

* [`.github/workflows/playwright.yml`](diffhunk://#diff-7afcd2d8f7b49bda74843f209eefb7b2da45f7e7803bf2e4bd636699b76aa2d3L56-R61): Updated the `run` command for merging reports and the `path` for uploading the HTML report to use the new directory `packages/docs/static/playwright-report`.
* [`playwright.config.ts`](diffhunk://#diff-f679bf1e58e8dddfc6cff0fa37c8e755c8d2cfc9e6b5dc5520a5800beba59a92L16-R16): Changed the `outputFolder` for the HTML reporter to `./packages/docs/static/playwright-report`.

Documentation configuration:

* [`packages/docs/netlify.toml`](diffhunk://#diff-87870a65bb5bbd0fb91d8c4436435b675a77511f02d9fac1214d4b1ce90224daR29-R34): Added a redirect from `/coverage` to `/playwright-report/index.html` to facilitate access to the Playwright coverage report.