### PR TITLE
fix: artifact for test finally

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -50,12 +50,13 @@ jobs:
           echo "Found PR Number: $PR_NUMBER"
           echo "Found PR Head SHA: $PR_HEAD_SHA"
 
-          # Find the latest successful workflow run ID for the playwright workflow on the PR head commit
+          # Find the latest workflow run ID for the playwright workflow on the PR head commit
           # Uses the workflow file name 'playwright.yml'
-          RUN_ID=$(gh run list --workflow playwright.yml --commit "$PR_HEAD_SHA" --event pull_request --status success --json databaseId --jq '.[0].databaseId')
+          # Remove the --status success flag to find any run
+          RUN_ID=$(gh run list --workflow playwright.yml --commit "$PR_HEAD_SHA" --event pull_request --json databaseId --jq '.[0].databaseId')
 
           if [ -z "$RUN_ID" ]; then
-            echo "Could not find successful 'playwright.yml' run for PR $PR_NUMBER (Head SHA: $PR_HEAD_SHA)."
+            echo "Could not find any 'playwright.yml' run for PR $PR_NUMBER (Head SHA: $PR_HEAD_SHA)."
             # Decide how to handle - maybe try finding the artifact from the merge commit run if that exists?
             # For now, let's fail.
             exit 1


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/build-docs.yml` file to modify the way the latest workflow run ID for the `playwright.yml` workflow is found. The most important change is the removal of the `--status success` flag to allow finding any run, not just successful ones.

Workflow adjustments:

* [`.github/workflows/build-docs.yml`](diffhunk://#diff-4fdc48ab490b670c90974725b8e3d399b24c03d6d09563acf8ea87d4113930fbL53-R59): Removed the `--status success` flag from the `gh run list` command to find any workflow run, not just successful ones.