### PR TITLE
fix: Adapter issues

### DIFF
--- a/packages/adapters/src/adapters/Cornerstone3D/Angle.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/Angle.ts
@@ -43,7 +43,7 @@ class Angle extends BaseAdapter3D {
             ...state.annotation.data,
             handles: {
                 ...state.annotation.data.handles,
-                points: worldCoords
+                points: [worldCoords[0], worldCoords[1], worldCoords[3]]
             },
             cachedStats,
             frameNumber: ReferencedFrameNumber

--- a/packages/adapters/src/adapters/Cornerstone3D/Probe.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/Probe.ts
@@ -43,7 +43,8 @@ class Probe extends BaseAdapter3D {
         const cachedStats = referencedImageId
             ? {
                   [`imageId:${referencedImageId}`]: {
-                      length: NUMGroup?.MeasuredValueSequence?.NumericValue || 0
+                      value:
+                          NUMGroup?.MeasuredValueSequence?.NumericValue ?? null
                   }
               }
             : {};
@@ -54,7 +55,8 @@ class Probe extends BaseAdapter3D {
                 points: worldCoords
             },
             cachedStats,
-            frameNumber: ReferencedFrameNumber
+            frameNumber: ReferencedFrameNumber,
+            invalidated: true
         };
 
         return state;

--- a/packages/adapters/src/adapters/Cornerstone3D/RectangleROI.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/RectangleROI.ts
@@ -20,8 +20,6 @@ export class RectangleROI extends BaseAdapter3D {
         const {
             state,
             NUMGroup,
-            scoord,
-            scoordArgs,
             worldCoords,
             referencedImageId,
             ReferencedFrameNumber
@@ -32,12 +30,20 @@ export class RectangleROI extends BaseAdapter3D {
             this.toolType
         );
 
+        const areaGroup = MeasurementGroup.ContentSequence.find(
+            g =>
+                g.ValueType === "NUM" &&
+                g.ConceptNameCodeSequence[0].CodeMeaning === "Area"
+        );
         const cachedStats = referencedImageId
             ? {
                   [`imageId:${referencedImageId}`]: {
-                      area: NUMGroup
-                          ? NUMGroup.MeasuredValueSequence.NumericValue
-                          : 0
+                      area:
+                          areaGroup?.MeasuredValueSequence?.[0]?.NumericValue ||
+                          0,
+                      areaUnit:
+                          areaGroup?.MeasuredValueSequence?.[0]
+                              ?.MeasurementUnitsCodeSequence?.CodeValue
                   }
               }
             : {};
@@ -45,7 +51,12 @@ export class RectangleROI extends BaseAdapter3D {
             ...state.annotation.data,
             handles: {
                 ...state.annotation.data.handles,
-                points: worldCoords
+                points: [
+                    worldCoords[0],
+                    worldCoords[1],
+                    worldCoords[3],
+                    worldCoords[2]
+                ]
             },
             cachedStats,
             frameNumber: ReferencedFrameNumber

--- a/packages/tools/src/tools/annotation/ProbeTool.ts
+++ b/packages/tools/src/tools/annotation/ProbeTool.ts
@@ -658,6 +658,7 @@ class ProbeTool extends AnnotationTool {
           Modality: modality,
           modalityUnit,
         };
+        annotation.invalidated = true;
       } else {
         this.isHandleOutsideImage = true;
         cachedStats[targetId] = {


### PR DESCRIPTION
### Context

There are a number of small save/load issues when cs3d adapters are used with OHIF.
RectangleROI - area was not restored
     - display area was incorrect after restore, even thought actual saved area was correct
 Angle - needs both lines
Probe - needs to be updateable after restore and have a "value" text (this is NOT stored/restored at this point due to limitations in dcmjs.   This could be added later if desired)
ProbeTOol - would never update the value in OHIF, only the one in display.

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

Link in SCoord3d PR in OHIF (need to link core, tools and adapters)
Save/load rectangles, probe and angles

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)



#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
