### PR TITLE
fix/artifact 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "prepare": "husky",
     "commit:prepare": "yarn test:ci && yarn test:unit",
     "start": "yarn run dev",
-    "test:e2e:coverage": "nyc --reporter=html yarn run test:e2e:ci -g @debug",
+    "test:e2e:coverage": "nyc --reporter=html yarn run test:e2e:ci",
     "test:e2e:ci": "npx playwright test",
     "test:e2e:ui": "npx playwright test --ui",
     "test:e2e:headed": "npx playwright test --headed",

--- a/packages/docs/sidebars.js
+++ b/packages/docs/sidebars.js
@@ -297,7 +297,7 @@ module.exports = {
     {
       type: 'link',
       label: 'Test Coverage',
-      href: 'https://cornerstone3D.js.org/coverage',
+      href: 'https://www.cornerstonejs.org/coverage',
     },
   ],
 };


### PR DESCRIPTION
This pull request includes minor changes to the `package.json` and `sidebars.js` files to update the end-to-end test coverage script and the test coverage link.

Updates to test coverage:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L45-R45): Modified the `test:e2e:coverage` script to remove the `-g @debug` flag.

Documentation updates:

* [`packages/docs/sidebars.js`](diffhunk://#diff-bc2679717ef57f791880f7056e2f612bfac8cb0cd59fcb0b010fa77ba3d6ed8dL300-R300): Updated the `href` for the 'Test Coverage' link to point to the correct URL.