### PR TITLE
feat: save scoord3d for tools

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -136,26 +136,26 @@
     },
     "packages/adapters": {
       "name": "@cornerstonejs/adapters",
-      "version": "3.10.5",
+      "version": "3.10.30",
       "dependencies": {
         "@babel/runtime-corejs2": "^7.17.8",
         "buffer": "^6.0.3",
-        "dcmjs": "^0.29.8",
+        "dcmjs": "^0.40.0",
         "gl-matrix": "^3.4.3",
         "ndarray": "^1.0.19",
       },
       "peerDependencies": {
-        "@cornerstonejs/core": "^3.7.6",
-        "@cornerstonejs/tools": "^3.7.6",
+        "@cornerstonejs/core": "^3.10.30",
+        "@cornerstonejs/tools": "^3.10.30",
       },
     },
     "packages/ai": {
       "name": "@cornerstonejs/ai",
-      "version": "3.10.5",
+      "version": "3.10.30",
       "dependencies": {
         "@babel/runtime-corejs2": "^7.17.8",
         "buffer": "^6.0.3",
-        "dcmjs": "^0.29.8",
+        "dcmjs": "^0.40.0",
         "gl-matrix": "^3.4.3",
         "lodash.clonedeep": "^4.5.0",
         "ndarray": "^1.0.19",
@@ -163,13 +163,13 @@
         "onnxruntime-web": "1.17.1",
       },
       "peerDependencies": {
-        "@cornerstonejs/core": "^3.7.6",
-        "@cornerstonejs/tools": "^3.7.6",
+        "@cornerstonejs/core": "^3.10.30",
+        "@cornerstonejs/tools": "^3.10.30",
       },
     },
     "packages/core": {
       "name": "@cornerstonejs/core",
-      "version": "3.10.5",
+      "version": "3.10.30",
       "dependencies": {
         "@kitware/vtk.js": "32.12.1",
         "comlink": "^4.4.1",
@@ -179,7 +179,7 @@
     },
     "packages/dicomImageLoader": {
       "name": "@cornerstonejs/dicom-image-loader",
-      "version": "3.10.5",
+      "version": "3.10.30",
       "dependencies": {
         "@cornerstonejs/codec-charls": "^1.2.3",
         "@cornerstonejs/codec-libjpeg-turbo-8bit": "^1.2.2",
@@ -198,7 +198,7 @@
     },
     "packages/labelmap-interpolation": {
       "name": "@cornerstonejs/labelmap-interpolation",
-      "version": "3.10.5",
+      "version": "3.10.30",
       "dependencies": {
         "@itk-wasm/morphological-contour-interpolation": "1.1.0",
         "itk-wasm": "1.0.0-b.165",
@@ -211,7 +211,7 @@
     },
     "packages/nifti-volume-loader": {
       "name": "@cornerstonejs/nifti-volume-loader",
-      "version": "3.10.5",
+      "version": "3.10.30",
       "dependencies": {
         "nifti-reader-js": "^0.6.8",
       },
@@ -221,7 +221,7 @@
     },
     "packages/polymorphic-segmentation": {
       "name": "@cornerstonejs/polymorphic-segmentation",
-      "version": "3.10.5",
+      "version": "3.10.30",
       "dependencies": {
         "@icr/polyseg-wasm": "0.4.0",
       },
@@ -233,7 +233,7 @@
     },
     "packages/tools": {
       "name": "@cornerstonejs/tools",
-      "version": "3.10.5",
+      "version": "3.10.30",
       "dependencies": {
         "@types/offscreencanvas": "2019.7.3",
         "comlink": "^4.4.1",
@@ -243,7 +243,7 @@
         "canvas": "^3.1.0",
       },
       "peerDependencies": {
-        "@cornerstonejs/core": "^3.7.6",
+        "@cornerstonejs/core": "^3.10.30",
         "@kitware/vtk.js": "32.12.1",
         "@types/d3-array": "^3.0.4",
         "@types/d3-interpolate": "^3.0.1",
@@ -1997,7 +1997,7 @@
 
     "dateformat": ["dateformat@3.0.3", "", {}, "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="],
 
-    "dcmjs": ["dcmjs@0.29.13", "", { "dependencies": { "@babel/runtime-corejs3": "^7.22.5", "adm-zip": "^0.5.10", "gl-matrix": "^3.1.0", "lodash.clonedeep": "^4.5.0", "loglevelnext": "^3.0.1", "ndarray": "^1.0.19", "pako": "^2.0.4" } }, "sha512-Bf9tKzJNWqk4kbV210N5TLEHDqaZvO3S+MH9vezFAU8WKcG4cR6z4/II3TQVqhLI185eNUL+lhfPCVH1Uu2yTA=="],
+    "dcmjs": ["dcmjs@0.40.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.22.5", "adm-zip": "^0.5.10", "gl-matrix": "^3.1.0", "lodash.clonedeep": "^4.5.0", "loglevel": "^1.8.1", "ndarray": "^1.0.19", "pako": "^2.0.4" } }, "sha512-FId8dPpDg45ynIjpWF1mXlA77YcQBcE/eQGgkQpJqB0k9NF4simMYbSm9pJ5ORizYdDzOzjZpVNVym/vnFQJzQ=="],
 
     "debounce": ["debounce@1.2.1", "", {}, "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="],
 
@@ -5154,6 +5154,8 @@
     "detective-typescript/@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@5.62.0", "", { "dependencies": { "@typescript-eslint/types": "5.62.0", "@typescript-eslint/visitor-keys": "5.62.0", "debug": "^4.3.4", "globby": "^11.1.0", "is-glob": "^4.0.3", "semver": "^7.3.7", "tsutils": "^3.21.0" } }, "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA=="],
 
     "detective-typescript/typescript": ["typescript@5.7.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg=="],
+
+    "dicom-microscopy-viewer/dcmjs": ["dcmjs@0.29.13", "", { "dependencies": { "@babel/runtime-corejs3": "^7.22.5", "adm-zip": "^0.5.10", "gl-matrix": "^3.1.0", "lodash.clonedeep": "^4.5.0", "loglevelnext": "^3.0.1", "ndarray": "^1.0.19", "pako": "^2.0.4" } }, "sha512-Bf9tKzJNWqk4kbV210N5TLEHDqaZvO3S+MH9vezFAU8WKcG4cR6z4/II3TQVqhLI185eNUL+lhfPCVH1Uu2yTA=="],
 
     "dir-glob/path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
 

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -79,7 +79,7 @@
     "dependencies": {
         "@babel/runtime-corejs2": "^7.17.8",
         "buffer": "^6.0.3",
-        "dcmjs": "^0.29.8",
+        "dcmjs": "^0.40.0",
         "gl-matrix": "^3.4.3",
         "ndarray": "^1.0.19"
     },

--- a/packages/adapters/src/adapters/Cornerstone3D/Angle.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/Angle.ts
@@ -68,14 +68,12 @@ class Angle extends BaseAdapter3D {
         const { referencedImageId } = metadata;
 
         if (!referencedImageId) {
-            throw new Error(
-                "Angle.getTID300RepresentationArguments: referencedImageId is not defined"
-            );
+            return this.getTID300RepresentationArgumentsSCOORD3D(tool);
         }
 
+        // Using image coordinates for 2D points
         const start1 = worldToImageCoords(referencedImageId, handles.points[0]);
         const middle = worldToImageCoords(referencedImageId, handles.points[1]);
-
         const end = worldToImageCoords(referencedImageId, handles.points[2]);
 
         const point1 = { x: start1[0], y: start1[1] };
@@ -94,7 +92,38 @@ class Angle extends BaseAdapter3D {
             rAngle: angle,
             trackingIdentifierTextValue: this.trackingIdentifierTextValue,
             finding,
-            findingSites: findingSites || []
+            findingSites: findingSites || [],
+            use3DSpatialCoordinates: false
+        };
+    }
+
+    public static getTID300RepresentationArgumentsSCOORD3D(tool) {
+        const { data, finding, findingSites } = tool;
+        const { cachedStats = {}, handles } = data;
+
+        // Using world coordinates for 3D points
+        const start = handles.points[0];
+        const middle = handles.points[1];
+        const end = handles.points[2];
+
+        const point1 = { x: start[0], y: start[1], z: start[2] };
+        const point2 = { x: middle[0], y: middle[1], z: middle[2] };
+        const point3 = point2;
+        const point4 = { x: end[0], y: end[1], z: end[2] };
+
+        const cachedStatsKeys = Object.keys(cachedStats)[0];
+        const { angle } = cachedStatsKeys ? cachedStats[cachedStatsKeys] : {};
+
+        return {
+            point1,
+            point2,
+            point3,
+            point4,
+            rAngle: angle,
+            trackingIdentifierTextValue: this.trackingIdentifierTextValue,
+            finding,
+            findingSites: findingSites || [],
+            use3DSpatialCoordinates: true
         };
     }
 }

--- a/packages/adapters/src/adapters/Cornerstone3D/Angle.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/Angle.ts
@@ -17,14 +17,45 @@ class Angle extends BaseAdapter3D {
         imageToWorldCoords,
         metadata
     ) {
-        const { defaultState, NUMGroup, SCOORDGroup, ReferencedFrameNumber } =
-            MeasurementReport.getSetupMeasurementData(
-                MeasurementGroup,
-                sopInstanceUIDToImageIdMap,
-                metadata,
-                Angle.toolType
+        const {
+            defaultState,
+            NUMGroup,
+            SCOORDGroup,
+            SCOORD3DGroup,
+            ReferencedFrameNumber
+        } = MeasurementReport.getSetupMeasurementData(
+            MeasurementGroup,
+            sopInstanceUIDToImageIdMap,
+            metadata,
+            Angle.toolType
+        );
+        if (SCOORDGroup) {
+            return this.getMeasurementDataFromScoord({
+                defaultState,
+                SCOORDGroup,
+                imageToWorldCoords,
+                NUMGroup,
+                ReferencedFrameNumber
+            });
+        } else if (SCOORD3DGroup) {
+            return this.getMeasurementDataFromScoord3D({
+                defaultState,
+                SCOORD3DGroup
+            });
+        } else {
+            throw new Error(
+                "Can't get measurement data with missing SCOORD and SCOORD3D groups."
             );
+        }
+    }
 
+    static getMeasurementDataFromScoord({
+        defaultState,
+        SCOORDGroup,
+        imageToWorldCoords,
+        NUMGroup,
+        ReferencedFrameNumber
+    }) {
         const referencedImageId =
             defaultState.annotation.metadata.referencedImageId;
 
@@ -56,6 +87,34 @@ class Angle extends BaseAdapter3D {
                 }
             },
             frameNumber: ReferencedFrameNumber
+        };
+
+        return state;
+    }
+
+    static getMeasurementDataFromScoord3D({ defaultState, SCOORD3DGroup }) {
+        const { GraphicData } = SCOORD3DGroup;
+        const worldCoords = [];
+        for (let i = 0; i < GraphicData.length; i += 3) {
+            const point = [
+                GraphicData[i],
+                GraphicData[i + 1],
+                GraphicData[i + 2]
+            ];
+            worldCoords.push(point);
+        }
+
+        const state = defaultState;
+
+        state.annotation.data = {
+            handles: {
+                points: [worldCoords[0], worldCoords[1], worldCoords[3]],
+                activeHandleIndex: 0,
+                textBox: {
+                    hasMoved: false
+                }
+            },
+            cachedStats: {}
         };
 
         return state;

--- a/packages/adapters/src/adapters/Cornerstone3D/Angle.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/Angle.ts
@@ -98,7 +98,7 @@ class Angle extends BaseAdapter3D {
     }
 
     public static getTID300RepresentationArgumentsSCOORD3D(tool) {
-        const { data, finding, findingSites } = tool;
+        const { data, finding, findingSites, metadata } = tool;
         const { cachedStats = {}, handles } = data;
 
         // Using world coordinates for 3D points
@@ -123,6 +123,7 @@ class Angle extends BaseAdapter3D {
             trackingIdentifierTextValue: this.trackingIdentifierTextValue,
             finding,
             findingSites: findingSites || [],
+            ReferencedFrameOfReferenceUID: metadata.FrameOfReferenceUID,
             use3DSpatialCoordinates: true
         };
     }

--- a/packages/adapters/src/adapters/Cornerstone3D/ArrowAnnotate.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/ArrowAnnotate.ts
@@ -92,9 +92,7 @@ class ArrowAnnotate extends BaseAdapter3D {
         const { referencedImageId } = metadata;
 
         if (!referencedImageId) {
-            throw new Error(
-                "ArrowAnnotate.getTID300RepresentationArguments: referencedImageId is not defined"
-            );
+            return this.getTID300RepresentationArgumentsSCOORD3D(tool);
         }
 
         const { points, arrowFirst } = data.handles;
@@ -110,6 +108,7 @@ class ArrowAnnotate extends BaseAdapter3D {
             point2 = points[0];
         }
 
+        // Using image coordinates for 2D points
         const pointImage = worldToImageCoords(referencedImageId, point);
         const pointImage2 = worldToImageCoords(referencedImageId, point2);
 
@@ -126,7 +125,60 @@ class ArrowAnnotate extends BaseAdapter3D {
             ],
             trackingIdentifierTextValue: this.trackingIdentifierTextValue,
             findingSites: findingSites || [],
-            finding
+            finding,
+            use3DSpatialCoordinates: false
+        };
+
+        // If freetext finding isn't present, add it from the tool text.
+        if (!finding || finding.CodeValue !== codeValues.CORNERSTONEFREETEXT) {
+            finding = {
+                CodeValue: codeValues.CORNERSTONEFREETEXT,
+                CodingSchemeDesignator: CodingScheme.CodingSchemeDesignator,
+                CodeMeaning: data.text
+            };
+        }
+
+        return TID300RepresentationArguments;
+    }
+
+    static getTID300RepresentationArgumentsSCOORD3D(tool) {
+        const { data, findingSites } = tool;
+        let { finding } = tool;
+
+        const { points, arrowFirst } = data.handles;
+
+        let point;
+        let point2;
+
+        if (arrowFirst) {
+            point = points[0];
+            point2 = points[1];
+        } else {
+            point = points[1];
+            point2 = points[0];
+        }
+
+        // Using world coordinates for 3D points
+        const pointImage = point;
+        const pointImage2 = point2;
+
+        const TID300RepresentationArguments = {
+            points: [
+                {
+                    x: pointImage[0],
+                    y: pointImage[1],
+                    z: pointImage[2]
+                },
+                {
+                    x: pointImage2[0],
+                    y: pointImage2[1],
+                    z: pointImage2[2]
+                }
+            ],
+            trackingIdentifierTextValue: this.trackingIdentifierTextValue,
+            findingSites: findingSites || [],
+            finding,
+            use3DSpatialCoordinates: true
         };
 
         // If freetext finding isn't present, add it from the tool text.

--- a/packages/adapters/src/adapters/Cornerstone3D/ArrowAnnotate.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/ArrowAnnotate.ts
@@ -142,7 +142,7 @@ class ArrowAnnotate extends BaseAdapter3D {
     }
 
     static getTID300RepresentationArgumentsSCOORD3D(tool) {
-        const { data, findingSites } = tool;
+        const { data, findingSites, metadata } = tool;
         let { finding } = tool;
 
         const { points, arrowFirst } = data.handles;
@@ -178,6 +178,7 @@ class ArrowAnnotate extends BaseAdapter3D {
             trackingIdentifierTextValue: this.trackingIdentifierTextValue,
             findingSites: findingSites || [],
             finding,
+            ReferencedFrameOfReferenceUID: metadata.FrameOfReferenceUID,
             use3DSpatialCoordinates: true
         };
 

--- a/packages/adapters/src/adapters/Cornerstone3D/BaseAdapter3D.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/BaseAdapter3D.ts
@@ -149,15 +149,14 @@ export default class BaseAdapter3D {
         const { referencedImageId } = metadata;
 
         if (!referencedImageId) {
-            throw new Error(
-                "Probe.getTID300RepresentationArguments: referencedImageId is not defined"
-            );
+            return this.getTID300RepresentationArgumentsSCOORD3D(tool);
         }
 
         const {
             handles: { points = [] }
         } = data;
 
+        // Using image coordinates for 2D points
         const pointsImage = points.map(point => {
             const pointImage = worldToImageCoords(referencedImageId, point);
             return {
@@ -174,5 +173,24 @@ export default class BaseAdapter3D {
         };
 
         return tidArguments;
+    }
+
+    static getTID300RepresentationArgumentsSCOORD3D(tool) {
+        const { data, finding, findingSites } = tool;
+        const {
+            handles: { points = [] }
+        } = data;
+
+        // Using world coordinates for 3D points
+        const point = points[0];
+
+        const pointXYZ = { x: point[0], y: point[1], z: point[2] };
+
+        return {
+            points: [pointXYZ],
+            trackingIdentifierTextValue: this.trackingIdentifierTextValue,
+            findingSites: findingSites || [],
+            finding
+        };
     }
 }

--- a/packages/adapters/src/adapters/Cornerstone3D/Bidirectional.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/Bidirectional.ts
@@ -187,7 +187,7 @@ class Bidirectional extends BaseAdapter3D {
         shortAxisPoints,
         longAxisPoints
     }) {
-        const { data, finding, findingSites } = tool;
+        const { data, finding, findingSites, metadata } = tool;
         const { cachedStats = {} } = data;
 
         // Using world coordinates for 3D points
@@ -231,6 +231,7 @@ class Bidirectional extends BaseAdapter3D {
             trackingIdentifierTextValue: this.trackingIdentifierTextValue,
             finding: finding,
             findingSites: findingSites || [],
+            ReferencedFrameOfReferenceUID: metadata.FrameOfReferenceUID,
             use3DSpatialCoordinates: true
         };
     }

--- a/packages/adapters/src/adapters/Cornerstone3D/Bidirectional.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/Bidirectional.ts
@@ -95,14 +95,6 @@ class Bidirectional extends BaseAdapter3D {
 
         const { referencedImageId } = metadata;
 
-        if (!referencedImageId) {
-            throw new Error(
-                "Bidirectional.getTID300RepresentationArguments: referencedImageId is not defined"
-            );
-        }
-
-        const { length, width } =
-            cachedStats[`imageId:${referencedImageId}`] || {};
         const { points } = handles;
 
         // Find the length and width point pairs by comparing the distances of the points at 0,1 to points at 2,3
@@ -131,6 +123,15 @@ class Bidirectional extends BaseAdapter3D {
             longAxisPoints = firstPointPairs;
         }
 
+        if (!referencedImageId) {
+            return this.getTID300RepresentationArgumentsSCOORD3D({
+                tool,
+                shortAxisPoints,
+                longAxisPoints
+            });
+        }
+
+        // Using image coordinates for 2D points
         const longAxisStartImage = worldToImageCoords(
             referencedImageId,
             shortAxisPoints[0]
@@ -147,6 +148,9 @@ class Bidirectional extends BaseAdapter3D {
             referencedImageId,
             longAxisPoints[1]
         );
+
+        const { length, width } =
+            cachedStats[`imageId:${referencedImageId}`] || {};
 
         return {
             longAxis: {
@@ -173,7 +177,61 @@ class Bidirectional extends BaseAdapter3D {
             shortAxisLength: width,
             trackingIdentifierTextValue: this.trackingIdentifierTextValue,
             finding: finding,
-            findingSites: findingSites || []
+            findingSites: findingSites || [],
+            use3DSpatialCoordinates: false
+        };
+    }
+
+    static getTID300RepresentationArgumentsSCOORD3D({
+        tool,
+        shortAxisPoints,
+        longAxisPoints
+    }) {
+        const { data, finding, findingSites } = tool;
+        const { cachedStats = {} } = data;
+
+        // Using world coordinates for 3D points
+        const longAxisStart = shortAxisPoints[0];
+        const longAxisEnd = shortAxisPoints[1];
+        const shortAxisStart = longAxisPoints[0];
+        const shortAxisEnd = longAxisPoints[1];
+
+        const cachedStatsKeys = Object.keys(cachedStats)[0];
+        const { length, width } = cachedStatsKeys
+            ? cachedStats[cachedStatsKeys]
+            : {};
+
+        return {
+            longAxis: {
+                point1: {
+                    x: longAxisStart[0],
+                    y: longAxisStart[1],
+                    z: longAxisStart[2]
+                },
+                point2: {
+                    x: longAxisEnd[0],
+                    y: longAxisEnd[1],
+                    z: longAxisEnd[2]
+                }
+            },
+            shortAxis: {
+                point1: {
+                    x: shortAxisStart[0],
+                    y: shortAxisStart[1],
+                    z: shortAxisStart[2]
+                },
+                point2: {
+                    x: shortAxisEnd[0],
+                    y: shortAxisEnd[1],
+                    z: shortAxisEnd[2]
+                }
+            },
+            longAxisLength: length,
+            shortAxisLength: width,
+            trackingIdentifierTextValue: this.trackingIdentifierTextValue,
+            finding: finding,
+            findingSites: findingSites || [],
+            use3DSpatialCoordinates: true
         };
     }
 }

--- a/packages/adapters/src/adapters/Cornerstone3D/CircleROI.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/CircleROI.ts
@@ -108,7 +108,7 @@ class CircleROI extends BaseAdapter3D {
     }
 
     static getTID300RepresentationArgumentsSCOORD3D(tool) {
-        const { data, finding, findingSites } = tool;
+        const { data, finding, findingSites, metadata } = tool;
         const { cachedStats = {}, handles } = data;
 
         // Using world coordinates for 3D points
@@ -133,6 +133,7 @@ class CircleROI extends BaseAdapter3D {
             trackingIdentifierTextValue: this.trackingIdentifierTextValue,
             finding,
             findingSites: findingSites || [],
+            ReferencedFrameOfReferenceUID: metadata.FrameOfReferenceUID,
             use3DSpatialCoordinates: true
         };
     }

--- a/packages/adapters/src/adapters/Cornerstone3D/CircleROI.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/CircleROI.ts
@@ -80,11 +80,10 @@ class CircleROI extends BaseAdapter3D {
         const { referencedImageId } = metadata;
 
         if (!referencedImageId) {
-            throw new Error(
-                "CircleROI.getTID300RepresentationArguments: referencedImageId is not defined"
-            );
+            return this.getTID300RepresentationArgumentsSCOORD3D(tool);
         }
 
+        // Using image coordinates for 2D points
         const center = worldToImageCoords(referencedImageId, handles.points[0]);
         const end = worldToImageCoords(referencedImageId, handles.points[1]);
 
@@ -103,7 +102,38 @@ class CircleROI extends BaseAdapter3D {
             points,
             trackingIdentifierTextValue: this.trackingIdentifierTextValue,
             finding,
-            findingSites: findingSites || []
+            findingSites: findingSites || [],
+            use3DSpatialCoordinates: false
+        };
+    }
+
+    static getTID300RepresentationArgumentsSCOORD3D(tool) {
+        const { data, finding, findingSites } = tool;
+        const { cachedStats = {}, handles } = data;
+
+        // Using world coordinates for 3D points
+        const center = handles.points[0];
+        const end = handles.points[1];
+
+        const points = [];
+        points.push({ x: center[0], y: center[1], z: center[2] });
+        points.push({ x: end[0], y: end[1], z: center[2] });
+
+        const cachedStatsKeys = Object.keys(cachedStats)[0];
+        const { area, radius } = cachedStatsKeys
+            ? cachedStats[cachedStatsKeys]
+            : {};
+        const perimeter = 2 * Math.PI * radius;
+
+        return {
+            area,
+            perimeter,
+            radius,
+            points,
+            trackingIdentifierTextValue: this.trackingIdentifierTextValue,
+            finding,
+            findingSites: findingSites || [],
+            use3DSpatialCoordinates: true
         };
     }
 }

--- a/packages/adapters/src/adapters/Cornerstone3D/CobbAngle.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/CobbAngle.ts
@@ -104,7 +104,7 @@ class CobbAngle extends BaseAdapter3D {
     }
 
     public static getTID300RepresentationArgumentsSCOORD3D(tool) {
-        const { data, finding, findingSites } = tool;
+        const { data, finding, findingSites, metadata } = tool;
         const { cachedStats = {}, handles } = data;
 
         // Using world coordinates for 3D points
@@ -130,6 +130,7 @@ class CobbAngle extends BaseAdapter3D {
             trackingIdentifierTextValue: this.trackingIdentifierTextValue,
             finding,
             findingSites: findingSites || [],
+            ReferencedFrameOfReferenceUID: metadata.FrameOfReferenceUID,
             use3DSpatialCoordinates: true
         };
     }

--- a/packages/adapters/src/adapters/Cornerstone3D/CobbAngle.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/CobbAngle.ts
@@ -18,14 +18,46 @@ class CobbAngle extends BaseAdapter3D {
         imageToWorldCoords,
         metadata
     ) {
-        const { defaultState, NUMGroup, SCOORDGroup, ReferencedFrameNumber } =
-            MeasurementReport.getSetupMeasurementData(
-                MeasurementGroup,
-                sopInstanceUIDToImageIdMap,
-                metadata,
-                CobbAngle.toolType
-            );
+        const {
+            defaultState,
+            NUMGroup,
+            SCOORDGroup,
+            SCOORD3DGroup,
+            ReferencedFrameNumber
+        } = MeasurementReport.getSetupMeasurementData(
+            MeasurementGroup,
+            sopInstanceUIDToImageIdMap,
+            metadata,
+            CobbAngle.toolType
+        );
 
+        if (SCOORDGroup) {
+            return this.getMeasurementDataFromScoord({
+                defaultState,
+                SCOORDGroup,
+                imageToWorldCoords,
+                NUMGroup,
+                ReferencedFrameNumber
+            });
+        } else if (SCOORD3DGroup) {
+            return this.getMeasurementDataFromScoord3D({
+                defaultState,
+                SCOORD3DGroup
+            });
+        } else {
+            throw new Error(
+                "Can't get measurement data with missing SCOORD and SCOORD3D groups."
+            );
+        }
+    }
+
+    static getMeasurementDataFromScoord({
+        defaultState,
+        SCOORDGroup,
+        imageToWorldCoords,
+        NUMGroup,
+        ReferencedFrameNumber
+    }) {
         const referencedImageId =
             defaultState.annotation.metadata.referencedImageId;
 
@@ -62,6 +94,39 @@ class CobbAngle extends BaseAdapter3D {
                 }
             },
             frameNumber: ReferencedFrameNumber
+        };
+
+        return state;
+    }
+
+    static getMeasurementDataFromScoord3D({ defaultState, SCOORD3DGroup }) {
+        const { GraphicData } = SCOORD3DGroup;
+        const worldCoords = [];
+        for (let i = 0; i < GraphicData.length; i += 3) {
+            const point = [
+                GraphicData[i],
+                GraphicData[i + 1],
+                GraphicData[i + 2]
+            ];
+            worldCoords.push(point);
+        }
+
+        const state = defaultState;
+
+        state.annotation.data = {
+            handles: {
+                points: [
+                    worldCoords[0],
+                    worldCoords[1],
+                    worldCoords[2],
+                    worldCoords[3]
+                ],
+                activeHandleIndex: 0,
+                textBox: {
+                    hasMoved: false
+                }
+            },
+            cachedStats: {}
         };
 
         return state;

--- a/packages/adapters/src/adapters/Cornerstone3D/CobbAngle.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/CobbAngle.ts
@@ -74,14 +74,12 @@ class CobbAngle extends BaseAdapter3D {
         const { referencedImageId } = metadata;
 
         if (!referencedImageId) {
-            throw new Error(
-                "CobbAngle.getTID300RepresentationArguments: referencedImageId is not defined"
-            );
+            return this.getTID300RepresentationArgumentsSCOORD3D(tool);
         }
 
+        // Using image coordinates for 2D points
         const start1 = worldToImageCoords(referencedImageId, handles.points[0]);
         const end1 = worldToImageCoords(referencedImageId, handles.points[1]);
-
         const start2 = worldToImageCoords(referencedImageId, handles.points[2]);
         const end2 = worldToImageCoords(referencedImageId, handles.points[3]);
 
@@ -100,7 +98,39 @@ class CobbAngle extends BaseAdapter3D {
             rAngle: angle,
             trackingIdentifierTextValue: this.trackingIdentifierTextValue,
             finding,
-            findingSites: findingSites || []
+            findingSites: findingSites || [],
+            use3DSpatialCoordinates: false
+        };
+    }
+
+    public static getTID300RepresentationArgumentsSCOORD3D(tool) {
+        const { data, finding, findingSites } = tool;
+        const { cachedStats = {}, handles } = data;
+
+        // Using world coordinates for 3D points
+        const start1 = handles.points[0];
+        const end1 = handles.points[1];
+        const start2 = handles.points[2];
+        const end2 = handles.points[3];
+
+        const point1 = { x: start1[0], y: start1[1], z: start1[2] };
+        const point2 = { x: end1[0], y: end1[1], z: end1[2] };
+        const point3 = { x: start2[0], y: start2[1], z: start2[2] };
+        const point4 = { x: end2[0], y: end2[1], z: end2[2] };
+
+        const cachedStatsKeys = Object.keys(cachedStats)[0];
+        const { angle } = cachedStatsKeys ? cachedStats[cachedStatsKeys] : {};
+
+        return {
+            point1,
+            point2,
+            point3,
+            point4,
+            rAngle: angle,
+            trackingIdentifierTextValue: this.trackingIdentifierTextValue,
+            finding,
+            findingSites: findingSites || [],
+            use3DSpatialCoordinates: true
         };
     }
 }

--- a/packages/adapters/src/adapters/Cornerstone3D/EllipticalROI.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/EllipticalROI.ts
@@ -189,7 +189,8 @@ class EllipticalROI extends BaseAdapter3D {
             points,
             trackingIdentifierTextValue: this.trackingIdentifierTextValue,
             finding,
-            findingSites: findingSites || []
+            findingSites: findingSites || [],
+            use3DSpatialCoordinates: false
         };
     }
 
@@ -253,7 +254,8 @@ class EllipticalROI extends BaseAdapter3D {
             points,
             trackingIdentifierTextValue: this.trackingIdentifierTextValue,
             finding,
-            findingSites: findingSites || []
+            findingSites: findingSites || [],
+            use3DSpatialCoordinates: true
         };
     }
 }

--- a/packages/adapters/src/adapters/Cornerstone3D/EllipticalROI.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/EllipticalROI.ts
@@ -195,7 +195,7 @@ class EllipticalROI extends BaseAdapter3D {
     }
 
     static getTID300RepresentationArgumentsSCOORD3D(tool) {
-        const { data, finding, findingSites } = tool;
+        const { data, finding, findingSites, metadata } = tool;
         const { cachedStats, handles } = data;
         const rotation = data.initialRotation || 0;
 
@@ -255,6 +255,7 @@ class EllipticalROI extends BaseAdapter3D {
             trackingIdentifierTextValue: this.trackingIdentifierTextValue,
             finding,
             findingSites: findingSites || [],
+            ReferencedFrameOfReferenceUID: metadata.FrameOfReferenceUID,
             use3DSpatialCoordinates: true
         };
     }

--- a/packages/adapters/src/adapters/Cornerstone3D/Length.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/Length.ts
@@ -96,7 +96,7 @@ export default class Length extends BaseAdapter3D {
     }
 
     static getTID300RepresentationArgumentsSCOORD3D(tool) {
-        const { data, finding, findingSites } = tool;
+        const { data, finding, findingSites, metadata } = tool;
         const { cachedStats = {}, handles } = data;
 
         // Using world coordinates for 3D points
@@ -118,6 +118,7 @@ export default class Length extends BaseAdapter3D {
             trackingIdentifierTextValue: this.trackingIdentifierTextValue,
             finding,
             findingSites: findingSites || [],
+            ReferencedFrameOfReferenceUID: metadata.FrameOfReferenceUID,
             use3DSpatialCoordinates: true
         };
     }

--- a/packages/adapters/src/adapters/Cornerstone3D/Length.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/Length.ts
@@ -118,7 +118,7 @@ export default class Length extends BaseAdapter3D {
             trackingIdentifierTextValue: this.trackingIdentifierTextValue,
             finding,
             findingSites: findingSites || [],
-            use3DSpatialCoordinates: false
+            use3DSpatialCoordinates: true
         };
     }
 }

--- a/packages/adapters/src/adapters/Cornerstone3D/Length.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/Length.ts
@@ -71,11 +71,10 @@ export default class Length extends BaseAdapter3D {
         const { referencedImageId } = metadata;
 
         if (!referencedImageId) {
-            throw new Error(
-                "Length.getTID300RepresentationArguments: referencedImageId is not defined"
-            );
+            return this.getTID300RepresentationArgumentsSCOORD3D(tool);
         }
 
+        // Using image coordinates for 2D points
         const start = worldToImageCoords(referencedImageId, handles.points[0]);
         const end = worldToImageCoords(referencedImageId, handles.points[1]);
 
@@ -91,7 +90,35 @@ export default class Length extends BaseAdapter3D {
             distance,
             trackingIdentifierTextValue: this.trackingIdentifierTextValue,
             finding,
-            findingSites: findingSites || []
+            findingSites: findingSites || [],
+            use3DSpatialCoordinates: false
+        };
+    }
+
+    static getTID300RepresentationArgumentsSCOORD3D(tool) {
+        const { data, finding, findingSites } = tool;
+        const { cachedStats = {}, handles } = data;
+
+        // Using world coordinates for 3D points
+        const start = handles.points[0];
+        const end = handles.points[1];
+
+        const point1 = { x: start[0], y: start[1], z: start[2] };
+        const point2 = { x: end[0], y: end[1], z: end[2] };
+
+        const cachedStatsKeys = Object.keys(cachedStats)[0];
+        const { length: distance } = cachedStatsKeys
+            ? cachedStats[cachedStatsKeys]
+            : {};
+
+        return {
+            point1,
+            point2,
+            distance,
+            trackingIdentifierTextValue: this.trackingIdentifierTextValue,
+            finding,
+            findingSites: findingSites || [],
+            use3DSpatialCoordinates: false
         };
     }
 }

--- a/packages/adapters/src/adapters/Cornerstone3D/MeasurementReport.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/MeasurementReport.ts
@@ -419,7 +419,7 @@ export default class MeasurementReport {
         sopInstanceUIDsToSeriesInstanceUIDMap,
         derivationSourceDatasets
     }) {
-        if (imageId === "orphan") {
+        if (imageId === "none") {
             return;
         }
 

--- a/packages/adapters/src/adapters/Cornerstone3D/MeasurementReport.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/MeasurementReport.ts
@@ -516,6 +516,7 @@ export default class MeasurementReport {
         const derivationSourceDatasets = [];
 
         const _meta = MeasurementReport.generateDatasetMeta();
+        let is3DSR = false;
 
         // Loop through each image in the toolData
         Object.keys(toolState).forEach(imageId => {
@@ -536,6 +537,7 @@ export default class MeasurementReport {
                     metadataProvider,
                     derivationSourceDatasets
                 });
+                is3DSR = true;
             }
 
             // Loop through each tool type for the image
@@ -573,6 +575,11 @@ export default class MeasurementReport {
         report.dataset = Object.assign(report.dataset, contentItem);
         report.dataset._meta = _meta;
         report.SpecificCharacterSet = "ISO_IR 192";
+
+        if (is3DSR) {
+            report.dataset.SOPClassUID =
+                DicomMetaDictionary.sopClassUIDsByName.Comprehensive3DSR;
+        }
 
         return report;
     }

--- a/packages/adapters/src/adapters/Cornerstone3D/PlanarFreehandROI.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/PlanarFreehandROI.ts
@@ -99,6 +99,7 @@ class PlanarFreehandROI extends BaseAdapter3D {
             );
         }
 
+        // Using image coordinates for 2D points
         const points = polyline.map(worldPos =>
             worldToImageCoords(referencedImageId, worldPos)
         );
@@ -113,6 +114,44 @@ class PlanarFreehandROI extends BaseAdapter3D {
 
         const { area, areaUnit, modalityUnit, perimeter, mean, max, stdDev } =
             data.cachedStats[`imageId:${referencedImageId}`] || {};
+
+        return {
+            /** From cachedStats */
+            points,
+            area,
+            areaUnit,
+            perimeter,
+            modalityUnit,
+            mean,
+            max,
+            stdDev,
+            /** Other */
+            trackingIdentifierTextValue: this.trackingIdentifierTextValue,
+            finding,
+            findingSites: findingSites || []
+        };
+    }
+
+    static getTID300RepresentationArgumentsSCOORD3D(tool, worldToImageCoords) {
+        const { data, finding, findingSites } = tool;
+
+        const { polyline, closed } = data.contour;
+        const isOpenContour = closed !== true;
+
+        // Using world coordinates for 3D points
+        const points = polyline;
+
+        if (!isOpenContour) {
+            // Need to repeat the first point at the end of to have an explicitly closed contour.
+            const firstPoint = points[0];
+
+            // Explicitly expand to avoid circular references.
+            points.push([firstPoint[0], firstPoint[1], firstPoint[2]]);
+        }
+
+        const cachedStatsKeys = Object.keys(data.cachedStats)[0];
+        const { area, areaUnit, modalityUnit, perimeter, mean, max, stdDev } =
+            cachedStatsKeys ? data.cachedStats[cachedStatsKeys] : {};
 
         return {
             /** From cachedStats */

--- a/packages/adapters/src/adapters/Cornerstone3D/PlanarFreehandROI.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/PlanarFreehandROI.ts
@@ -94,9 +94,7 @@ class PlanarFreehandROI extends BaseAdapter3D {
         const { referencedImageId } = metadata;
 
         if (!referencedImageId) {
-            throw new Error(
-                "PlanarFreehandROI.getTID300RepresentationArguments: referencedImageId is not defined"
-            );
+            return this.getTID300RepresentationArgumentsSCOORD3D(tool);
         }
 
         // Using image coordinates for 2D points
@@ -128,11 +126,12 @@ class PlanarFreehandROI extends BaseAdapter3D {
             /** Other */
             trackingIdentifierTextValue: this.trackingIdentifierTextValue,
             finding,
-            findingSites: findingSites || []
+            findingSites: findingSites || [],
+            use3DSpatialCoordinates: false
         };
     }
 
-    static getTID300RepresentationArgumentsSCOORD3D(tool, worldToImageCoords) {
+    static getTID300RepresentationArgumentsSCOORD3D(tool) {
         const { data, finding, findingSites } = tool;
 
         const { polyline, closed } = data.contour;
@@ -166,7 +165,8 @@ class PlanarFreehandROI extends BaseAdapter3D {
             /** Other */
             trackingIdentifierTextValue: this.trackingIdentifierTextValue,
             finding,
-            findingSites: findingSites || []
+            findingSites: findingSites || [],
+            use3DSpatialCoordinates: true
         };
     }
 }

--- a/packages/adapters/src/adapters/Cornerstone3D/PlanarFreehandROI.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/PlanarFreehandROI.ts
@@ -132,7 +132,7 @@ class PlanarFreehandROI extends BaseAdapter3D {
     }
 
     static getTID300RepresentationArgumentsSCOORD3D(tool) {
-        const { data, finding, findingSites } = tool;
+        const { data, finding, findingSites, metadata } = tool;
 
         const { polyline, closed } = data.contour;
         const isOpenContour = closed !== true;
@@ -166,6 +166,7 @@ class PlanarFreehandROI extends BaseAdapter3D {
             trackingIdentifierTextValue: this.trackingIdentifierTextValue,
             finding,
             findingSites: findingSites || [],
+            ReferencedFrameOfReferenceUID: metadata.FrameOfReferenceUID,
             use3DSpatialCoordinates: true
         };
     }

--- a/packages/adapters/src/adapters/Cornerstone3D/Probe.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/Probe.ts
@@ -25,7 +25,7 @@ class Probe extends BaseAdapter3D {
             trackingIdentifier
         );
 
-        const { defaultState, SCOORDGroup } =
+        const { defaultState, SCOORDGroup, SCOORD3DGroup } =
             MeasurementReport.getSetupMeasurementData(
                 MeasurementGroup,
                 sopInstanceUIDToImageIdMap,
@@ -33,6 +33,31 @@ class Probe extends BaseAdapter3D {
                 Probe.toolType
             );
 
+        if (SCOORDGroup) {
+            return this.getMeasurementDataFromScoord({
+                state,
+                defaultState,
+                SCOORDGroup,
+                imageToWorldCoords
+            });
+        } else if (SCOORD3DGroup) {
+            return this.getMeasurementDataFromScoord3D({
+                state,
+                SCOORD3DGroup
+            });
+        } else {
+            throw new Error(
+                "Can't get measurement data with missing SCOORD and SCOORD3D groups."
+            );
+        }
+    }
+
+    static getMeasurementDataFromScoord({
+        state,
+        defaultState,
+        SCOORDGroup,
+        imageToWorldCoords
+    }) {
         const referencedImageId =
             defaultState.annotation.metadata.referencedImageId;
 
@@ -59,6 +84,85 @@ class Probe extends BaseAdapter3D {
         };
 
         return state;
+    }
+
+    static getMeasurementDataFromScoord3D({ state, SCOORD3DGroup }) {
+        const { GraphicData } = SCOORD3DGroup;
+
+        const worldCoords = [];
+        for (let i = 0; i < GraphicData.length; i += 3) {
+            const point = [
+                GraphicData[i],
+                GraphicData[i + 1],
+                GraphicData[i + 2]
+            ];
+            worldCoords.push(point);
+        }
+
+        state.annotation.data = {
+            ...state.annotation.data,
+            handles: {
+                points: worldCoords,
+                activeHandleIndex: null,
+                textBox: {
+                    hasMoved: false
+                }
+            }
+        };
+
+        return state;
+    }
+
+    public static getTID300RepresentationArguments(tool, worldToImageCoords) {
+        const { data, metadata } = tool;
+        const { finding, findingSites } = tool;
+        const { referencedImageId } = metadata;
+
+        if (!referencedImageId) {
+            return this.getTID300RepresentationArgumentsSCOORD3D(tool);
+        }
+
+        const {
+            handles: { points = [] }
+        } = data;
+
+        // Using image coordinates for 2D points
+        const pointsImage = points.map(point => {
+            const pointImage = worldToImageCoords(referencedImageId, point);
+            return {
+                x: pointImage[0],
+                y: pointImage[1]
+            };
+        });
+
+        return {
+            points: pointsImage,
+            trackingIdentifierTextValue: this.trackingIdentifierTextValue,
+            findingSites: findingSites || [],
+            finding,
+            use3DSpatialCoordinates: false
+        };
+    }
+
+    static getTID300RepresentationArgumentsSCOORD3D(tool) {
+        const { data, finding, findingSites, metadata } = tool;
+        const {
+            handles: { points = [] }
+        } = data;
+
+        // Using world coordinates for 3D points
+        const point = points[0];
+
+        const pointXYZ = { x: point[0], y: point[1], z: point[2] };
+
+        return {
+            points: [pointXYZ],
+            trackingIdentifierTextValue: this.trackingIdentifierTextValue,
+            ReferencedFrameOfReferenceUID: metadata.FrameOfReferenceUID,
+            findingSites: findingSites || [],
+            finding,
+            use3DSpatialCoordinates: true
+        };
     }
 }
 

--- a/packages/adapters/src/adapters/Cornerstone3D/RectangleROI.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/RectangleROI.ts
@@ -100,7 +100,7 @@ class RectangleROI extends BaseAdapter3D {
     }
 
     static getTID300RepresentationArgumentsSCOORD3D(tool) {
-        const { data, finding, findingSites } = tool;
+        const { data, finding, findingSites, metadata } = tool;
         const { cachedStats = {}, handles } = data;
 
         //Using world coordinates for 3D points
@@ -121,6 +121,7 @@ class RectangleROI extends BaseAdapter3D {
             trackingIdentifierTextValue: this.trackingIdentifierTextValue,
             finding,
             findingSites: findingSites || [],
+            ReferencedFrameOfReferenceUID: metadata.FrameOfReferenceUID,
             use3DSpatialCoordinates: true
         };
     }

--- a/packages/adapters/src/adapters/Cornerstone3D/RectangleROI.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/RectangleROI.ts
@@ -72,11 +72,10 @@ class RectangleROI extends BaseAdapter3D {
         const { referencedImageId } = metadata;
 
         if (!referencedImageId) {
-            throw new Error(
-                "CobbAngle.getTID300RepresentationArguments: referencedImageId is not defined"
-            );
+            return this.getTID300RepresentationArgumentsSCOORD3D(tool);
         }
 
+        //Using image coordinates for 2D points
         const corners = handles.points.map(point =>
             worldToImageCoords(referencedImageId, point)
         );
@@ -95,7 +94,34 @@ class RectangleROI extends BaseAdapter3D {
             perimeter,
             trackingIdentifierTextValue: this.trackingIdentifierTextValue,
             finding,
-            findingSites: findingSites || []
+            findingSites: findingSites || [],
+            use3DSpatialCoordinates: false
+        };
+    }
+
+    static getTID300RepresentationArgumentsSCOORD3D(tool) {
+        const { data, finding, findingSites } = tool;
+        const { cachedStats = {}, handles } = data;
+
+        //Using world coordinates for 3D points
+        const corners = handles.points;
+
+        const { area, perimeter } = cachedStats;
+
+        return {
+            points: [
+                corners[0],
+                corners[1],
+                corners[3],
+                corners[2],
+                corners[0]
+            ],
+            area,
+            perimeter,
+            trackingIdentifierTextValue: this.trackingIdentifierTextValue,
+            finding,
+            findingSites: findingSites || [],
+            use3DSpatialCoordinates: true
         };
     }
 }

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@babel/runtime-corejs2": "^7.17.8",
     "buffer": "^6.0.3",
-    "dcmjs": "^0.29.8",
+    "dcmjs": "^0.40.0",
     "gl-matrix": "^3.4.3",
     "lodash.clonedeep": "^4.5.0",
     "ndarray": "^1.0.19",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -48,7 +48,7 @@
     "@svgr/webpack": "^8.1.0",
     "clsx": "^1.1.1",
     "cross-env": "^7.0.3",
-    "dcmjs": "^0.33.0",
+    "dcmjs": "^0.40.0",
     "dicom-parser": "^1.8.21",
     "dicomweb-client": "0.10.4",
     "docusaurus-plugin-copy": "0.1.1",

--- a/packages/tools/src/tools/segmentation/LabelmapBaseTool.ts
+++ b/packages/tools/src/tools/segmentation/LabelmapBaseTool.ts
@@ -529,7 +529,6 @@ export default class LabelmapBaseTool extends BaseTool {
       return;
     }
     const contourAnnotations = viewAnnotations.filter(
-      // @ts-expect-error
       (annotation) => annotation.data.contour?.polyline?.length
     );
     if (!contourAnnotations.length) {
@@ -573,7 +572,6 @@ export default class LabelmapBaseTool extends BaseTool {
         [Infinity, -Infinity],
       ];
 
-      // @ts-expect-error
       const { polyline } = annotation.data.contour;
       for (const point of polyline) {
         const indexPoint = imageData.worldToIndex(point);

--- a/packages/tools/src/types/AnnotationTypes.ts
+++ b/packages/tools/src/types/AnnotationTypes.ts
@@ -59,7 +59,18 @@ type Annotation = {
     cachedStats?: Record<string, unknown>;
     /** Label of an annotation */
     label?: string;
+    /** contour data */
+    contour?: Contour;
   };
+};
+
+type Contour = {
+  /** world location of the polyline in the space */
+  polyline?: Types.Point3[];
+  /** PointsManager */
+  pointsManager?: Types.IPointsManager<Types.Point3>;
+  /** boolean indicating if the contour is closed */
+  closed?: boolean;
 };
 
 /** Array of annotations */

--- a/packages/tools/src/utilities/planar/filterAnnotationsWithinSlice.ts
+++ b/packages/tools/src/utilities/planar/filterAnnotationsWithinSlice.ts
@@ -103,7 +103,6 @@ export default function filterAnnotationsWithinSlice(
   for (const annotation of annotationsWithParallelNormals) {
     const data = annotation.data;
 
-    // @ts-expect-error
     const point = data.handles.points[0] || data.contour?.polyline[0];
 
     if (!annotation.isVisible) {

--- a/packages/tools/src/utilities/planar/filterAnnotationsWithinSlice.ts
+++ b/packages/tools/src/utilities/planar/filterAnnotationsWithinSlice.ts
@@ -1,7 +1,9 @@
 import { vec3 } from 'gl-matrix';
-import { CONSTANTS, metaData } from '@cornerstonejs/core';
+import { CONSTANTS, metaData, utilities } from '@cornerstonejs/core';
 import type { Types } from '@cornerstonejs/core';
 import type { Annotations, Annotation } from '../../types';
+
+const { isEqual } = utilities;
 
 const { EPSILON } = CONSTANTS;
 
@@ -34,6 +36,23 @@ export default function filterAnnotationsWithinSlice(
   const annotationsWithParallelNormals = annotations.filter(
     (td: Annotation) => {
       let annotationViewPlaneNormal = td.metadata.viewPlaneNormal;
+
+      if (
+        !td.metadata.referencedImageId &&
+        !annotationViewPlaneNormal &&
+        td.metadata.FrameOfReferenceUID
+      ) {
+        for (const point of td.data.handles.points) {
+          const vector = vec3.sub(vec3.create(), point, camera.focalPoint);
+          const dotProduct = vec3.dot(vector, camera.viewPlaneNormal);
+          if (!isEqual(dotProduct, 0)) {
+            return false;
+          }
+        }
+        td.metadata.viewPlaneNormal = camera.viewPlaneNormal;
+        td.metadata.cameraFocalPoint = camera.focalPoint;
+        return true;
+      }
 
       if (!annotationViewPlaneNormal) {
         // This code is run to set the annotation view plane normal

--- a/yarn.lock
+++ b/yarn.lock
@@ -7606,6 +7606,19 @@ dcmjs@^0.29.8:
     ndarray "^1.0.19"
     pako "^2.0.4"
 
+dcmjs@^0.40.0:
+  version "0.40.0"
+  resolved "https://registry.yarnpkg.com/dcmjs/-/dcmjs-0.40.0.tgz#04218d221b4b197d36580301ce7e8110cd99aa50"
+  integrity sha512-FId8dPpDg45ynIjpWF1mXlA77YcQBcE/eQGgkQpJqB0k9NF4simMYbSm9pJ5ORizYdDzOzjZpVNVym/vnFQJzQ==
+  dependencies:
+    "@babel/runtime-corejs3" "^7.22.5"
+    adm-zip "^0.5.10"
+    gl-matrix "^3.1.0"
+    lodash.clonedeep "^4.5.0"
+    loglevel "^1.8.1"
+    ndarray "^1.0.19"
+    pako "^2.0.4"
+
 debounce@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
@@ -13173,7 +13186,7 @@ logform@^2.6.0, logform@^2.6.1:
     safe-stable-stringify "^2.3.1"
     triple-beam "^1.3.0"
 
-loglevel@^1.9.2:
+loglevel@^1.8.1, loglevel@^1.9.2:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.9.2.tgz#c2e028d6c757720107df4e64508530db6621ba08"
   integrity sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==


### PR DESCRIPTION
### Context

TID.300 measurements can now be defined using either 2D or 3D points with the [latest dcmjs changes](https://github.com/dcmjs-org/dcmjs/pull/432). This is controlled by the use of either `SCOORD` (2D) or `SCOORD3D` (3D) in the **Measurement Value Sequence**, as described in the TID.320 section of TID.300:  
🔗 [DICOM TID.320 Reference](https://dicom.nema.org/medical/dicom/current/output/chtml/part16/chapter_A.html#sect_TID_320)

TID.1501 defines the reference information for the SCOORD3D points:
🔗 [DICOM TID.1501 Reference](https://dicom.nema.org/medical/dicom/current/output/chtml/part16/chapter_A.html#sect_TID_1501)

This pull request introduces support for selecting between `SCOORD` and `SCOORD3D` encodings in several TID.300 measurement types, including:

- Length  
- Bidirectional  
- Cobb Angle  
- Ellipse  

### Changes & Results

It's now possible to save and load SRs with annotations that were drawn on reconstructed views:

https://github.com/user-attachments/assets/b296d0a9-e3c8-406c-9b3b-19022cee67da


### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)



#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
