### PR TITLE
feat(rendering): add render stats

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -84,7 +84,8 @@
     "@kitware/vtk.js": "32.12.1",
     "comlink": "^4.4.1",
     "gl-matrix": "^3.4.3",
-    "loglevel": "^1.9.2"
+    "loglevel": "^1.9.2",
+    "stats.js": "^0.17.0"
   },
   "contributors": [
     {

--- a/packages/core/src/RenderingEngine/BaseRenderingEngine.ts
+++ b/packages/core/src/RenderingEngine/BaseRenderingEngine.ts
@@ -8,7 +8,11 @@ import BaseVolumeViewport from './BaseVolumeViewport';
 import StackViewport from './StackViewport';
 import viewportTypeUsesCustomRenderingPipeline from './helpers/viewportTypeUsesCustomRenderingPipeline';
 import getOrCreateCanvas from './helpers/getOrCreateCanvas';
-import { getShouldUseCPURendering, isCornerstoneInitialized } from '../init';
+import {
+  getShouldUseCPURendering,
+  isCornerstoneInitialized,
+  getConfiguration,
+} from '../init';
 import type IStackViewport from '../types/IStackViewport';
 import type IVolumeViewport from '../types/IVolumeViewport';
 import viewportTypeToViewportClass from './helpers/viewportTypeToViewportClass';
@@ -22,6 +26,7 @@ import type {
 } from '../types/IViewport';
 import { OrientationAxis } from '../enums';
 import type { VtkOffscreenMultiRenderWindow } from '../types';
+import { cleanStatsOverlay, setupStatsOverlay } from './helpers/stats';
 
 // Rendering engines seem to not like rendering things less than 2 pixels per side
 export const VIEWPORT_MIN_SIZE = 2;
@@ -64,6 +69,12 @@ abstract class BaseRenderingEngine {
 
     this._viewports = new Map();
     this.hasBeenDestroyed = false;
+
+    const config = getConfiguration();
+
+    if (config.rendering?.statsOverlay) {
+      setupStatsOverlay();
+    }
   }
 
   /**
@@ -434,6 +445,8 @@ abstract class BaseRenderingEngine {
     if (this.hasBeenDestroyed) {
       return;
     }
+
+    cleanStatsOverlay();
 
     // remove vtk rendered first before resetting the viewport
     if (!this.useCPURendering) {

--- a/packages/core/src/RenderingEngine/helpers/stats.ts
+++ b/packages/core/src/RenderingEngine/helpers/stats.ts
@@ -1,0 +1,58 @@
+import Stats from 'stats.js';
+
+let statsInstance;
+let statsAnimationFrameId;
+
+const loop = () => {
+  if (statsInstance) {
+    statsInstance.update();
+    statsAnimationFrameId = requestAnimationFrame(loop);
+  }
+};
+
+/**
+ * Sets up the stats overlay for debugging purposes.
+ * Creates a Stats.js instance and positions it in the top-right corner of the page.
+ */
+const setupStatsOverlay = () => {
+  if (statsInstance) {
+    return;
+  }
+
+  try {
+    statsInstance = new Stats();
+
+    statsInstance.showPanel(0);
+
+    const statsElement = statsInstance.dom;
+    statsElement.style.position = 'fixed';
+    statsElement.style.top = '0px';
+    statsElement.style.right = '0px';
+    statsElement.style.left = 'auto';
+    statsElement.style.zIndex = '9999';
+
+    document.body.appendChild(statsElement);
+
+    statsAnimationFrameId = requestAnimationFrame(loop);
+  } catch (error) {
+    console.warn('Failed to setup stats overlay:', error);
+  }
+};
+
+/**
+ * Cleans up the stats overlay by removing it from the DOM.
+ * Should be called when the application is closed or when stats are no longer needed.
+ */
+const cleanStatsOverlay = () => {
+  if (statsAnimationFrameId) {
+    cancelAnimationFrame(statsAnimationFrameId);
+    statsAnimationFrameId = null;
+  }
+
+  if (statsInstance && statsInstance.dom && statsInstance.dom.parentNode) {
+    statsInstance.dom.parentNode.removeChild(statsInstance.dom);
+    statsInstance = null;
+  }
+};
+
+export { setupStatsOverlay, cleanStatsOverlay };

--- a/packages/core/src/init.ts
+++ b/packages/core/src/init.ts
@@ -27,6 +27,14 @@ const defaultConfig: Cornerstone3DConfig = {
      * The default value is 7, which is suitable for mobile/desktop.
      */
     webGlContextCount: 7,
+
+    /**
+     * Wether or not to show the stats overlay for debugging purposes, stats include:
+     * - FPS Frames rendered in the last second. The higher the number the better.
+     * - MS Milliseconds needed to render a frame. The lower the number the better.
+     * - MB MBytes of allocated memory. (Run Chrome with --enable-precise-memory-info)
+     */
+    statsOverlay: false,
   },
 
   /**

--- a/packages/core/src/types/Cornerstone3DConfig.ts
+++ b/packages/core/src/types/Cornerstone3DConfig.ts
@@ -45,6 +45,14 @@ interface Cornerstone3DConfig {
      * The default value is 7, which is suitable for mobile/desktop.
      */
     webGlContextCount?: number;
+
+    /**
+     * Wether or not to show the stats overlay for debugging purposes, stats include:
+     * - FPS Frames rendered in the last second. The higher the number the better.
+     * - MS Milliseconds needed to render a frame. The lower the number the better.
+     * - MB MBytes of allocated memory. (Run Chrome with --enable-precise-memory-info)
+     */
+    statsOverlay?: boolean;
   };
 
   /**

--- a/utils/demo/helpers/initDemo.ts
+++ b/utils/demo/helpers/initDemo.ts
@@ -20,13 +20,25 @@ import * as polySeg from '@cornerstonejs/polymorphic-segmentation';
 window.cornerstone = cornerstone;
 window.cornerstoneTools = cornerstoneTools;
 
-export default async function initDemo(config = {}) {
+export default async function initDemo(config: any = {}) {
   initProviders();
   cornerstoneDICOMImageLoader.init();
   initVolumeLoader();
   await csRenderInit({
     peerImport,
-    ...(config?.core ? config.core : {}),
+    ...(config?.core
+      ? {
+          ...config.core,
+          rendering: {
+            ...config.core.rendering,
+            statsOverlay: true,
+          },
+        }
+      : {
+          rendering: {
+            statsOverlay: true,
+          },
+        }),
   });
   await csToolsInit({
     addons: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2472,7 +2472,7 @@
     rw "^1.3.3"
     sort-object "^0.3.2"
 
-"@mapbox/node-pre-gyp@^1.0.5":
+"@mapbox/node-pre-gyp@^1.0.0", "@mapbox/node-pre-gyp@^1.0.5":
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz#417db42b7f5323d79e93b34a6d7a2a12c0df43fa"
   integrity sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==
@@ -6300,7 +6300,16 @@ caniuse-lite@^1.0.30001700:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001701.tgz#ad9c90301f7153cf6b3314d16cc30757285bf9e7"
   integrity sha512-faRs/AW3jA9nTwmJBSO1PQ6L/EOgsB5HMQQq4iCu5zhPgVVgO/pZRHlmatwijZKetFw8/Pr4q6dEN8sJuq8qTw==
 
-canvas@2.11.2, canvas@3.1.0, canvas@^3.1.0:
+canvas@2.11.2:
+  version "2.11.2"
+  resolved "https://registry.yarnpkg.com/canvas/-/canvas-2.11.2.tgz#553d87b1e0228c7ac0fc72887c3adbac4abbd860"
+  integrity sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==
+  dependencies:
+    "@mapbox/node-pre-gyp" "^1.0.0"
+    nan "^2.17.0"
+    simple-get "^3.0.3"
+
+canvas@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/canvas/-/canvas-3.1.0.tgz#6cdf094b859fef8e39b0e2c386728a376f1727b2"
   integrity sha512-tTj3CqqukVJ9NgSahykNwtGda7V33VLObwrHfzT0vqJXu7J4d4C/7kQQW3fOEGDfZZoILPut5H00gOjyttPGyg==
@@ -7691,6 +7700,13 @@ decimal.js@^10.4.2, decimal.js@^10.4.3:
   version "10.4.3"
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.3.tgz#1044092884d245d1b7f65725fa4ad4c6f781cc23"
   integrity sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==
+
+decompress-response@^4.2.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-4.2.1.tgz#414023cc7a302da25ce2ec82d0d5238ccafd8986"
+  integrity sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==
+  dependencies:
+    mimic-response "^2.0.0"
 
 decompress-response@^6.0.0:
   version "6.0.0"
@@ -13680,6 +13696,11 @@ mimic-function@^5.0.0:
   resolved "https://registry.yarnpkg.com/mimic-function/-/mimic-function-5.0.1.tgz#acbe2b3349f99b9deaca7fb70e48b83e94e67076"
   integrity sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==
 
+mimic-response@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.1.0.tgz#d13763d35f613d09ec37ebb30bac0469c0ee8f43"
+  integrity sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
+
 mimic-response@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
@@ -14012,6 +14033,11 @@ nan@^2.16.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.20.0.tgz#08c5ea813dd54ed16e5bd6505bf42af4f7838ca3"
   integrity sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw==
+
+nan@^2.17.0:
+  version "2.23.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.23.0.tgz#24aa4ddffcc37613a2d2935b97683c1ec96093c6"
+  integrity sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==
 
 nanoid@^3.3.7:
   version "3.3.8"
@@ -17591,6 +17617,15 @@ simple-concat@^1.0.0:
   resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
   integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
 
+simple-get@^3.0.3:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-3.1.1.tgz#cc7ba77cfbe761036fbfce3d021af25fc5584d55"
+  integrity sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==
+  dependencies:
+    decompress-response "^4.2.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
+
 simple-get@^4.0.0, simple-get@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-4.0.1.tgz#4a39db549287c979d352112fa03fd99fd6bc3543"
@@ -17971,6 +18006,11 @@ stackframe@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.3.4.tgz#b881a004c8c149a5e8efef37d51b16e412943310"
   integrity sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==
+
+stats.js@^0.17.0:
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/stats.js/-/stats.js-0.17.0.tgz#b1c3dc46d94498b578b7fd3985b81ace7131cc7d"
+  integrity sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==
 
 statuses@2.0.1:
   version "2.0.1"


### PR DESCRIPTION
### Context

This adds render stats like the ones used in the WebGPU examples https://webgpu.github.io/webgpu-samples/?sample=renderBundles

The library for stats: https://github.com/mrdoob/stats.js

<img width="2922" height="1740" alt="CleanShot 2025-07-13 at 15 18 09@2x" src="https://github.com/user-attachments/assets/b629082e-1d59-4362-be34-b52a3e914e6b" />
