### PR TITLE
getBrushToolInstances always return array

### DIFF
--- a/packages/tools/src/utilities/segmentation/getBrushToolInstances.ts
+++ b/packages/tools/src/utilities/segmentation/getBrushToolInstances.ts
@@ -5,13 +5,13 @@ export function getBrushToolInstances(toolGroupId: string, toolName?: string) {
   const toolGroup = getToolGroup(toolGroupId);
 
   if (toolGroup === undefined) {
-    return;
+    return [];
   }
 
   const toolInstances = toolGroup._toolInstances;
 
   if (!Object.keys(toolInstances).length) {
-    return;
+    return [];
   }
 
   if (toolName && toolInstances[toolName]) {


### PR DESCRIPTION
### Context

Picked up a bug where getBrushToolInstances was returning undefined when calling code was expecting array without null safe operators,
Now getBrushToolInstances always return array (empty array if no brush tool instances)

### Changes & Results
getBrushToolInstances always return array making array prototype (map, foreach) calls on return value safe

### Testing



### Checklist

#### PR




#### Code



#### Public Documentation Updates


#### Tested Environment


