### PR TITLE
fix(dicomImageLoader): use toWindowLevel from core utilities to calculate window level

### DIFF
--- a/packages/dicomImageLoader/src/imageLoader/createImage.ts
+++ b/packages/dicomImageLoader/src/imageLoader/createImage.ts
@@ -357,11 +357,13 @@ function createImage(
           image.windowCenter === undefined ||
           image.windowWidth === undefined
         ) {
-          const minVoi = image.imageFrame.smallestPixelValue;
-          const maxVoi = image.imageFrame.largestPixelValue;
+          const windowLevel = utilities.windowLevel.toWindowLevel(
+            image.imageFrame.smallestPixelValue,
+            image.imageFrame.largestPixelValue
+          );
 
-          image.windowWidth = maxVoi - minVoi;
-          image.windowCenter = (maxVoi + minVoi) / 2;
+          image.windowWidth = windowLevel.windowWidth;
+          image.windowCenter = windowLevel.windowCenter;
         }
         resolve(image);
       }, reject);


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

The code base currently contains multiple ways to calculate the window level from low and high pixel values. In the core utilities there is a helper method `toWindowLevel` which contains a reference to the DICOM standard. I think this method should also be used in`@cornerstonejs/dicom-image-loader`.

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

Use `toWindowLevel` from core utilities to calculate window level in `@cornerstonejs/dicom-image-loader`.

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)



#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
