### PR TITLE
fix: enhance opacity threshold handling and refactor scaling logic

### DIFF
--- a/packages/core/src/utilities/colormap.ts
+++ b/packages/core/src/utilities/colormap.ts
@@ -151,8 +151,15 @@ export function updateThreshold(volumeActor, newThreshold) {
  * @param {number|null} threshold - The absolute threshold value (not normalized)
  */
 function updateOpacityWithThreshold(volumeActor, opacity, threshold) {
-  const transferFunction = volumeActor.getProperty().getRGBTransferFunction(0);
-  const range = transferFunction.getRange();
+  // there is always a voxel manager for each volume actor
+  const meta = volumeActor.getMapper().getInputData().get('voxelManager');
+
+  if (!meta?.voxelManager) {
+    throw new Error(
+      'No voxel manager was found for the volume actor, or you cannot yet update opacity with a threshold using stacked images'
+    );
+  }
+  const range = meta.voxelManager.getRange();
   const ofun = vtkPiecewiseFunction.newInstance();
 
   if (threshold !== null) {


### PR DESCRIPTION
This pull request introduces significant improvements to the handling of scaling and threshold logic in the `colormap` utility and the DICOM image loader. The changes focus on modularizing scaling calculations, improving error handling, and ensuring robust data validation.

### Improvements to scaling logic in DICOM image loader:

* Introduced a new helper function `_calculateScaledMinMax` to centralize and simplify the calculation of scaled minimum and maximum values based on various scaling parameters, such as `rescaleSlope`, `rescaleIntercept`, `suvbw`, and `doseGridScaling`. This reduces code duplication and improves maintainability (`packages/dicomImageLoader/src/decodeImageFrameWorker.js`).

* Replaced inline scaling calculations with calls to `_calculateScaledMinMax` in multiple functions, such as `postProcessDecodedPixels` and `_handlePreScaleSetup`, to ensure consistent scaling logic across the codebase (`packages/dicomImageLoader/src/decodeImageFrameWorker.js`). [[1]](diffhunk://#diff-e6c4ba87a62236b35b170b4ea873880564367ff0ddff2bf0e7761db1f60affaaL89-R97) [[2]](diffhunk://#diff-e6c4ba87a62236b35b170b4ea873880564367ff0ddff2bf0e7761db1f60affaaL139-R146) [[3]](diffhunk://#diff-e6c4ba87a62236b35b170b4ea873880564367ff0ddff2bf0e7761db1f60affaaL243-R252)

### Enhancements to threshold handling in colormap utility:

* Updated the `updateOpacityWithThreshold` function to retrieve the range from a `voxelManager` object instead of directly from the transfer function. Added error handling to ensure a `voxelManager` is present, improving robustness when working with volume actors (`packages/core/src/utilities/colormap.ts`).