### PR TITLE
fix(statistics): include unit in volume statistics calculation

### DIFF
--- a/packages/tools/src/utilities/segmentation/getStatistics.ts
+++ b/packages/tools/src/utilities/segmentation/getStatistics.ts
@@ -142,6 +142,7 @@ async function calculateVolumeStatistics({
       segmentationInfo,
       imageInfo,
       indices,
+      unit,
       mode,
     }
   );

--- a/packages/tools/src/workers/computeWorker.js
+++ b/packages/tools/src/workers/computeWorker.js
@@ -146,7 +146,7 @@ const computeWorker = {
     };
   },
   calculateSegmentsStatisticsVolume: (args) => {
-    const { mode, indices } = args;
+    const { mode, indices, unit } = args;
     const { segmentation, image } = computeWorker.getArgsFromInfo(args);
 
     const { voxelManager: segVoxelManager, spacing: segmentationSpacing } =
@@ -173,8 +173,8 @@ const computeWorker = {
     // Get statistics based on the mode
     const stats = SegmentStatsCalculator.getStatistics({
       spacing: segmentationSpacing,
-      unit: 'mm',
       mode,
+      unit,
     });
 
     return stats;


### PR DESCRIPTION
addresses https://github.com/OHIF/Viewers/issues/4954

This pull request introduces a new `unit` parameter to improve flexibility in volume statistics calculations. The changes ensure that the `unit` can be dynamically specified instead of being hardcoded, enhancing the functionality of the segmentation utilities and compute worker.

### Enhancements to volume statistics calculation:

* [`packages/tools/src/utilities/segmentation/getStatistics.ts`](diffhunk://#diff-6964b8509da89eeeae1cef8b3a2346e873273c05240486ccb93e4a06dae6a327R145): Added the `unit` parameter to the `calculateVolumeStatistics` function arguments, enabling dynamic specification of measurement units.

* [`packages/tools/src/workers/computeWorker.js`](diffhunk://#diff-abea066247d5fca6f24c869d18d686df8eb6a0c4bb33961d70a6689903096b43L149-R149): Updated the `calculateSegmentsStatisticsVolume` method to include the `unit` parameter in its arguments, and replaced the previously hardcoded `'mm'` unit with the dynamically provided `unit` parameter when calling `SegmentStatsCalculator.getStatistics`. [[1]](diffhunk://#diff-abea066247d5fca6f24c869d18d686df8eb6a0c4bb33961d70a6689903096b43L149-R149) [[2]](diffhunk://#diff-abea066247d5fca6f24c869d18d686df8eb6a0c4bb33961d70a6689903096b43L176-R177)