### PR TITLE
feat: add segmentLabel color

### DIFF
--- a/packages/tools/src/tools/segmentation/SegmentLabelTool.ts
+++ b/packages/tools/src/tools/segmentation/SegmentLabelTool.ts
@@ -16,7 +16,8 @@ import { getActiveSegmentation } from '../../stateManagement/segmentation/active
 import { getSegmentIndexAtWorldPoint } from '../../utilities/segmentation';
 import { state } from '../../store/state';
 import type { Segmentation } from '../../types/SegmentationStateTypes';
-import { drawLinkedTextBox as drawLinkedTextBoxSvg } from '../../drawingSvg';
+import { drawTextBox as drawTextBoxSvg } from '../../drawingSvg';
+import type { Point2 } from 'packages/core/dist/esm/types';
 
 /**
  * Represents a tool used for segment selection. It is used to select a segment
@@ -153,7 +154,6 @@ class SegmentLabelTool extends BaseTool {
       hoveredSegmentIndex,
       hoveredSegmentLabel: label,
       canvasCoordinates,
-      worldPoint,
       color,
     };
 
@@ -184,7 +184,6 @@ class SegmentLabelTool extends BaseTool {
       hoveredSegmentIndex,
       hoveredSegmentLabel,
       canvasCoordinates,
-      worldPoint,
       color,
     } = this._editData;
 
@@ -192,16 +191,18 @@ class SegmentLabelTool extends BaseTool {
       return;
     }
 
-    const textBoxPosition = viewport.worldToCanvas(worldPoint);
+    const offset = -15;
+    const textBoxPosition = [
+      canvasCoordinates[0] + offset,
+      canvasCoordinates[1] + offset,
+    ] as Point2;
 
-    const boundingBox = drawLinkedTextBoxSvg(
+    const boundingBox = drawTextBoxSvg(
       svgDrawingHelper,
       'segmentSelectLabelAnnotation',
       'segmentSelectLabelTextBox',
-      [hoveredSegmentLabel ? hoveredSegmentLabel : '(unnamed segment)'],
+      [hoveredSegmentLabel ?? '(unnamed segment)'],
       textBoxPosition,
-      [canvasCoordinates],
-      {},
       {
         color: `rgba(${color[0]}, ${color[1]}, ${color[2]}, ${color[3]})`,
       }

--- a/packages/tools/src/tools/segmentation/SegmentLabelTool.ts
+++ b/packages/tools/src/tools/segmentation/SegmentLabelTool.ts
@@ -1,6 +1,8 @@
 import { getEnabledElement } from '@cornerstonejs/core';
 import type { Types } from '@cornerstonejs/core';
 
+import { config as segmentationConfig } from '../../stateManagement/segmentation';
+
 import { BaseTool } from '../base';
 import type {
   PublicToolProps,
@@ -140,6 +142,11 @@ class SegmentLabelTool extends BaseTool {
       }
     );
     const segment = activeSegmentation.segments[hoveredSegmentIndex];
+    const color = segmentationConfig.color.getSegmentIndexColor(
+      viewport.id,
+      segmentationId,
+      hoveredSegmentIndex
+    );
     const label = segment?.label;
     const canvasCoordinates = viewport.worldToCanvas(worldPoint);
     this._editData = {
@@ -147,6 +154,7 @@ class SegmentLabelTool extends BaseTool {
       hoveredSegmentLabel: label,
       canvasCoordinates,
       worldPoint,
+      color,
     };
 
     // No need to select background
@@ -177,6 +185,7 @@ class SegmentLabelTool extends BaseTool {
       hoveredSegmentLabel,
       canvasCoordinates,
       worldPoint,
+      color,
     } = this._editData;
 
     if (!hoveredSegmentIndex) {
@@ -193,7 +202,9 @@ class SegmentLabelTool extends BaseTool {
       textBoxPosition,
       [canvasCoordinates],
       {},
-      {}
+      {
+        color: `rgba(${color[0]}, ${color[1]}, ${color[2]}, ${color[3]})`,
+      }
     );
 
     const left = canvasCoordinates[0];


### PR DESCRIPTION
### Context

Using the same segment color with the segmentLabel tool as requested here: https://github.com/OHIF/Viewers/pull/5164#issuecomment-3012979663

Related to https://github.com/OHIF/Viewers/issues/4600

### Changes & Results

![image](https://github.com/user-attachments/assets/4e21f43b-9402-4945-b5e8-e6555b2c6f6d)

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)



#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
