### PR TITLE
feat: Make jump to click can update multiple target tool groups

### DIFF
--- a/packages/tools/examples/mipJumpToClick/index.ts
+++ b/packages/tools/examples/mipJumpToClick/index.ts
@@ -83,16 +83,22 @@ async function run() {
   await initDemo();
 
   const mipToolGroupUID = 'MIP_TOOL_GROUP_UID';
+  const ctToolGroupUID = 'CT_TOOL_GROUP_UID';
+  const ptToolGroupUID = 'PT_TOOL_GROUP_UID';
 
   // Add tools to Cornerstone3D
   cornerstoneTools.addTool(StackScrollTool);
   cornerstoneTools.addTool(MIPJumpToClickTool);
   cornerstoneTools.addTool(VolumeRotateTool);
   const mipToolGroup = ToolGroupManager.createToolGroup(mipToolGroupUID);
+  const ctToolGroup = ToolGroupManager.createToolGroup(ctToolGroupUID);
+  const ptToolGroup = ToolGroupManager.createToolGroup(ptToolGroupUID);
 
   mipToolGroup.addTool(VolumeRotateTool.toolName);
   mipToolGroup.addTool(MIPJumpToClickTool.toolName, {
     targetViewportIds: [viewportIds[0], viewportIds[1]],
+    //Same using toolGroups
+    //toolGroupIds: [ctToolGroup.id, ptToolGroup.id],
   });
 
   // Set the initial state of the tools, here we set one tool active on left click.
@@ -179,6 +185,8 @@ async function run() {
   renderingEngine.setViewports(viewportInputArray);
 
   // Set the tool group on the viewports
+  ctToolGroup.addViewport(viewportIds[0], renderingEngineId);
+  ptToolGroup.addViewport(viewportIds[1], renderingEngineId);
   mipToolGroup.addViewport(viewportIds[2], renderingEngineId);
 
   // Define volumes in memory

--- a/packages/tools/src/tools/MIPJumpToClickTool.ts
+++ b/packages/tools/src/tools/MIPJumpToClickTool.ts
@@ -20,6 +20,8 @@ class MIPJumpToClickTool extends BaseTool {
       supportedInteractionTypes: ['Mouse', 'Touch'],
       configuration: {
         targetViewportIds: [],
+        toolGroupId: undefined,
+        toolGroupIds: [],
       },
     }
   ) {
@@ -75,7 +77,7 @@ class MIPJumpToClickTool extends BaseTool {
       return;
     }
 
-    const { targetViewportIds, toolGroupId } = this.configuration;
+    const { targetViewportIds, toolGroupId, toolGroupIds } = this.configuration;
     // TODO - consider making this a utility
     const viewports = renderingEngine.getViewports().filter((vp) => {
       if (targetViewportIds?.indexOf(vp.id) >= 0) {
@@ -83,6 +85,11 @@ class MIPJumpToClickTool extends BaseTool {
       }
       const foundToolGroup = getToolGroupForViewport(vp.id, renderingEngine.id);
       if (toolGroupId && toolGroupId === foundToolGroup?.id) {
+        return true;
+      } else if (
+        toolGroupIds.length > 0 &&
+        toolGroupIds.includes(foundToolGroup?.id)
+      ) {
         return true;
       }
       return false;


### PR DESCRIPTION
### Context

Until now JumpToClick was accepting only one toolgroup.
The problem is depending on stage you might have multiple viewport with multiple toolgroup non being instanciated in all stages.
This PR add the possibility to add a toolgroupId array to make JumpToClick act on multiple toolgroups

### Changes & Results

Add toolGroupIds configuration which expect array of tool group Id

### Testing

See mipJumpToClick example, add a commented toolGroupIds that does the same than viewport selection but using toolgroups

### Checklist

#### PR

#### Code


#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

Linux, chrome latest, node 20
