### PR TITLE
fix(monochrome1): images were being inverted incorrectly

### DIFF
--- a/packages/dicomImageLoader/src/imageLoader/createImage.ts
+++ b/packages/dicomImageLoader/src/imageLoader/createImage.ts
@@ -249,6 +249,7 @@ function createImage(
           slope: modalityLutModule.rescaleSlope
             ? modalityLutModule.rescaleSlope
             : 1,
+          // Note: We set invert flag but actual inversion should happen after VOI/windowing
           invert: imageFrame.photometricInterpretation === 'MONOCHROME1',
           minPixelValue: imageFrame.smallestPixelValue,
           maxPixelValue: imageFrame.largestPixelValue,


### PR DESCRIPTION
### Context
We inverted MONOCHROME1 during VOI/window building. DICOM says the minimum sample value must appear white **AFTER** VOI grayscale transforms. Doing it early caused incorrect polarity on some 16‑bit CR images and double inversion. Our pipeline now does the following: Pixel → Modality LUT → VOI (WC/WW or LUT) → then MONOCHROME1 inversion (by swap low/high output mapping in the final transfer function). Added helper applyInversionToTransferFunction; simplified setVOIGPU & setInvertColorGPU.

### Why its correct

https://dicom.innolitics.com/ciods/rt-dose/image-pixel/00280004

MONOCHROME1
Pixel data represent a single monochrome image plane. The minimum sample value is intended to be displayed as white **AFTER any VOI gray scale transformations have been performed.** See [PS3.4](http://dicom.nema.org/medical/dicom/current/output/html/part04.html#PS3.4). This value may be used only when Samples per Pixel (0028,0002) has a value of 1. May be used for pixel data in a Native (uncompressed) or Encapsulated (compressed) format; see [Section 8.2 in PS3.5 ](http://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_8.2.html#sect_8.2).


https://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_c.7.6.3.html

MONOCHROME1
Pixel data represent a single monochrome image plane. The minimum sample value is intended to be displayed as white **AFTER any VOI gray scale transformations have been performed**. See [PS3.4](https://dicom.nema.org/medical/dicom/current/output/chtml/part04/PS3.4.html). This Value may be used only when Samples per Pixel (0028,0002) has a Value of 1. May be used for pixel data in a Native (uncompressed) or Encapsulated (compressed) format; see [Section 8.2 in PS3.5 ](https://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_8.2.html).