### PR TITLE
fix(metadata): add get pixelSpacing from ImagerPixelSpacing (0018,1164)

### DIFF
--- a/packages/dicomImageLoader/src/imageLoader/wadouri/metaData/extractPositioningFromDataset.ts
+++ b/packages/dicomImageLoader/src/imageLoader/wadouri/metaData/extractPositioningFromDataset.ts
@@ -151,6 +151,12 @@ function extractSpacingFromDataset(dataSet) {
     );
   }
 
+  // If pixelSpacing not valid to this point, trying to get the spacing
+  // from the Imager Pixel Spacing
+  if (!pixelSpacing && dataSet.elements.x00181164) {
+    pixelSpacing = getNumberValues(dataSet, 'x00181164', 2);
+  }
+
   return pixelSpacing;
 }
 


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

Fixes #2042.

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

Takes pixelSpacing metadata from imagerPixelSpacing tag - 0018,1164 if not found earlier.

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

Load dicom without Pixel Spacing tag - 0028,0030, in current version of application measurement would give wrong values. With change it will have correct value. Dicom to test is provided in issue #2042. 

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)



#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->Windows  11
- [x] "Node version: <!--[e.g. 16.14.0]"--> v20.18.0
- [x] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"--> Brave v1.78.97

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
