### PR TITLE
fix(contourHandler): remove unnecessary camera reset in handleContourSegmentation function

### DIFF
--- a/packages/tools/src/tools/displayTools/Contour/contourHandler/handleContourSegmentation.ts
+++ b/packages/tools/src/tools/displayTools/Contour/contourHandler/handleContourSegmentation.ts
@@ -105,7 +105,6 @@ function addContourSetsToElement(
     }
   });
 
-  viewport.resetCamera();
   viewport.render();
 }
 


### PR DESCRIPTION
This pull request includes a minor change to the `handleContourSegmentation.ts` file. The change removes a call to `viewport.resetCamera()` in the `addContourSetsToElement` function.

Now that we've switched from VTK actors to only annotations in contours, we no longer need a reset camera.
