### PR TITLE
Fix: Segments not removed when ROI deleted after SEG load with ≥2 segments on same slice

### DIFF
--- a/packages/adapters/src/adapters/Cornerstone3D/Segmentation/labelmapImagesFromBuffer.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/Segmentation/labelmapImagesFromBuffer.ts
@@ -370,6 +370,7 @@ export function insertPixelDataPlanar({
                 const imageIdIndex = imageIdMaps.indices[imageId];
                 const labelmapImage = labelMapImages[imageIdIndex];
                 const labelmap2DView = labelmapImage.getPixelData();
+                const imageVoxelManager = labelmapImage.voxelManager;
 
                 const data = alignedPixelDataI.data;
 
@@ -400,7 +401,16 @@ export function insertPixelDataPlanar({
                                         })
                                     );
                                 }
-                                labelmap2DView[x] = segmentIndex;
+                                if (imageVoxelManager) {
+                                    // Ensure voxelManager updates boundaries
+                                    imageVoxelManager.setAtIndex(
+                                        x,
+                                        segmentIndex
+                                    );
+                                } else {
+                                    // Directly assign pixel data when volume is not managed via voxelManager.
+                                    labelmap2DView[x] = segmentIndex;
+                                }
                                 indexCache.push(x);
                             }
                         }


### PR DESCRIPTION
… user deletes the ROI after loading a SEG file if at least 2 segments drawn in the same slice

<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->
Fix for https://github.com/OHIF/Viewers/issues/5290
When a SEG file with ≥2 segments on the same slice is loaded, deleting the ROI doesn’t remove the segments from the viewport.

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

- Updated voxelManager bounds during initial SEG file load.

- Segments now correctly disappear after ROI deletion.

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->
 - Open viewer with data: [link](https://viewer-dev.ohif.org/segmentation?StudyInstanceUIDs=1.3.6.1.4.1.14519.5.2.1.256467663913010332776401703474716742458)
 - Load SEG data into the viewport.
 - From the segmentation panel, delete one segment.
 - Delete another segment drawn on the same slice as the first.
 - Verify that both segments are removed from the viewport.
### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"--> Windows 10
- [] "Node version: <!--[e.g. 16.14.0]"-->  v22.11.0
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"--> Chrome 

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
