### PR TITLE
add tests for circle and rectangle start stop

### DIFF
--- a/packages/tools/test/CircleROIStartEnd_test.js
+++ b/packages/tools/test/CircleROIStartEnd_test.js
@@ -1,0 +1,208 @@
+import * as cornerstone3D from '@cornerstonejs/core';
+import * as csTools3d from '../src/index';
+import * as testUtils from '../../../utils/test/testUtils';
+
+const {
+  cache,
+  RenderingEngine,
+  Enums,
+  utilities,
+  imageLoader,
+  metaData,
+  eventTarget,
+  volumeLoader,
+  setVolumesForViewports,
+  getEnabledElement,
+} = cornerstone3D;
+
+const { Events, ViewportType } = Enums;
+const { registerVolumeLoader, createAndCacheVolume } = volumeLoader;
+
+const {
+  CircleROIStartEndThresholdTool,
+  ToolGroupManager,
+  cancelActiveManipulations,
+  annotation,
+  Enums: csToolsEnums,
+} = csTools3d;
+
+const { Events: csToolsEvents } = csToolsEnums;
+
+const {
+  fakeImageLoader,
+  fakeVolumeLoader,
+  fakeMetaDataProvider,
+  createNormalizedMouseEvent,
+} = testUtils;
+
+const renderingEngineId = utilities.uuidv4();
+
+const viewportId = 'VIEWPORT';
+
+const AXIAL = 'AXIAL';
+
+const volumeId = testUtils.encodeVolumeIdInfo({
+  loader: 'fakeVolumeLoader',
+  name: 'volumeURI',
+  rows: 100,
+  columns: 100,
+  slices: 4,
+  xSpacing: 1,
+  ySpacing: 1,
+  zSpacing: 1,
+});
+
+describe('Circle Start End Tool: ', () => {
+  let renderingEngine;
+  let toolGroup;
+
+  beforeEach(function () {
+    const testEnv = testUtils.setupTestEnvironment({
+      renderingEngineId,
+      toolGroupIds: ['volume'],
+      viewportIds: [viewportId],
+      tools: [CircleROIStartEndThresholdTool],
+      toolConfigurations: {
+        [CircleROIStartEndThresholdTool.toolName]: {
+          configuration: { volumeId: volumeId },
+        },
+      },
+      toolActivations: {
+        [CircleROIStartEndThresholdTool.toolName]: {
+          bindings: [{ mouseButton: 1 }],
+        },
+      },
+    });
+    renderingEngine = testEnv.renderingEngine;
+    toolGroup = testEnv.toolGroups['volume'];
+  });
+
+  afterEach(function () {
+    testUtils.cleanupTestEnvironment({
+      renderingEngineId: renderingEngineId,
+      toolGroupIds: ['volume'],
+      cleanupDOMElements: true,
+    });
+  });
+
+  it('Should successfully create a circle start end tool on a canvas with mouse drag - 512 x 128', function (done) {
+    const element = testUtils.createViewports(renderingEngine, {
+      viewportId,
+      viewportType: ViewportType.ORTHOGRAPHIC,
+      width: 512,
+      height: 128,
+    });
+
+    const volumeId = testUtils.encodeVolumeIdInfo({
+      loader: 'fakeVolumeLoader',
+      name: 'volumeURI',
+      rows: 100,
+      columns: 100,
+      slices: 10,
+      xSpacing: 1,
+      ySpacing: 1,
+      zSpacing: 1,
+    });
+
+    const vp = renderingEngine.getViewport(viewportId);
+
+    const addEventListenerForAnnotationRendered = () => {
+      element.addEventListener(csToolsEvents.ANNOTATION_RENDERED, () => {
+        const circleAnnotations = annotation.state.getAnnotations(
+          CircleROIStartEndThresholdTool.toolName,
+          element
+        );
+        expect(circleAnnotations).toBeDefined();
+        expect(circleAnnotations.length).toBe(1);
+
+        const circleAnnotation = circleAnnotations[0];
+        //expect(circleAnnotation.metadata.referencedImageId).toBe(imageId1);
+        expect(circleAnnotation.metadata.toolName).toBe(
+          CircleROIStartEndThresholdTool.toolName
+        );
+        expect(circleAnnotation.invalidated).toBe(false);
+
+        const data = circleAnnotation.data.cachedStats;
+        const targets = Array.from(Object.keys(data));
+        expect(targets.length).toBe(3);
+        expect(data.pointsInVolume).toBeInstanceOf(Array);
+
+        // the rectangle is drawn on the strip
+        expect(data.statistics.mean).toBeCloseTo(28.33);
+
+        annotation.state.removeAnnotation(circleAnnotation.annotationUID);
+        done();
+      });
+    };
+
+    element.addEventListener(Events.IMAGE_RENDERED, () => {
+      // Since circle draws from center to out, we are picking a very center
+      // point in the image  (strip is 255 from 10-15 in X and from 0-64 in Y)
+      const index1 = [12, 30, 0];
+      const index2 = [14, 30, 0];
+
+      if (!vp.getImageData()) {
+        return;
+      }
+
+      const { imageData } = vp.getImageData();
+
+      const {
+        pageX: pageX1,
+        pageY: pageY1,
+        clientX: clientX1,
+        clientY: clientY1,
+        worldCoord: worldCoord1,
+      } = testUtils.createNormalizedMouseEvent(imageData, index1, element, vp);
+
+      const {
+        pageX: pageX2,
+        pageY: pageY2,
+        clientX: clientX2,
+        clientY: clientY2,
+        worldCoord: worldCoord2,
+      } = testUtils.createNormalizedMouseEvent(imageData, index2, element, vp);
+
+      // Mouse Down
+      let evt = new MouseEvent('mousedown', {
+        target: element,
+        buttons: 1,
+        clientX: clientX1,
+        clientY: clientY1,
+        pageX: pageX1,
+        pageY: pageY1,
+      });
+      element.dispatchEvent(evt);
+
+      // Mouse move to put the end somewhere else
+      evt = new MouseEvent('mousemove', {
+        target: element,
+        buttons: 1,
+        clientX: clientX2,
+        clientY: clientY2,
+        pageX: pageX2,
+        pageY: pageY2,
+      });
+      document.dispatchEvent(evt);
+
+      // Mouse Up instantly after
+      evt = new MouseEvent('mouseup');
+
+      addEventListenerForAnnotationRendered();
+      document.dispatchEvent(evt);
+    });
+
+    try {
+      createAndCacheVolume(volumeId, { imageIds: [] }).then(() => {
+        setVolumesForViewports(
+          renderingEngine,
+          [{ volumeId: volumeId }],
+          [viewportId]
+        );
+        vp.render();
+      });
+    } catch (e) {
+      done.fail(e);
+    }
+  });
+});

--- a/packages/tools/test/RectangleROIStartEnd_test.js
+++ b/packages/tools/test/RectangleROIStartEnd_test.js
@@ -1,0 +1,191 @@
+import * as cornerstone3D from '@cornerstonejs/core';
+import * as csTools3d from '../src/index';
+import * as testUtils from '../../../utils/test/testUtils';
+import { performMouseDownAndUp } from '../../../utils/test/testUtilsMouseEvents';
+import {
+  encodeImageIdInfo,
+  createViewports,
+} from '../../../utils/test/testUtils';
+
+const {
+  cache,
+  RenderingEngine,
+  Enums,
+  utilities,
+  imageLoader,
+  eventTarget,
+  metaData,
+  volumeLoader,
+  setVolumesForViewports,
+} = cornerstone3D;
+
+const { Events, ViewportType } = Enums;
+
+const {
+  RectangleROIStartEndThresholdTool,
+  ToolGroupManager,
+  Enums: csToolsEnums,
+  cancelActiveManipulations,
+  annotation,
+} = csTools3d;
+
+const { Events: csToolsEvents } = csToolsEnums;
+
+const {
+  fakeImageLoader,
+  fakeVolumeLoader,
+  fakeMetaDataProvider,
+  createNormalizedMouseEvent,
+} = testUtils;
+
+const renderingEngineId = utilities.uuidv4();
+
+const viewportId = 'VIEWPORT';
+
+const volumeId = testUtils.encodeVolumeIdInfo({
+  loader: 'fakeVolumeLoader',
+  name: 'volumeURI',
+  rows: 100,
+  columns: 100,
+  slices: 4,
+  xSpacing: 1,
+  ySpacing: 1,
+});
+
+fdescribe('Rectangle ROI StartEnd Tool:', () => {
+  let testEnv;
+  let renderingEngine;
+
+  beforeAll(() => {
+    cornerstone3D.setUseCPURendering(false);
+  });
+
+  beforeEach(function () {
+    testEnv = testUtils.setupTestEnvironment({
+      renderingEngineId: renderingEngineId,
+      toolGroupIds: ['volume'],
+      tools: [RectangleROIStartEndThresholdTool],
+      toolActivations: {
+        [RectangleROIStartEndThresholdTool.toolName]: {
+          bindings: [{ mouseButton: 1 }],
+        },
+      },
+      viewportIds: [viewportId],
+    });
+
+    renderingEngine = testEnv.renderingEngine;
+  });
+
+  afterEach(function () {
+    testUtils.cleanupTestEnvironment({
+      renderingEngineId: renderingEngineId,
+      toolGroupIds: ['volume'],
+      cleanupDOMElements: true,
+    });
+  });
+
+  it('Should successfully create a rectangle tool on a canvas with mouse drag in a Volume viewport - 512 x 128', function (done) {
+    const element = createViewports(renderingEngine, {
+      viewportType: ViewportType.ORTHOGRAPHIC,
+      width: 512,
+      height: 128,
+      viewportId: viewportId,
+    });
+
+    const vp = renderingEngine.getViewport(viewportId);
+
+    const addEventListenerForAnnotationRendered = () => {
+      element.addEventListener(csToolsEvents.ANNOTATION_RENDERED, () => {
+        const rectangleAnnotations = annotation.state.getAnnotations(
+          RectangleROIStartEndThresholdTool.toolName,
+          element
+        );
+        // Can successfully add rectangleROI to annotationManager
+        expect(rectangleAnnotations).toBeDefined();
+        expect(rectangleAnnotations.length).toBe(1);
+
+        const rectangleAnnotation = rectangleAnnotations[0];
+        expect(rectangleAnnotation.metadata.toolName).toBe(
+          RectangleROIStartEndThresholdTool.toolName
+        );
+        expect(rectangleAnnotation.invalidated).toBe(false);
+
+        const data = rectangleAnnotation.data.cachedStats;
+        const targets = Array.from(Object.keys(data));
+        expect(targets.length).toBe(4);
+        expect(data.statistics.mean).toBe(85);
+        expect(data.statistics.stdDev).toBeCloseTo(120.208);
+
+        annotation.state.removeAnnotation(rectangleAnnotation.annotationUID);
+        done();
+      });
+    };
+
+    element.addEventListener(Events.IMAGE_RENDERED, () => {
+      // Inside the strip which is from 50-75 in slice 2
+      // volumeURI_100_100_4_1_1_1_0
+      // The strip is from
+      const index1 = [50, 10, 2];
+      const index2 = [52, 20, 2];
+
+      const { imageData } = vp.getImageData();
+
+      const {
+        pageX: pageX1,
+        pageY: pageY1,
+        clientX: clientX1,
+        clientY: clientY1,
+        worldCoord: worldCoord1,
+      } = createNormalizedMouseEvent(imageData, index1, element, vp);
+
+      const {
+        pageX: pageX2,
+        pageY: pageY2,
+        clientX: clientX2,
+        clientY: clientY2,
+        worldCoord: worldCoord2,
+      } = createNormalizedMouseEvent(imageData, index2, element, vp);
+
+      // Mouse Down
+      let evt = new MouseEvent('mousedown', {
+        target: element,
+        buttons: 1,
+        clientX: clientX1,
+        clientY: clientY1,
+        pageX: pageX1,
+        pageY: pageY1,
+      });
+      element.dispatchEvent(evt);
+
+      // Mouse move to put the end somewhere else
+      evt = new MouseEvent('mousemove', {
+        target: element,
+        buttons: 1,
+        clientX: clientX2,
+        clientY: clientY2,
+        pageX: pageX2,
+        pageY: pageY2,
+      });
+      document.dispatchEvent(evt);
+
+      // Mouse Up instantly after
+      evt = new MouseEvent('mouseup');
+
+      addEventListenerForAnnotationRendered();
+      document.dispatchEvent(evt);
+    });
+
+    try {
+      volumeLoader.createAndCacheVolume(volumeId, { imageIds: [] }).then(() => {
+        setVolumesForViewports(
+          renderingEngine,
+          [{ volumeId: volumeId }],
+          [viewportId]
+        );
+        vp.render();
+      });
+    } catch (e) {
+      done.fail(e);
+    }
+  });
+});

--- a/packages/tools/test/RectangleROIStartEnd_test.js
+++ b/packages/tools/test/RectangleROIStartEnd_test.js
@@ -52,7 +52,7 @@ const volumeId = testUtils.encodeVolumeIdInfo({
   ySpacing: 1,
 });
 
-fdescribe('Rectangle ROI StartEnd Tool:', () => {
+describe('Rectangle ROI StartEnd Tool:', () => {
   let testEnv;
   let renderingEngine;
 


### PR DESCRIPTION
As discussed at office hour, I add a simple test to at least check those tools are not broken by changes,

Would need to make more extensive tests to tests manipulation of start and end slices (missing time to do it)

Thus PR https://github.com/cornerstonejs/cornerstone3D/pull/2254 and https://github.com/cornerstonejs/cornerstone3D/pull/2221 shall not break these tests