### PR TITLE
fix(dicom-loader): Correctly merge shared and per-frame functional groups for wadouri imageLoader

### DIFF
--- a/packages/dicomImageLoader/src/imageLoader/wadouri/combineFrameInstanceDataset.ts
+++ b/packages/dicomImageLoader/src/imageLoader/wadouri/combineFrameInstanceDataset.ts
@@ -81,6 +81,54 @@ function getMultiframeInformation(dataSet) {
   };
 }
 
+/**
+ * Recursively merges DICOM element objects. It gives precedence to per-frame elements,
+ * but for nested sequences (SQ), it merges their contents instead of replacing them.
+ */
+function deepMergeElements(shared, perFrame) {
+  // Start with a copy of the shared elements
+  const merged = { ...shared };
+
+  // Iterate over per-frame elements
+  for (const tag in perFrame) {
+    const sharedItem = merged[tag];
+    const perFrameItem = perFrame[tag];
+
+    // If the tag exists in both, and both are sequences (have .items),
+    // we need to merge their contents recursively.
+    if (
+      sharedItem &&
+      sharedItem.items &&
+      perFrameItem.items &&
+      sharedItem.items.length > 0 &&
+      perFrameItem.items.length > 0 &&
+      sharedItem.items[0].dataSet &&
+      perFrameItem.items[0].dataSet
+    ) {
+      // Assuming sequences in this context have only one item, which is standard.
+      // If there could be more, this logic would need to be more complex.
+      const mergedSubElements = deepMergeElements(
+        sharedItem.items[0].dataSet.elements,
+        perFrameItem.items[0].dataSet.elements
+      );
+
+      // Modify the dataSet of the sharedItem in place.
+      // This is necessary because we cannot create a new DataSet object with the correct prototype.
+      sharedItem.items[0].dataSet.elements = mergedSubElements;
+
+      // Create a new merged sequence item
+      merged[tag] = {
+        ...sharedItem,
+      };
+    } else {
+      // Otherwise, the per-frame element takes precedence (overwrite or add).
+      merged[tag] = perFrameItem;
+    }
+  }
+
+  return merged;
+}
+
 // function that retrieves specific frame metadata information from multiframe
 // metadata
 function combineFrameInstanceDataset(frameNumber, dataSet) {
@@ -102,12 +150,13 @@ function combineFrameInstanceDataset(frameNumber, dataSet) {
       frameNumber
     );
 
+    const mergedFrameElements = deepMergeElements(shared, perFrame);
+
     // creating a new copy of the dataset to remove the two multiframe dicom tags
     const newElements = {
       elements: {
         ...otherElements,
-        ...shared,
-        ...perFrame,
+        ...mergedFrameElements,
       },
     };
 


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->
This change addresses a critical issue in the WADO-URI loader where DICOM metadata was being incorrectly merged, leading to data loss.

The root cause is the shallow merge strategy used in combineFrameInstanceDataset when combining SharedFunctionalGroupsSequence (x52009229) and PerFrameFunctionalGroupsSequence (x52009230).

When a nested sequence (e.g., PlaneOrientationSequence) exists in both the shared and per-frame groups, the per-frame version would completely overwrite the shared version.
If the per-frame sequence was missing some tags that were present in the shared one, those tags were lost.

This PR fixes the merging logic to ensure that no metadata is lost and that the frame-specific DataSet is correctly constructed.

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

Changes

   * Added `deepMergeElements` function: A new private function has been introduced to
     perform a recursive (deep) merge of DICOM element objects.
   * Updated Merge Logic: The core logic in combineFrameInstanceDataset was updated to use
     deepMergeElements. Instead of a shallow merge that overwrites entire sequences, the new
      logic correctly merges nested elements within sequences.
   * Preserved Attribute Priority: The implementation ensures that attributes from
     PerFrameFunctionalGroupsSequence correctly override those from
     SharedFunctionalGroupsSequence at every level of nesting, as intended by the DICOM
     standard.

  Results

   * Before: A shallow merge was causing the PerFrameFunctionalGroupsSequence to completely
     overwrite the SharedFunctionalGroupsSequence for tags that existed in both. This led to
      a loss of nested metadata attributes that were present only in the shared sequence.
   * After: The new deep merge logic correctly combines the shared and per-frame functional
     groups. Attributes from the per-frame group augment and override the shared group's
     attributes without data loss. The resulting DataSet for each frame is now complete and
     accurate.

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

The changes were manually tested using a real-world DICOM file that originally exposed the
   metadata merging bug.

   1. Test Data:
       * The test was performed with a multi-frame DICOM file that contains both
         SharedFunctionalGroupsSequence (x52009229) and PerFrameFunctionalGroupsSequence
         (x52009230).
       * This file's metadata includes a nested PixelValueTransformationSequence (x00289110)
          in both the shared and per-frame functional groups.
       * The issue was discovered because the PixelSpacing tag (x00280030) was present
         within this sequence in the SharedFunctionalGroupsSequence but was absent from the
         sequence in the PerFrameFunctionalGroupsSequence, which caused it to be lost after
         the previous shallow merge logic.

   2. Test Procedure & Results:
       * The problematic DICOM file was loaded using the WADO-URI image loader.
       * The DataSet for a specific frame was then inspected after the image was fully
         loaded.
       * Verification: It was confirmed that the PixelSpacing tag is now correctly inherited
          from the shared PixelValueTransformationSequence and is present in the final
         merged metadata for the frame.

   3. Regression Testing:
       * A suite of other standard single-frame and multi-frame DICOM images were also
         loaded successfully, confirming that these changes have not introduced any
         regressions into the standard image loading process.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"--> Ubuntu 24.04.2
- [x] "Node version: <!--[e.g. 16.14.0]"--> 20.17.0
- [x] "Browser: Chrome 139.0.7258.66
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
