### PR TITLE
fix: fallback for colormap not known

### DIFF
--- a/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
@@ -1142,7 +1142,7 @@ abstract class BaseVolumeViewport extends Viewport {
       return acc;
     }, []);
 
-    const matchedColormap = findMatchingColormap(RGBPoints, volumeActor);
+    const matchedColormap = findMatchingColormap(RGBPoints, volumeActor) || {};
 
     const threshold = getThresholdValue(volumeActor);
     const opacity = getMaxOpacity(volumeActor);


### PR DESCRIPTION
This pull request includes a minor update to the `BaseVolumeViewport` class in the `RenderingEngine` module. The change ensures that `findMatchingColormap` returns an empty object (`{}`) as a fallback when no matching colormap is found.

* [`packages/core/src/RenderingEngine/BaseVolumeViewport.ts`](diffhunk://#diff-d8f8b6f60e39bf30c7ddecc31bda70056c63091aad137431809e7cf16eadd3b9L1145-R1145): Updated the `matchedColormap` assignment to include a fallback value of `{}` if `findMatchingColormap` returns `undefined` or `null`.