### PR TITLE
fix: artifact for test finally

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -77,7 +77,7 @@ jobs:
           echo "Artifact downloaded successfully."
 
       - name: Install docs dependencies
-        run: cd packages/docs && bun install --frozen-lockfile
+        run: cd packages/docs && bun install
 
       - name: Copy coverage to docs static directory
         run: |


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/build-docs.yml` file. The change removes the `--frozen-lockfile` option from the `bun install` command used to install documentation dependencies.

* [`.github/workflows/build-docs.yml`](diffhunk://#diff-4fdc48ab490b670c90974725b8e3d399b24c03d6d09563acf8ea87d4113930fbL80-R80): Removed the `--frozen-lockfile` option from the `bun install` command in the `Install docs dependencies` step.