### PR TITLE
fix(segmentation): The volume value for a segmentation is 1000 times too large

### DIFF
--- a/packages/tools/src/utilities/segmentation/VolumetricCalculator.ts
+++ b/packages/tools/src/utilities/segmentation/VolumetricCalculator.ts
@@ -88,7 +88,7 @@ function volumetricGetStatistics(
     },
     []
   );
-  const volumeScale = spacing ? spacing[0] * spacing[1] * spacing[2] * 1000 : 1;
+  const volumeScale = spacing ? spacing[0] * spacing[1] * spacing[2] : 1;
 
   stats.volume = {
     value: Array.isArray(stats.count.value)


### PR DESCRIPTION

<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

Pixel spacing is in mm, so there is no need to multiply the volume scale by 1000 for cubic millimeter units.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

Removed the multiplication of the cubic pixel spacing by 1000.
<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

1. Open the following OHIF URL https://viewer-dev.ohif.org/segmentation?StudyInstanceUIDs=1.3.6.1.4.1.32722.99.99.239341353911714368772597187099978969331
2. Navigate to roughly the middle image of the stack.
3. Add a new segmentation.
4. Segment using a 10mm sphere tool and draw/segment a precise as possible 10mm radius sphere. The volume for such a sphere should be about 4/3 * Pi * 10³ = 4188mm³
5. Hover over the segment added and note the volume it should be about 4188mm³. Previous to this change the volume reported in OHIF was about 1000 times this value (see the screen capture below)

![image](https://github.com/user-attachments/assets/c2327c97-25b4-43b0-9fa4-06c4fde00e5a)

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)



#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Windows 11<!--[e.g. Windows 10, macOS 10.15.4]"-->
- [x] "Node version: 21.1.0<!--[e.g. 16.14.0]"-->
- [x] "Browser: Chrome 136.0.7103.93 
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
