### PR TITLE
fix: add missing call to update spheres on on receive event from control tool

### DIFF
--- a/packages/tools/src/tools/VolumeCroppingTool.ts
+++ b/packages/tools/src/tools/VolumeCroppingTool.ts
@@ -842,6 +842,7 @@ class VolumeCroppingTool extends BaseTool {
           }
         }
       }
+      this._updateCornerSpheres();
       viewport.render();
     }
   };


### PR DESCRIPTION

### Context

The spheres are not moving when the control tool ( reference line) is moved because an update command was deleted by mistake.


### Changes & Results

add missing line

### Testing

Reference lines change the sphere and cropping planes,  not just the cropping planes.

