### PR TITLE
fix(copyStudyTags): missing SeriesInstanceUID

### DIFF
--- a/packages/adapters/src/adapters/Cornerstone3D/MeasurementReport.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/MeasurementReport.ts
@@ -3,6 +3,7 @@ import { normalizers, data, utilities, derivations } from "dcmjs";
 import CORNERSTONE_3D_TAG from "./cornerstone3DTag";
 import { toArray, codeMeaningEquals, copyStudyTags } from "../helpers";
 import Cornerstone3DCodingScheme from "./CodingScheme";
+import { copySeriesTags } from "../helpers/copySeriesTags";
 
 const { TID1500, addAccessors } = utilities;
 
@@ -200,15 +201,10 @@ export default class MeasurementReport {
     }
 
     static generateDerivationSourceDataset = instance => {
-        const _vrMap = {
-            PixelData: "OW"
-        };
+        const studyTags = copyStudyTags(instance);
+        const seriesTags = copySeriesTags(instance);
 
-        const _meta = MeasurementReport.generateDatasetMeta();
-
-        const derivationSourceDataset = copyStudyTags(instance);
-
-        return derivationSourceDataset;
+        return { ...studyTags, ...seriesTags };
     };
 
     public static getSetupMeasurementData(

--- a/packages/adapters/src/adapters/helpers/copySeriesTags.ts
+++ b/packages/adapters/src/adapters/helpers/copySeriesTags.ts
@@ -1,0 +1,28 @@
+export const seriesTags = [
+    "SeriesInstanceUID",
+    "SeriesNumber",
+    "SeriesDescription",
+    "Modality",
+    "SeriesDate",
+    "SeriesTime"
+];
+
+/**
+ * Copies series tags from src into a new object.
+ *
+ * Usage:  `const newStudyInstance = copySeriesTags(exampleInstance)`
+ */
+export function copySeriesTags(src) {
+    const study = {
+        _meta: src._meta,
+        _vrMap: src._vrMap
+    };
+    for (const tagKey of seriesTags) {
+        const value = src[tagKey];
+        if (value === undefined) {
+            continue;
+        }
+        study[tagKey] = value;
+    }
+    return study;
+}

--- a/packages/adapters/src/adapters/helpers/copyStudyTags.ts
+++ b/packages/adapters/src/adapters/helpers/copyStudyTags.ts
@@ -1,5 +1,3 @@
-import dcmjs from "dcmjs";
-
 export const patientTags = [
     "PatientName",
     "PatientID",
@@ -28,11 +26,13 @@ export const studyTags = [
     "TimezoneOffsetFromUTC"
 ];
 
+export const seriesTags = ["SeriesInstanceUID"];
+
 /**
  * A list of patient/study tag names used to create new instances in the same study
  * from an existing instance.
  */
-export const patientStudyTags = [...patientTags, ...studyTags];
+export const patientStudyTags = [...patientTags, ...studyTags, ...seriesTags];
 
 /**
  * Copies study (and patient) tags from src into a new object.

--- a/packages/adapters/src/adapters/helpers/copyStudyTags.ts
+++ b/packages/adapters/src/adapters/helpers/copyStudyTags.ts
@@ -26,13 +26,11 @@ export const studyTags = [
     "TimezoneOffsetFromUTC"
 ];
 
-export const seriesTags = ["SeriesInstanceUID"];
-
 /**
  * A list of patient/study tag names used to create new instances in the same study
  * from an existing instance.
  */
-export const patientStudyTags = [...patientTags, ...studyTags, ...seriesTags];
+export const patientStudyTags = [...patientTags, ...studyTags];
 
 /**
  * Copies study (and patient) tags from src into a new object.

--- a/packages/adapters/src/adapters/helpers/index.ts
+++ b/packages/adapters/src/adapters/helpers/index.ts
@@ -3,5 +3,6 @@ import { codeMeaningEquals } from "./codeMeaningEquals";
 import { graphicTypeEquals } from "./graphicTypeEquals";
 import { downloadDICOMData } from "./downloadDICOMData";
 export { copyStudyTags } from "./copyStudyTags";
+export { copySeriesTags } from "./copySeriesTags";
 
 export { toArray, codeMeaningEquals, graphicTypeEquals, downloadDICOMData };


### PR DESCRIPTION
### Context

https://github.com/cornerstonejs/cornerstone3D/pull/1887, recently merged, introduced a bug:

The `packages/adapters/src/adapters/Cornerstone3D/MeasurementReport.ts` calls the `contentItem` method of the `TID1500MeasurementReport`:

![image](https://github.com/user-attachments/assets/90246a85-e718-4020-9f89-86dd3fca8c91)

This method, in turn, relies on the `SeriesInstanceUID` of the derivation source datasets, which is always undefined with the changes of the PR above:

![image](https://github.com/user-attachments/assets/e1a7387c-9025-4981-bedd-9ed81c41208c)

This was causing an error when trying to save measurements to different Series in the same SR. See next section to see an example.


### Changes & Results

Before:

![image](https://github.com/user-attachments/assets/4164440f-3364-446c-903b-e2f02e3be4cc)

After:

![image](https://github.com/user-attachments/assets/a6244d3c-8184-4dc9-997f-08f6a85fafb7)


### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)



#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
