### PR TITLE
fix: Ensure FOR is stored when required and cachedStats created

### DIFF
--- a/packages/adapters/.gitignore
+++ b/packages/adapters/.gitignore
@@ -1,4 +1,7 @@
+# Ignore the version.js because it is generated
+src/version.ts
 
+# Misc items
 *.sw*
 *~
 

--- a/packages/adapters/src/adapters/Cornerstone/MeasurementReport.js
+++ b/packages/adapters/src/adapters/Cornerstone/MeasurementReport.js
@@ -34,6 +34,9 @@ const codeValueMatch = (group, code, oldCode) => {
 function getTID300ContentItem(tool, ReferencedSOPSequence, adapterClass) {
     const args = adapterClass.getTID300RepresentationArguments(tool);
     args.ReferencedSOPSequence = ReferencedSOPSequence;
+    args.ReferencedFrameOfReferenceUID = args.use3DSpatialCoordinates
+        ? tool.metadata.FrameOfReferenceUID
+        : null;
 
     const tid300Measurement = new adapterClass.TID300Representation(args);
 

--- a/packages/adapters/src/adapters/Cornerstone3D/Length.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/Length.ts
@@ -80,9 +80,6 @@ export default class Length extends BaseAdapter3D {
             trackingIdentifierTextValue: this.trackingIdentifierTextValue,
             finding,
             findingSites: findingSites || [],
-            ReferencedFrameOfReferenceUID: is3DMeasurement
-                ? metadata.FrameOfReferenceUID
-                : null,
             use3DSpatialCoordinates: is3DMeasurement
         };
     }

--- a/packages/adapters/src/adapters/Cornerstone3D/MeasurementReport.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/MeasurementReport.ts
@@ -185,6 +185,10 @@ export default class MeasurementReport {
             is3DMeasurement
         );
         args.ReferencedSOPSequence = ReferencedSOPSequence;
+        if (args.use3DSpatialCoordinates) {
+            args.ReferencedFrameOfReferenceUID =
+                tool.metadata.FrameOfReferenceUID;
+        }
 
         const tid300Measurement = new toolClass.TID300Representation(args);
         const labelMeasurement = new LabelData(tid300Measurement, tool);
@@ -328,6 +332,7 @@ export default class MeasurementReport {
                 annotation: {
                     data: {
                         annotationUID,
+                        cachedStats: {},
                         handles: {
                             activeHandleIndex: 0,
                             textBox: {
@@ -361,6 +366,7 @@ export default class MeasurementReport {
                     annotationUID,
                     data: {
                         annotationUID,
+                        cachedStats: {},
                         handles: {
                             activeHandleIndex: 0,
                             textBox: {

--- a/packages/adapters/src/adapters/Cornerstone3D/RectangleROI.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/RectangleROI.ts
@@ -17,18 +17,13 @@ export class RectangleROI extends BaseAdapter3D {
         sopInstanceUIDToImageIdMap,
         metadata
     ) {
-        const {
-            state,
-            NUMGroup,
-            worldCoords,
-            referencedImageId,
-            ReferencedFrameNumber
-        } = MeasurementReport.getSetupMeasurementData(
-            MeasurementGroup,
-            sopInstanceUIDToImageIdMap,
-            metadata,
-            this.toolType
-        );
+        const { state, worldCoords, referencedImageId, ReferencedFrameNumber } =
+            MeasurementReport.getSetupMeasurementData(
+                MeasurementGroup,
+                sopInstanceUIDToImageIdMap,
+                metadata,
+                this.toolType
+            );
 
         const areaGroup = MeasurementGroup.ContentSequence.find(
             g =>

--- a/packages/adapters/src/version.ts
+++ b/packages/adapters/src/version.ts
@@ -1,5 +1,0 @@
-/**
- * Auto-generated from version.json
- * Do not modify this file directly
- */
-export const version = "3.32.3";


### PR DESCRIPTION
### Context

Some of the annotation adapters weren't storing referenced frame of reference uid, nor were they creating cached stats.
Add both items automatically when appropriate.

### Changes & Results

Add Ref FOR for 3d measurements
Add cached stats always

### Testing

Link into OHIF and save 3d annotations.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)



#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
