### PR TITLE
fix: panTool in wsi

### DIFF
--- a/packages/core/src/RenderingEngine/WSIViewport.ts
+++ b/packages/core/src/RenderingEngine/WSIViewport.ts
@@ -370,13 +370,9 @@ class WSIViewport extends Viewport {
 
   public getCamera(): ICamera {
     this.refreshRenderValues();
-    const { resolution, xSpacing } = this.internalCamera;
+    const { resolution, xSpacing, centerIndex } = this.internalCamera;
     const canvasToWorldRatio = resolution * xSpacing;
-
-    const canvasCenter: Point2 = [
-      this.element.clientWidth / 2,
-      this.element.clientHeight / 2,
-    ];
+    const canvasCenter = this.indexToCanvas(centerIndex.slice(0, 2) as Point2);
     const focalPoint = this.canvasToWorld(canvasCenter);
 
     return {


### PR DESCRIPTION

### Context

Ticket number: 8925455119

### Changes & Results

Changed the center of canvas calculation to use centerIndex from the camera in getCamera.

### Testing

Run the wsi example.
Click on the mouse wheel and drag to pan.
Panning is not moving correctly before the change and correctly after.


<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
