### PR TITLE
fix(WindowLevelTool): adapt voi multiplier based on dynamic range for volume viewports

### DIFF
--- a/packages/tools/src/tools/WindowLevelTool.ts
+++ b/packages/tools/src/tools/WindowLevelTool.ts
@@ -192,9 +192,9 @@ class WindowLevelTool extends BaseTool {
       // Burned in Pixels often use pixel values above the BitsStored.
       // This results in a multiplier which is way higher than what you would
       // want in practice. Thus we take the min between the metadata dynamic
-      // range and actual middle slice dynamic range.
+      // range upper value and actual middle slice dynamic range.
       imageDynamicRange = Math.min(
-        calculatedDynamicRange,
+        calculatedDynamicRange[1] - calculatedDynamicRange[0],
         metadataDynamicRange
       );
     } else {


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->
**Current behavior**
When trying to use the `WindowLevelTool` with NIFTI volumes, I noticed that the behavior is not as expected. Specifically, the window level is adapted very slowly (big mouse drag movements required) when we load 3D volumes with high resolution / dynamic range.

**Expected behavior**
 `WindowLevelTool` can be used similarly for volumes with different dynamic ranges / resolutions. 
Window level can be adapted relatively easily, without needing multiple strokes to change it from min to max value and vice versa.

**How to reproduce** 
[axial.nii.gz](https://github.com/user-attachments/files/21162027/axial.nii.gz)
Load the above file in the `niftiWithTools` example, and change the windowLevel using the `WindowLevelTool` (selected by default).

-> it is really hard to change the window level, see video:
https://github.com/user-attachments/assets/b37d7f58-4ef8-41cf-b230-62ec5fd6f376

**Bug analysis**
We have a bug in the code that prevents us from retrieving the correct VOI multiplier (the value that determines how much our windowWidth and windowCenter will change, based on the image spacing/dynamic range of the image).

Most probably, the bug is here: https://github.com/cornerstonejs/cornerstone3D/blob/edbc6b034314b78cfdfddb812532cf070187db3f/packages/tools/src/tools/WindowLevelTool.ts#L196-L199

-> `calculatedDynamicRange` is an array, which leads to `Math.min` returning ` NaN`, so the [default multiplier](https://github.com/cornerstonejs/cornerstone3D/blob/edbc6b034314b78cfdfddb812532cf070187db3f/packages/tools/src/tools/WindowLevelTool.ts#L11) of `4` is used for all (Nifti) volumes. This means the window level always changes with the same factor, disregarding the volume's dynamic range.

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

**What:**
Change the function to calculate the multiplier properly, incorporating the dynamic range -> WindowLevelTool should behave similarly with different volumes / different dynamic ranges.

**How:**
We simply need to substract the array's values from each other to make sure we actually calculate the dynamic range. 

**Result**
After the above changes, the windowLevel can be changed very easily/smoothly for the above dataset:
https://github.com/user-attachments/assets/4d83d2b9-87a2-4e10-a6c0-c011d6670cc1

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

Load the above file (or any other nifti) in the `niftiWithTools` example, and change the windowLevel using the `WindowLevelTool` (selected by default).

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)



#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: Ubuntu 24 <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: v22.7.0 <!--[e.g. 16.14.0]"-->
- [] "Browser: [Brave 1.80.115 (Official Build) (64-bit)](https://brave.com/latest/)
Chromium: 138.0.7204.97
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
