### PR TITLE
feat: Enhance orientation and position extraction from DICOM datasets…

### DIFF
--- a/packages/dicomImageLoader/src/imageLoader/wadouri/metaData/extractPositioningFromDataset.ts
+++ b/packages/dicomImageLoader/src/imageLoader/wadouri/metaData/extractPositioningFromDataset.ts
@@ -104,15 +104,22 @@ function extractOrientationFromDataset(dataSet) {
   // If orientation not valid to this point, trying to get the orientation from
   // Per-frame Functional Groups Sequence (5200,9230). This is commonly used
   // in enhanced multiframe DICOMs. Only the first frame is considered.
-  if (!imageOrientationPatient && dataSet.elements.x52009230 && dataSet.elements.x52009230.items?.length > 0) {
+  if (
+    !imageOrientationPatient &&
+    dataSet.elements.x52009230 &&
+    dataSet.elements.x52009230.items?.length > 0
+  ) {
     const frame0 = dataSet.elements.x52009230.items[0].dataSet;
     const planeOrientationSeq = frame0.elements?.x00209116?.items?.[0]?.dataSet;
 
     if (planeOrientationSeq) {
-      imageOrientationPatient = getNumberValues(planeOrientationSeq, 'x00200037', 6);
+      imageOrientationPatient = getNumberValues(
+        planeOrientationSeq,
+        'x00200037',
+        6
+      );
     }
   }
-
 
   return imageOrientationPatient;
 }


### PR DESCRIPTION
… using Per-frame Functional Groups Sequence

<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

This PR addresses the issue of missing ImageOrientationPatient, ImagePositionPatient, and PixelSpacing in enhanced multiframe DICOM datasets (e.g., CT/MR) where these values are not present at the top level of the dataset.

When loading volumes from multiframe images, cornerstone failed to extract required spatial metadata, leading to errors such as:

`ImageOrientationPatient is undefined`

This happened because the current implementation only supports:

-  Top-level attributes
-  Some NM-specific structures

Enhanced DICOM datasets often store these values inside the Per-frame Functional Groups Sequence (5200,9230) or Shared Functional Groups Sequence (5200,9229), which were not considered until now.

### Changes & Results

Added fallbacks as last resort in:
- extractOrientationFromDataset() to read from Per-frame Functional Groups Sequence → Plane Orientation Sequence
- extractPositionFromDataset() to read from Per-frame Functional Groups Sequence → Plane Position Sequence
- extractSpacingFromDataset() to read from Shared Functional Groups Sequence → Pixel Measures Sequence

These fallbacks are only triggered when no value is found in standard locations, preserving existing logic and behavior for non-enhanced DICOMs.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)



#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Windows 11
- [x] "Node version: v24.4.1
- [x] "Browser: Firefox 141.0, Chrome 138.0.7204.184

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
