### PR TITLE
priority prefetch

### DIFF
--- a/packages/tools/src/utilities/stackPrefetch/stackContextPrefetch.ts
+++ b/packages/tools/src/utilities/stackPrefetch/stackContextPrefetch.ts
@@ -11,7 +11,6 @@ import { addToolState, getToolState, type StackPrefetchData } from './state';
 import {
   getStackData,
   requestType,
-  priority,
   clearFromImageIds,
   getPromiseRemovedHandler,
 } from './stackPrefetchUtils';
@@ -62,8 +61,11 @@ const resetPrefetchDelay = 5;
  *     * Up to 100 images in the direction of travel will be prefetched
  *
  * @param element - to prefetch on
+ * @param priority - priority to be used for the request manager
  */
-const enable = (element): void => {
+const enable = (element, priority = 0): void => {
+  console.log(`CornerstoneTools.stackPrefetch - ${priority}`);
+
   const stack = getStackData(element);
   if (!stack) {
     return;
@@ -75,7 +77,7 @@ const enable = (element): void => {
 
   updateToolState(element);
 
-  prefetch(element);
+  prefetch(element, priority);
 
   element.removeEventListener(Enums.Events.STACK_NEW_IMAGE, onImageUpdated);
   element.addEventListener(Enums.Events.STACK_NEW_IMAGE, onImageUpdated);
@@ -92,7 +94,7 @@ const enable = (element): void => {
   );
 };
 
-function prefetch(element) {
+function prefetch(element, priority = 0) {
   const stack = getStackData(element);
   if (!stack) {
     return;
@@ -194,7 +196,7 @@ function prefetch(element) {
           stats.initialTime = Date.now() - stats.start;
           stats.initialSize = stats.imageIds.size;
           updateToolState(element, usage);
-          prefetch(element);
+          prefetch(element, priority);
         } else if (stats.imageIds.size) {
           stats.fillTime = Date.now() - stats.start;
           const { size } = stats.imageIds;
@@ -268,7 +270,7 @@ function onImageUpdated(e) {
     // An exception will be thrown because the element will not be enabled anymore
     try {
       updateToolState(element);
-      prefetch(element);
+      prefetch(element, 0);
     } catch (error) {
       return;
     }

--- a/packages/tools/src/utilities/stackPrefetch/stackContextPrefetch.ts
+++ b/packages/tools/src/utilities/stackPrefetch/stackContextPrefetch.ts
@@ -66,8 +66,6 @@ const priorities = {};
  * @param priority - priority to be used for the request manager
  */
 const enable = (element, priority = 0): void => {
-  console.log(`CornerstoneTools.stackPrefetch - ${priority}`);
-
   const stack = getStackData(element);
   if (!stack) {
     return;

--- a/packages/tools/src/utilities/stackPrefetch/stackContextPrefetch.ts
+++ b/packages/tools/src/utilities/stackPrefetch/stackContextPrefetch.ts
@@ -32,6 +32,8 @@ let resetPrefetchTimeout;
 // loaded, so a 5 ms prefetch delay is fine
 const resetPrefetchDelay = 5;
 
+const priorities = {};
+
 /**
  * Call this to enable stack context sensitive prefetch.  Should be called
  * before stack data is set in order to start prefetch after load first image.
@@ -76,6 +78,8 @@ const enable = (element, priority = 0): void => {
   }
 
   updateToolState(element);
+
+  priorities[element] = priority;
 
   prefetch(element, priority);
 
@@ -270,7 +274,7 @@ function onImageUpdated(e) {
     // An exception will be thrown because the element will not be enabled anymore
     try {
       updateToolState(element);
-      prefetch(element, 0);
+      prefetch(element, priorities[element]);
     } catch (error) {
       return;
     }


### PR DESCRIPTION
Currently `0` is used for the image loader when prefetching for stack images. I added `priority` as a parameter to `enable` method. `0` will be used by default when omitting that parameter so it will not break others.