### PR TITLE
fix(colormap): do not return empty opacity arrays

### DIFF
--- a/packages/core/src/utilities/colormap.ts
+++ b/packages/core/src/utilities/colormap.ts
@@ -100,14 +100,12 @@ function findMatchingColormap(rgbPoints, actor): ColormapPublic | null {
     }
   }
 
-  return opacity.length > 0
-    ? {
-        name: matchedColormap.Name,
-        opacity,
-      }
-    : {
-        name: matchedColormap.Name,
-      };
+  const result = {
+    name: matchedColormap.Name,
+    ...(opacity.length > 0 && { opacity }),
+  };
+
+  return result;
 }
 
 export function setColorMapTransferFunctionForVolumeActor(volumeInfo) {

--- a/packages/core/src/utilities/colormap.ts
+++ b/packages/core/src/utilities/colormap.ts
@@ -100,10 +100,14 @@ function findMatchingColormap(rgbPoints, actor): ColormapPublic | null {
     }
   }
 
-  return {
-    name: matchedColormap.Name,
-    opacity,
-  };
+  return opacity.length > 0
+    ? {
+        name: matchedColormap.Name,
+        opacity,
+      }
+    : {
+        name: matchedColormap.Name,
+      };
 }
 
 export function setColorMapTransferFunctionForVolumeActor(volumeInfo) {


### PR DESCRIPTION
### context

prevents the returning of empty opacity arrays to not cause rendering issues