### PR TITLE
Feat/3D rendering settings

### DIFF
--- a/packages/core/examples/volumeViewport3D/index.ts
+++ b/packages/core/examples/volumeViewport3D/index.ts
@@ -60,7 +60,8 @@ viewportGrid.appendChild(element1);
 content.appendChild(viewportGrid);
 
 const instructions = document.createElement('p');
-instructions.innerText = 'Click the image to rotate it.';
+instructions.innerText =
+  'Click the image to rotate it.  Select the preset and sampling distance from the drop downs';
 
 content.append(instructions);
 

--- a/packages/core/examples/volumeViewport3D/index.ts
+++ b/packages/core/examples/volumeViewport3D/index.ts
@@ -92,6 +92,17 @@ addDropdownToToolbar({
   },
 });
 
+addDropdownToToolbar({
+  options: {
+    values: Array.from({ length: 16 }, (_, i) => i + 1), // [1, 2, ..., 16]
+    defaultValue: 1,
+  },
+  onSelectedValueChange: (sampleDistanceMultiplier) => {
+    viewport.setProperties({ sampleDistanceMultiplier });
+    viewport.render();
+  },
+});
+
 // ============================= //
 
 let viewport;

--- a/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
@@ -1119,11 +1119,6 @@ abstract class BaseVolumeViewport extends Viewport {
     if (properties.preset !== undefined) {
       this.setPreset(properties.preset, volumeId, false);
     }
-
-    if (properties.preset !== undefined) {
-      this.setPreset(properties.preset, volumeId, false);
-    }
-
     this.render();
   }
 

--- a/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
@@ -143,10 +143,6 @@ abstract class BaseVolumeViewport extends Viewport {
     return false;
   }
 
-  public updateRenderingPipeline = () => {
-    this._configureRenderingPipeline();
-  };
-
   public getSliceViewInfo(): {
     width: number;
     height: number;

--- a/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
@@ -1129,11 +1129,7 @@ abstract class BaseVolumeViewport extends Viewport {
     }
   }
 
-  public setSampleDistanceMultiplier(multiplier: number): void {
-    console.debug(
-      `Setting sample distance multiplier in BaseVolumeViewport: ${multiplier}`
-    );
-  }
+  public setSampleDistanceMultiplier(multiplier: number): void {}
 
   /**
    * Retrieve the viewport default properties

--- a/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
@@ -143,6 +143,10 @@ abstract class BaseVolumeViewport extends Viewport {
     return false;
   }
 
+  public updateRenderingPipeline = () => {
+    this._configureRenderingPipeline();
+  };
+
   public getSliceViewInfo(): {
     width: number;
     height: number;

--- a/packages/core/src/RenderingEngine/VolumeViewport3D.ts
+++ b/packages/core/src/RenderingEngine/VolumeViewport3D.ts
@@ -36,9 +36,6 @@ class VolumeViewport3D extends BaseVolumeViewport {
   }
 
   public setSampleDistanceMultiplier = (multiplier: number): void => {
-    console.debug(
-      `Setting sample distance multiplier in volumeviewport3d: ${multiplier}`
-    );
     const actors = this.getActors();
     actors.forEach((actorEntry) => {
       if (actorIsA(actorEntry, 'vtkVolume')) {
@@ -64,7 +61,6 @@ class VolumeViewport3D extends BaseVolumeViewport {
               const currentSampleDistance = mapper.getSampleDistance();
               mapper.setSampleDistance(sampleDistance);
             }
-            console.debug(`New sample distance set: ${sampleDistance}`);
           }
         }
       }

--- a/packages/core/src/RenderingEngine/VolumeViewport3D.ts
+++ b/packages/core/src/RenderingEngine/VolumeViewport3D.ts
@@ -4,13 +4,13 @@ import { OrientationAxis, Events } from '../enums';
 import cache from '../cache/cache';
 import setDefaultVolumeVOI from './helpers/setDefaultVolumeVOI';
 import triggerEvent from '../utilities/triggerEvent';
-import { isImageActor } from '../utilities/actorCheck';
+import { actorIsA, isImageActor } from '../utilities/actorCheck';
 import { setTransferFunctionNodes } from '../utilities/transferFunctionUtils';
 import type vtkVolume from '@kitware/vtk.js/Rendering/Core/Volume';
 import type { ViewportInput } from '../types/IViewport';
 import type { ImageActor } from '../types/IActor';
 import BaseVolumeViewport from './BaseVolumeViewport';
-
+import type { Types } from '@cornerstonejs/core';
 /**
  * An object representing a 3-dimensional volume viewport. VolumeViewport3Ds are used to render
  * 3D volumes in their entirety, and not just load a single slice at a time.
@@ -34,6 +34,44 @@ class VolumeViewport3D extends BaseVolumeViewport {
       this.applyViewOrientation(orientation);
     }
   }
+
+  public setSampleDistanceMultiplier = (multiplier: number): void => {
+    console.debug(
+      `Setting sample distance multiplier in volumeviewport3d: ${multiplier}`
+    );
+    const actors = this.getActors();
+    actors.forEach((actorEntry) => {
+      if (actorIsA(actorEntry, 'vtkVolume')) {
+        const actor = actorEntry.actor as Types.VolumeActor;
+        const mapper = actor.getMapper();
+
+        if (mapper && mapper.getInputData) {
+          const imageData = mapper.getInputData();
+
+          if (imageData) {
+            const spacing = imageData.getSpacing();
+
+            //Calculate sample distance
+            const defaultSampleDistance =
+              (spacing[0] + spacing[1] + spacing[2]) / 6;
+
+            const sampleDistanceMultiplier = multiplier || 1;
+            let sampleDistance =
+              defaultSampleDistance * sampleDistanceMultiplier;
+
+            // Apply sample distance if specified
+            if (sampleDistance !== undefined && mapper.setSampleDistance) {
+              const currentSampleDistance = mapper.getSampleDistance();
+              mapper.setSampleDistance(sampleDistance);
+            }
+            console.debug(`New sample distance set: ${sampleDistance}`);
+          }
+        }
+      }
+    });
+
+    this.render();
+  };
 
   public getNumberOfSlices = (): number => {
     return 1;

--- a/packages/core/src/RenderingEngine/helpers/createVolumeMapper.ts
+++ b/packages/core/src/RenderingEngine/helpers/createVolumeMapper.ts
@@ -35,7 +35,6 @@ export default function createVolumeMapper(
   const volumeRenderingConfig =
     getConfiguration().rendering?.volumeRendering || {};
   if (volumeRenderingConfig.sampleDistanceMultiplier !== undefined) {
-    console.debug('Updated sampling quality:', volumeRenderingConfig);
     sampleDistance =
       sampleDistance * volumeRenderingConfig.sampleDistanceMultiplier;
   }

--- a/packages/core/src/RenderingEngine/helpers/createVolumeMapper.ts
+++ b/packages/core/src/RenderingEngine/helpers/createVolumeMapper.ts
@@ -4,7 +4,6 @@ import type vtkImageData from '@kitware/vtk.js/Common/DataModel/ImageData';
 import type vtkOpenGLTexture from '@kitware/vtk.js/Rendering/OpenGL/Texture';
 import vtkVolumeMapper from '@kitware/vtk.js/Rendering/Core/VolumeMapper';
 import vtkDataArray from '@kitware/vtk.js/Common/Core/DataArray';
-import { get } from 'http';
 
 /**
  * Given an imageData and a vtkOpenGLTexture, it creates a "shared" vtk volume mapper

--- a/packages/core/src/RenderingEngine/helpers/createVolumeMapper.ts
+++ b/packages/core/src/RenderingEngine/helpers/createVolumeMapper.ts
@@ -30,14 +30,11 @@ export default function createVolumeMapper(
   const spacing = imageData.getSpacing();
   // Set the sample distance to half the mean length of one side. This is where the divide by 6 comes from.
   // https://github.com/Kitware/VTK/blob/6b559c65bb90614fb02eb6d1b9e3f0fca3fe4b0b/Rendering/VolumeOpenGL2/vtkSmartVolumeMapper.cxx#L344
-  let sampleDistance = (spacing[0] + spacing[1] + spacing[2]) / 6;
-
   const sampleDistanceMultiplier =
     getConfiguration().rendering?.volumeRendering?.sampleDistanceMultiplier ||
     1;
-  if (sampleDistanceMultiplier !== undefined) {
-    sampleDistance = sampleDistance * sampleDistanceMultiplier;
-  }
+  const sampleDistance =
+    (sampleDistanceMultiplier * (spacing[0] + spacing[1] + spacing[2])) / 6;
 
   // This is to allow for good pixel level image quality.
   // Todo: why we are setting this to 4000? Is this a good number? it should be configurable

--- a/packages/core/src/RenderingEngine/helpers/createVolumeMapper.ts
+++ b/packages/core/src/RenderingEngine/helpers/createVolumeMapper.ts
@@ -32,11 +32,11 @@ export default function createVolumeMapper(
   // https://github.com/Kitware/VTK/blob/6b559c65bb90614fb02eb6d1b9e3f0fca3fe4b0b/Rendering/VolumeOpenGL2/vtkSmartVolumeMapper.cxx#L344
   let sampleDistance = (spacing[0] + spacing[1] + spacing[2]) / 6;
 
-  const volumeRenderingConfig =
-    getConfiguration().rendering?.volumeRendering || {};
-  if (volumeRenderingConfig.sampleDistanceMultiplier !== undefined) {
-    sampleDistance =
-      sampleDistance * volumeRenderingConfig.sampleDistanceMultiplier;
+  const sampleDistanceMultiplier =
+    getConfiguration().rendering?.volumeRendering?.sampleDistanceMultiplier ||
+    1;
+  if (sampleDistanceMultiplier !== undefined) {
+    sampleDistance = sampleDistance * sampleDistanceMultiplier;
   }
 
   // This is to allow for good pixel level image quality.

--- a/packages/core/src/RenderingEngine/helpers/createVolumeMapper.ts
+++ b/packages/core/src/RenderingEngine/helpers/createVolumeMapper.ts
@@ -4,6 +4,7 @@ import type vtkImageData from '@kitware/vtk.js/Common/DataModel/ImageData';
 import type vtkOpenGLTexture from '@kitware/vtk.js/Rendering/OpenGL/Texture';
 import vtkVolumeMapper from '@kitware/vtk.js/Rendering/Core/VolumeMapper';
 import vtkDataArray from '@kitware/vtk.js/Common/Core/DataArray';
+import { get } from 'http';
 
 /**
  * Given an imageData and a vtkOpenGLTexture, it creates a "shared" vtk volume mapper
@@ -30,7 +31,15 @@ export default function createVolumeMapper(
   const spacing = imageData.getSpacing();
   // Set the sample distance to half the mean length of one side. This is where the divide by 6 comes from.
   // https://github.com/Kitware/VTK/blob/6b559c65bb90614fb02eb6d1b9e3f0fca3fe4b0b/Rendering/VolumeOpenGL2/vtkSmartVolumeMapper.cxx#L344
-  const sampleDistance = (spacing[0] + spacing[1] + spacing[2]) / 6;
+  let sampleDistance = (spacing[0] + spacing[1] + spacing[2]) / 6;
+
+  const volumeRenderingConfig =
+    getConfiguration().rendering?.volumeRendering || {};
+  if (volumeRenderingConfig.sampleDistanceMultiplier !== undefined) {
+    console.debug('Updated sampling quality:', volumeRenderingConfig);
+    sampleDistance =
+      sampleDistance * volumeRenderingConfig.sampleDistanceMultiplier;
+  }
 
   // This is to allow for good pixel level image quality.
   // Todo: why we are setting this to 4000? Is this a good number? it should be configurable

--- a/packages/core/src/init.ts
+++ b/packages/core/src/init.ts
@@ -27,6 +27,10 @@ const defaultConfig: Cornerstone3DConfig = {
      * The default value is 7, which is suitable for mobile/desktop.
      */
     webGlContextCount: 7,
+    volumeRendering: {
+      /** Multiplier for the calculated sample distance */
+      sampleDistanceMultiplier: 1,
+    },
   },
 
   debug: {

--- a/packages/core/src/types/Cornerstone3DConfig.ts
+++ b/packages/core/src/types/Cornerstone3DConfig.ts
@@ -45,6 +45,10 @@ interface Cornerstone3DConfig {
      * The default value is 7, which is suitable for mobile/desktop.
      */
     webGlContextCount?: number;
+    volumeRendering?: {
+      /** Multiplier for the calculated sample distance */
+      sampleDistanceMultiplier?: number;
+    };
   };
 
   debug: {

--- a/packages/core/src/types/ViewportProperties.ts
+++ b/packages/core/src/types/ViewportProperties.ts
@@ -18,4 +18,6 @@ export interface ViewportProperties {
   interpolationType?: InterpolationType;
 
   preset?: string;
+
+  sampleDistanceMultiplier?: number;
 }


### PR DESCRIPTION
### Context

Ticket: 9756584582.

Adding sample distance multiplier to Cornerstone3D configuration.
This is used for VRT rendering.
The sample distance multiplier decreases the size of the volume when it is created. 
The other VRT  settings (opacity,shade,ect)  modify the properties of the existing volume.


### Changes & Results
Added the sampleDistanceMultiplier setting to config files.
Updated createvolumeviewport and basevolumeviewport to handle the new setting.

### Testing

Change sample distance (sampleDistanceMultiplier: 1) from 1 to 8 and notice lower GPU load and  lower resolution.

