### PR TITLE
Add simplified spline configuration

### DIFF
--- a/packages/tools/src/enums/Events.ts
+++ b/packages/tools/src/enums/Events.ts
@@ -105,6 +105,12 @@ enum Events {
   ANNOTATION_RENDERED = 'CORNERSTONE_TOOLS_ANNOTATION_RENDERED',
 
   /**
+   * Triggers on the eventTarget when an annotation cut merge process is completed.
+   * It starts when the users releases the mouse button in contour segmentation annotations
+   */
+  ANNOTATION_CUT_MERGE_PROCESS_COMPLETED = 'CORNERSTONE_TOOLS_ANNOTATION_CUT_MERGE_PROCESS_COMPLETED',
+
+  /**
    * Triggers on the eventTarget when an annotation interpolation process completed.
    * Make use of {@link EventTypes.AnnotationInterpolationCompletedEventType | Annotation Interpolation process Completed Event Type}
    * for typing your event listeners for this annotation interpolation complete event, and see what

--- a/packages/tools/src/eventListeners/annotations/contourSegmentation/contourSegmentationCompleted.ts
+++ b/packages/tools/src/eventListeners/annotations/contourSegmentation/contourSegmentationCompleted.ts
@@ -1,4 +1,4 @@
-import type { Types } from '@cornerstonejs/core';
+import { eventTarget, triggerEvent, type Types } from '@cornerstonejs/core';
 import type { ContourSegmentationAnnotation } from '../../../types/ContourSegmentationAnnotation';
 import getViewportsForAnnotation from '../../../utilities/getViewportsForAnnotation';
 import { getAllAnnotations } from '../../../stateManagement/annotation/annotationState';
@@ -19,6 +19,7 @@ import {
   createPolylineHole,
   combinePolylines,
 } from '../../../utilities/contourSegmentation/sharedOperations';
+import { Events } from '../../../enums';
 
 /**
  * Default tool name for contour segmentation operations.
@@ -55,6 +56,11 @@ export default async function contourSegmentationCompletedListener(
 
   // If no other relevant contour segmentations exist, there's nothing to combine or make a hole in.
   if (!contourSegmentationAnnotations.length) {
+    // we trigger the event here as here is the place where the source Annotation is not removed
+    triggerEvent(eventTarget, Events.ANNOTATION_CUT_MERGE_PROCESS_COMPLETED, {
+      element: viewport.element,
+      sourceAnnotation,
+    });
     return;
   }
 
@@ -72,6 +78,12 @@ export default async function contourSegmentationCompletedListener(
 
   // If no intersecting contours are found, do nothing.
   if (!intersectingContours.length) {
+    // we trigger the event here as here is the place where the source Annotation is not removed
+    triggerEvent(eventTarget, Events.ANNOTATION_CUT_MERGE_PROCESS_COMPLETED, {
+      element: viewport.element,
+      sourceAnnotation,
+    });
+
     return;
   }
 
@@ -84,6 +96,7 @@ export default async function contourSegmentationCompletedListener(
       sourcePolyline,
       intersectingContours
     );
+
     return;
   }
 

--- a/packages/tools/src/tools/annotation/SplineContourSegmentationTool.ts
+++ b/packages/tools/src/tools/annotation/SplineContourSegmentationTool.ts
@@ -1,9 +1,12 @@
-import { utilities } from '@cornerstonejs/core';
+import { eventTarget, utilities } from '@cornerstonejs/core';
 import type { PublicToolProps } from '../../types';
 import SplineROITool from './SplineROITool';
+import { Events } from '../../enums';
+import { convertContourSegmentationAnnotation } from '../../utilities/contourSegmentation';
 
 class SplineContourSegmentationTool extends SplineROITool {
   static toolName = 'SplineContourSegmentationTool';
+  private annotationCutMergeCompletedBinded;
 
   constructor(toolProps: PublicToolProps) {
     const initialProps = utilities.deepMerge(
@@ -16,11 +19,38 @@ class SplineContourSegmentationTool extends SplineROITool {
     );
 
     super(initialProps);
+    this.annotationCutMergeCompletedBinded =
+      this.annotationCutMergeCompleted.bind(this);
   }
 
   protected isContourSegmentationTool(): boolean {
     // Re-enable contour segmentation behavior disabled by SplineROITool
     return true;
+  }
+
+  protected initializeListeners() {
+    eventTarget.addEventListener(
+      Events.ANNOTATION_CUT_MERGE_PROCESS_COMPLETED,
+      this.annotationCutMergeCompletedBinded
+    );
+  }
+
+  protected removeListeners() {
+    eventTarget.removeEventListener(
+      Events.ANNOTATION_CUT_MERGE_PROCESS_COMPLETED,
+      this.annotationCutMergeCompletedBinded
+    );
+  }
+
+  protected annotationCutMergeCompleted(evt) {
+    const { sourceAnnotation: annotation } = evt.detail;
+    if (
+      !this.splineToolNames.includes(annotation?.metadata?.toolName) ||
+      !this.configuration.simplifiedSpline
+    ) {
+      return;
+    }
+    convertContourSegmentationAnnotation(annotation);
   }
 }
 

--- a/packages/tools/src/tools/annotation/SplineROITool.ts
+++ b/packages/tools/src/tools/annotation/SplineROITool.ts
@@ -84,15 +84,15 @@ enum SplineToolActions {
   DeleteControlPoint = 'deleteControlPoint',
 }
 
-const splineToolNames = [
-  'CatmullRomSplineROI',
-  'LinearSplineROI',
-  'BSplineROI',
-  'CardinalSplineROI',
-];
-
 class SplineROITool extends ContourSegmentationBaseTool {
   static toolName = 'SplineROI';
+  protected splineToolNames = [
+    'CatmullRomSplineROI',
+    'LinearSplineROI',
+    'BSplineROI',
+    'CardinalSplineROI',
+  ];
+
   static SplineTypes = SplineTypesEnum;
   static Actions = SplineToolActions;
   private annotationCompletedBinded;
@@ -123,7 +123,7 @@ class SplineROITool extends ContourSegmentationBaseTool {
       configuration: {
         preventHandleOutsideImage: false,
         calculateStats: true,
-        simplifiedSpline: true, // if true, it will convert the annotations to free hand
+        simplifiedSpline: false, // if true, it will convert the annotations to free hand
         getTextLines: defaultGetTextLines,
         /**
          * Specify which modifier key is used to add a hole to a contour. The
@@ -201,8 +201,9 @@ class SplineROITool extends ContourSegmentationBaseTool {
   protected annotationCompleted(evt) {
     const { sourceAnnotation: annotation } = evt.detail;
     if (
-      !splineToolNames.includes(annotation?.metadata?.toolName) ||
-      !this.configuration.simplifiedSpline
+      !this.splineToolNames.includes(annotation?.metadata?.toolName) ||
+      !this.configuration.simplifiedSpline ||
+      !this.isContourSegmentationTool() // if contour segmentation we need to wait the cut/merge completion
     ) {
       return;
     }
@@ -220,7 +221,7 @@ class SplineROITool extends ContourSegmentationBaseTool {
    */
   protected initializeListeners() {
     eventTarget.addEventListener(
-      Events.ANNOTATION_CUT_MERGE_PROCESS_COMPLETED,
+      Events.ANNOTATION_COMPLETED,
       this.annotationCompletedBinded
     );
   }
@@ -235,7 +236,7 @@ class SplineROITool extends ContourSegmentationBaseTool {
    */
   protected removeListeners() {
     eventTarget.removeEventListener(
-      Events.ANNOTATION_CUT_MERGE_PROCESS_COMPLETED,
+      Events.ANNOTATION_COMPLETED,
       this.annotationCompletedBinded
     );
   }

--- a/packages/tools/src/tools/annotation/SplineROITool.ts
+++ b/packages/tools/src/tools/annotation/SplineROITool.ts
@@ -123,7 +123,7 @@ class SplineROITool extends ContourSegmentationBaseTool {
       configuration: {
         preventHandleOutsideImage: false,
         calculateStats: true,
-        simplifiedSpline: false, // if true, it will convert the annotations to free hand
+        simplifiedSpline: true, // if true, it will convert the annotations to free hand
         getTextLines: defaultGetTextLines,
         /**
          * Specify which modifier key is used to add a hole to a contour. The
@@ -199,7 +199,7 @@ class SplineROITool extends ContourSegmentationBaseTool {
   }
 
   protected annotationCompleted(evt) {
-    const { annotation } = evt.detail;
+    const { sourceAnnotation: annotation } = evt.detail;
     if (
       !splineToolNames.includes(annotation?.metadata?.toolName) ||
       !this.configuration.simplifiedSpline
@@ -220,7 +220,7 @@ class SplineROITool extends ContourSegmentationBaseTool {
    */
   protected initializeListeners() {
     eventTarget.addEventListener(
-      Events.ANNOTATION_COMPLETED,
+      Events.ANNOTATION_CUT_MERGE_PROCESS_COMPLETED,
       this.annotationCompletedBinded
     );
   }
@@ -235,7 +235,7 @@ class SplineROITool extends ContourSegmentationBaseTool {
    */
   protected removeListeners() {
     eventTarget.removeEventListener(
-      Events.ANNOTATION_COMPLETED,
+      Events.ANNOTATION_CUT_MERGE_PROCESS_COMPLETED,
       this.annotationCompletedBinded
     );
   }

--- a/packages/tools/src/utilities/contourSegmentation/convertContourSegmentation.ts
+++ b/packages/tools/src/utilities/contourSegmentation/convertContourSegmentation.ts
@@ -1,0 +1,111 @@
+// Import necessary utilities and types from Cornerstone3D core
+import { utilities } from '@cornerstonejs/core';
+
+// Import state management functions for handling annotations
+import { addAnnotation, removeAnnotation } from '../../stateManagement';
+import type { ContourSegmentationAnnotation } from '../../types';
+import { removeContourSegmentationAnnotation } from './removeContourSegmentationAnnotation';
+import { addContourSegmentationAnnotation } from './addContourSegmentationAnnotation';
+
+// Default tool name used for converted contour segmentation annotations
+const DEFAULT_CONTOUR_SEG_TOOL_NAME = 'PlanarFreehandContourSegmentationTool';
+
+/**
+ * Converts a contour segmentation annotation to a standardized format.
+ * This function takes an existing contour segmentation annotation and transforms it
+ * into a new annotation with updated metadata and structure, ensuring compatibility
+ * with the PlanarFreehandContourSegmentationTool.
+ *
+ * The conversion process involves:
+ * 1. Validating the input annotation's polyline data
+ * 2. Removing the original annotation from the system
+ * 3. Creating a new annotation with standardized properties
+ * 4. Adding the new annotation back to the system
+ *
+ * @param annotation - The original contour segmentation annotation to convert
+ * @returns The newly created converted annotation, or undefined if conversion fails
+ */
+export default function convertContourSegmentationAnnotation(
+  annotation: ContourSegmentationAnnotation
+): ContourSegmentationAnnotation {
+  // Extract the polyline data from the annotation's contour
+  const { polyline } = annotation.data?.contour || {};
+
+  // Validate that the polyline exists and has sufficient points
+  // A valid contour requires at least 3 points to form a meaningful shape
+  if (!polyline || polyline.length < 3) {
+    console.warn(
+      'Skipping creation of new annotation due to invalid polyline:',
+      polyline
+    );
+    return;
+  }
+
+  // Remove the original annotation from both the general annotation system
+  // and the specific contour segmentation system
+  removeAnnotation(annotation.annotationUID);
+  removeContourSegmentationAnnotation(annotation);
+
+  // Extract the start and end points from the polyline for handle creation
+  // These points will be used as the primary handles for the new annotation
+  const startPointWorld = polyline[0];
+  const endPointWorld = polyline[polyline.length - 1];
+
+  // Create a new annotation with standardized structure and properties
+  const newAnnotation: ContourSegmentationAnnotation = {
+    // Update metadata with new tool information while preserving original tool name
+    metadata: {
+      ...annotation.metadata,
+      toolName: DEFAULT_CONTOUR_SEG_TOOL_NAME, // Set to standardized tool name
+      originalToolName:
+        annotation.metadata.originalToolName || annotation.metadata.toolName, // Preserve original tool name
+    },
+    data: {
+      // Reset cached statistics as they may no longer be valid
+      cachedStats: {},
+
+      // Create handles using start and end points of the polyline
+      handles: {
+        points: [startPointWorld, endPointWorld],
+        // Preserve text box if it exists, otherwise set to undefined
+        textBox: annotation.data.handles.textBox
+          ? { ...annotation.data.handles.textBox }
+          : undefined,
+      },
+
+      // Preserve the original contour data
+      contour: {
+        ...annotation.data.contour,
+      },
+
+      // Preserve spline data if it exists
+      spline: annotation.data.spline,
+
+      // Preserve segmentation data
+      segmentation: {
+        ...annotation.data.segmentation,
+      },
+    },
+
+    // Generate a new unique identifier for the converted annotation
+    annotationUID: utilities.uuidv4() as string,
+
+    // Set default states for the new annotation
+    highlighted: true, // Make the annotation highlighted by default
+    invalidated: true, // Mark as invalidated to trigger re-rendering
+    isLocked: false, // Allow editing of the new annotation
+    isVisible: undefined, // Use default visibility settings
+
+    // Preserve interpolation properties if they exist
+    interpolationUID: annotation.interpolationUID,
+    interpolationCompleted: annotation.interpolationCompleted,
+  };
+
+  // Add the new annotation to both the general annotation system
+  // and the specific contour segmentation system
+  addAnnotation(newAnnotation, annotation.metadata.FrameOfReferenceUID);
+  addContourSegmentationAnnotation(newAnnotation);
+
+  // Return the newly created annotation
+  return newAnnotation;
+}

--- a/packages/tools/src/utilities/contourSegmentation/index.ts
+++ b/packages/tools/src/utilities/contourSegmentation/index.ts
@@ -1,4 +1,5 @@
 import areSameSegment from './areSameSegment';
+import convertContourSegmentationAnnotation from './convertContourSegmentation';
 import { addition, subtraction } from './logicalOperators';
 export { default as isContourSegmentationAnnotation } from './isContourSegmentationAnnotation';
 export { addContourSegmentationAnnotation } from './addContourSegmentationAnnotation';
@@ -8,7 +9,12 @@ export { processMultipleIntersections } from './mergeMultipleAnnotations';
 export { contourSegmentationOperation } from './contourSegmentationOperation';
 export * from './sharedOperations';
 
-export { addition, subtraction, areSameSegment };
+export {
+  addition,
+  subtraction,
+  areSameSegment,
+  convertContourSegmentationAnnotation,
+};
 
 export {
   unifyPolylineSets,


### PR DESCRIPTION
This pull request introduces a new feature for handling spline annotations in the `SplineROITool` and adds a utility function to convert contour segmentation annotations to a standardized format. The key changes include adding event listeners for annotation completion, enabling a "simplified spline" mode, and implementing the `convertContourSegmentationAnnotation` utility.

### Enhancements to `SplineROITool`:

* Added a "simplified spline" mode in the tool's configuration. When enabled, it converts spline annotations into freehand contour annotations upon completion. (`[packages/tools/src/tools/annotation/SplineROITool.tsR126](diffhunk://#diff-a6d3d8b5adc48bda00b5cc45ff28a1e19dc3488d87d40798b8b9b7500d93b22dR126)`)
* Introduced event listeners to handle annotation completion events, with methods to initialize and clean up these listeners (`initializeListeners`, `removeListeners`, `onSetToolEnabled`, `onSetToolActive`, `onSetToolDisabled`). (`[packages/tools/src/tools/annotation/SplineROITool.tsR198-R272](diffhunk://#diff-a6d3d8b5adc48bda00b5cc45ff28a1e19dc3488d87d40798b8b9b7500d93b22dR198-R272)`)
* Defined a list of spline tool names (`splineToolNames`) to identify tools eligible for the simplified spline mode. (`[packages/tools/src/tools/annotation/SplineROITool.tsR87-R98](diffhunk://#diff-a6d3d8b5adc48bda00b5cc45ff28a1e19dc3488d87d40798b8b9b7500d93b22dR87-R98)`)

### New utility for contour segmentation:

* Implemented `convertContourSegmentationAnnotation`, a utility to transform contour segmentation annotations into a standardized format compatible with the `PlanarFreehandContourSegmentationTool`. This includes validation, metadata updates, and re-adding annotations to the system. (`[packages/tools/src/utilities/contourSegmentation/convertContourSegmentation.tsR1-R111](diffhunk://#diff-79e1cd796e47092e41454eb5b625dc656bdb93e30f17167062470d3d29d576b8R1-R111)`)
* Exported the `convertContourSegmentationAnnotation` function in the `contourSegmentation` utilities index for broader accessibility. (`[[1]](diffhunk://#diff-bc81ca22b3d03c78efaeb4e2816f38871235e8597c7327b21817ba0ee8f23c7cR2)`, `[[2]](diffhunk://#diff-bc81ca22b3d03c78efaeb4e2816f38871235e8597c7327b21817ba0ee8f23c7cL11-R17)`)

### Codebase improvements:

* Imported `convertContourSegmentationAnnotation` into `SplineROITool` to enable its use during annotation completion. (`[packages/tools/src/tools/annotation/SplineROITool.tsR61](diffhunk://#diff-a6d3d8b5adc48bda00b5cc45ff28a1e19dc3488d87d40798b8b9b7500d93b22dR61)`)