### PR TITLE
fix(viewport): viewport should take full canvas size by default

### DIFF
--- a/packages/core/src/RenderingEngine/Viewport.ts
+++ b/packages/core/src/RenderingEngine/Viewport.ts
@@ -98,7 +98,7 @@ class Viewport {
   /**
    * The amount by which the images are inset in a viewport by default.
    */
-  protected insetImageMultiplier = 1.1;
+  protected insetImageMultiplier = 1;
 
   protected flipHorizontal = false;
   protected flipVertical = false;
@@ -1112,8 +1112,22 @@ class Viewport {
       imageData.indexToWorld(idx, focalPoint);
     }
 
-    const { widthWorld, heightWorld } =
-      this._getWorldDistanceViewUpAndViewRight(bounds, viewUp, viewPlaneNormal);
+    let widthWorld;
+    let heightWorld;
+
+    if (imageData) {
+      const extent = imageData.getExtent();
+      const spacing = imageData.getSpacing();
+
+      widthWorld = (extent[1] - extent[0]) * spacing[0];
+      heightWorld = (extent[3] - extent[2]) * spacing[1];
+    } else {
+      ({ widthWorld, heightWorld } = this._getWorldDistanceViewUpAndViewRight(
+        bounds,
+        viewUp,
+        viewPlaneNormal
+      ));
+    }
 
     const canvasSize = [this.sWidth, this.sHeight];
 


### PR DESCRIPTION
### Context

Viewports were not taking the full canvas size


Before:

<img width="1190" height="1196" alt="CleanShot 2025-07-24 at 15 27 46@2x" src="https://github.com/user-attachments/assets/522be0a6-9bf0-4437-a6d7-35b406226b09" />

After:

<img width="996" height="988" alt="CleanShot 2025-07-24 at 15 28 24@2x" src="https://github.com/user-attachments/assets/d8340aa1-1c0d-462f-a41d-c482ca0172a9" />

