### PR TITLE
Fix(tools) don't allow passive tools to edit annotations

### DIFF
--- a/packages/tools/src/store/filterMoveableAnnotationTools.ts
+++ b/packages/tools/src/store/filterMoveableAnnotationTools.ts
@@ -35,12 +35,11 @@ export default function filterMoveableAnnotationTools(
   const moveableAnnotationTools = [];
 
   ToolAndAnnotations.forEach(({ tool, annotations }) => {
+    if (tool.mode === ToolModes.Passive) {
+      return;
+    }
     for (const annotation of annotations) {
-      if (
-        annotation.isLocked ||
-        !annotation.isVisible ||
-        tool.mode === ToolModes.Passive
-      ) {
+      if (annotation.isLocked || !annotation.isVisible) {
         continue;
       }
 

--- a/packages/tools/src/store/filterMoveableAnnotationTools.ts
+++ b/packages/tools/src/store/filterMoveableAnnotationTools.ts
@@ -4,6 +4,7 @@ import type {
   ToolAnnotationPair,
   ToolAnnotationsPair,
 } from '../types/InternalToolTypes';
+import { ToolModes } from '../enums';
 
 /**
  * Filters an array of tools with annotations, returning the first annotation
@@ -35,7 +36,11 @@ export default function filterMoveableAnnotationTools(
 
   ToolAndAnnotations.forEach(({ tool, annotations }) => {
     for (const annotation of annotations) {
-      if (annotation.isLocked || !annotation.isVisible) {
+      if (
+        annotation.isLocked ||
+        !annotation.isVisible ||
+        tool.mode === ToolModes.Passive
+      ) {
         continue;
       }
 

--- a/packages/tools/src/store/filterToolsWithMoveableHandles.ts
+++ b/packages/tools/src/store/filterToolsWithMoveableHandles.ts
@@ -25,12 +25,11 @@ export default function filterToolsWithMoveableHandles(
   const toolsWithMoveableHandles = [];
 
   ToolAndAnnotations.forEach(({ tool, annotations }) => {
+    if (tool.mode === ToolModes.Passive) {
+      return;
+    }
     for (const annotation of annotations) {
-      if (
-        annotation.isLocked ||
-        !annotation.isVisible ||
-        tool.mode === ToolModes.Passive
-      ) {
+      if (annotation.isLocked || !annotation.isVisible) {
         continue;
       }
 

--- a/packages/tools/src/store/filterToolsWithMoveableHandles.ts
+++ b/packages/tools/src/store/filterToolsWithMoveableHandles.ts
@@ -4,6 +4,7 @@ import type {
   ToolAnnotationsPair,
   ToolsWithMoveableHandles,
 } from '../types/InternalToolTypes';
+import { ToolModes } from '../enums';
 
 /**
  * Filters an array of tools, returning only tools with moveable handles at the mouse location that are not locked
@@ -25,7 +26,11 @@ export default function filterToolsWithMoveableHandles(
 
   ToolAndAnnotations.forEach(({ tool, annotations }) => {
     for (const annotation of annotations) {
-      if (annotation.isLocked || !annotation.isVisible) {
+      if (
+        annotation.isLocked ||
+        !annotation.isVisible ||
+        tool.mode === ToolModes.Passive
+      ) {
         continue;
       }
 


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
Fixes the Issue reported here: https://github.com/cornerstonejs/cornerstone3D/issues/403


### Changes & Results

Before:
When adding contours with any tool or using contour segmentations, there was no mechanism to prevent users from modifying them via mouse interactions.

After:
Passive tools are now excluded from filterMoveableAnnotationTools; if a tool is in passive mode, it will no longer be considered moveable and cannot be modified using mouse events.

### Testing

1. Run the example: `contourRendering`.
2. Navigate to `http://localhost:3000`.
3. **Expected Behavior (Default Tool Mode):**

   * Since the tool mode is not explicitly set to *Active*, it defaults to *Passive*.
   * As a result, contour annotations should **not** be moveable via mouse interactions.
4. **Activate Tool:**

   * Set the `PlanarFreehandROITool` to *Active* mode.
   * Now, the user **should** be able to move the contour annotations as before.




### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)



#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- Mac OS 15.1
- Node v20.19.0
- Edge Version 135.0.3179.98

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
