### PR TITLE
fix: first segment active 

### DIFF
--- a/packages/tools/src/stateManagement/segmentation/internalAddSegmentationRepresentation.ts
+++ b/packages/tools/src/stateManagement/segmentation/internalAddSegmentationRepresentation.ts
@@ -29,9 +29,18 @@ function internalAddSegmentationRepresentation(
     renderingConfig
   );
 
-  // If no active segment index is set, default to segment 1
+  // If no active segment index is set, default to the first segment
   if (!getActiveSegmentIndex(segmentationId)) {
-    setActiveSegmentIndex(segmentationId, 1); // defaults to segment 1
+    const segmentation =
+      defaultSegmentationStateManager.getSegmentation(segmentationId);
+
+    if (segmentation) {
+      const segmentKeys = Object.keys(segmentation.segments);
+      if (segmentKeys.length > 0) {
+        const firstSegmentIndex = segmentKeys.map((k) => Number(k)).sort()[0];
+        setActiveSegmentIndex(segmentationId, firstSegmentIndex);
+      }
+    }
   }
 
   if (representationInput.type === SegmentationRepresentations.Contour) {


### PR DESCRIPTION
This pull request updates the logic for setting the default active segment index in the `internalAddSegmentationRepresentation` function to ensure it dynamically selects the first segment based on the segmentation's data.

### Improvements to default active segment logic:
* [`packages/tools/src/stateManagement/segmentation/internalAddSegmentationRepresentation.ts`](diffhunk://#diff-0153ff619168e4074ab0f409b96ef7c6cf50c3adb1f838c51d54b688c3378273L32-R43): Updated the logic to dynamically determine the first segment index by retrieving and sorting segment keys, ensuring the default is set correctly even if segments are not numbered sequentially.