### PR TITLE
fix(cursor): skip reset when useCursors is disabled

### DIFF
--- a/packages/tools/src/store/ToolGroupManager/ToolGroup.ts
+++ b/packages/tools/src/store/ToolGroupManager/ToolGroup.ts
@@ -224,11 +224,8 @@ export default class ToolGroup {
 
     // Handle the newly added viewport's mouse cursor
     const toolName = this.getActivePrimaryMouseButtonTool();
-
-    const runtimeSettings = Settings.getRuntimeSettings();
-    if (runtimeSettings.get('useCursors')) {
-      this.setViewportsCursorByToolName(toolName);
-    }
+    
+    this.setViewportsCursorByToolName(toolName);
 
     const eventDetail = {
       toolGroupId: this.id,
@@ -400,19 +397,17 @@ export default class ToolGroup {
     this.toolOptions[toolName] = toolOptions;
     this._toolInstances[toolName].mode = Active;
 
-    // reset the mouse cursor if tool has left click binding
-    const runtimeSettings = Settings.getRuntimeSettings();
-    const useCursor = runtimeSettings.get('useCursors');
-
-    if (this._hasMousePrimaryButtonBinding(toolBindingsOptions) && useCursor) {
-      this.setViewportsCursorByToolName(toolName);
-    } else {
+    if (!this._hasMousePrimaryButtonBinding(toolBindingsOptions)) {
       // reset to default cursor only if there is no other tool with primary binding
       const activeToolIdentifier = this.getActivePrimaryMouseButtonTool();
-      if (!activeToolIdentifier && useCursor) {
+      if (!activeToolIdentifier) {
         const cursor = MouseCursor.getDefinedCursor('default');
         this._setCursorForViewports(cursor);
       }
+    }
+    else {
+      // reset the mouse cursor if tool has left click binding
+      this.setViewportsCursorByToolName(toolName);
     }
 
     // if it is a primary tool binding, we should store it as the previous primary tool
@@ -663,6 +658,11 @@ export default class ToolGroup {
   }
 
   _setCursorForViewports(cursor: MouseCursor): void {
+    const runtimeSettings = Settings.getRuntimeSettings();
+    if (!runtimeSettings.get('useCursors')) {
+      return
+    }
+    
     this.viewportsInfo.forEach(({ renderingEngineId, viewportId }) => {
       const enabledElement = getEnabledElementByIds(
         viewportId,


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
This change ensures that all cursor updates respect the global `useCursors` flag by centralizing its check in the viewport cursor setter.
Whenever I pressed any key, it automatically selected the first tool bound to the left mouse button.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

Removed scattered `useCursor` checks and refactored tool activation/deactivation logic so the cursor only updates when useCursor is enabled.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)



#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"--> Windows 11
- [x] "Node version: <!--[e.g. 16.14.0]"--> 22.11.0
- [x] "Browser: Chrome 137.0.3296.83
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
