### PR TITLE
fix(polyseg): fix updateSurfaceData type error

### DIFF
--- a/packages/tools/src/config.ts
+++ b/packages/tools/src/config.ts
@@ -59,7 +59,7 @@ type PolySegAddOn = {
   computeSurfaceData: ComputeRepresentationFn<SurfaceSegmentationData>;
 
   /** Updates different segmentation representation data */
-  updateSurfaceData: ComputeRepresentationFn<SurfaceSegmentationData>;
+  updateSurfaceData: ComputeRepresentationFn<void>;
 
   /** Clips and caches surfaces for a viewport */
   clipAndCacheSurfacesForViewport: (


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
Fixes [#1880](https://github.com/cornerstonejs/cornerstone3D/issues/1880)

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
Fix the type of `updateSurfaceData` from `ComputeRepresentationFn<SurfaceSegmentationData>` to `ComputeRepresentationFn<void>`.
<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
It will have a type error when we add `addons` in the cornerstone tools init function:
```typescript
await csToolsInit({
    addons: {
      polySeg, // type error occurs here
    },
  });
```

The detail of the type error:
```
Type 'typeof import("/Users/xxx/Desktop/repo/cornerstone3D/packages/polymorphic-segmentation/src/index")' is not assignable to type 'PolySegAddOn'.
  The types returned by 'updateSurfaceData(...)' are incompatible between these types.
    Type 'Promise<void>' is not assignable to type 'Promise<SurfaceSegmentationData>'.
      Type 'void' is not assignable to type 'SurfaceSegmentationData'.ts(2322)
config.ts(88, 3): The expected type comes from property 'polySeg' which is declared here on type 'AddOns'
```

After the fix, the type error is resolved.

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)



#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: macOS 15.2
- [x] "Node version: v22.14.0
- [x] "Browser: Chrome 136.0.7103.93

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
