### PR TITLE
fix(ZoomTool): use insetImageMultiplier to determine zoom scale

### DIFF
--- a/packages/tools/src/tools/ZoomTool.ts
+++ b/packages/tools/src/tools/ZoomTool.ts
@@ -207,8 +207,10 @@ class ZoomTool extends BaseTool {
 
       // Get display area, if available
       const displayArea = viewport.options?.displayArea;
-      const imageAreaScaleX = displayArea?.imageArea?.[0] ?? 1.1;
-      const imageAreaScaleY = displayArea?.imageArea?.[1] ?? 1.1;
+      const imageAreaScaleX =
+        displayArea?.imageArea?.[0] ?? viewport.insetImageMultiplier;
+      const imageAreaScaleY =
+        displayArea?.imageArea?.[1] ?? viewport.insetImageMultiplier;
 
       // Adjust image dimensions by display area scale
       const scaledImageWidth = imageWidth * imageAreaScaleX;


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

[[Bug] Stack viewport - minZoomScale and maxZoomScale are not respected](https://github.com/cornerstonejs/cornerstone3D/issues/1963) was partially fixed by [[PR] #2055 Fix zoom tool aspect ratio](https://github.com/cornerstonejs/cornerstone3D/pull/2055)

The above fix added a 10% allowance for the padding included in the viewport. With the [Camera FOV Changes](https://www.cornerstonejs.org/docs/migration-guides/4x/camera-fov) in the 4.0 release, the scale should be determined by the insetImageMultiplier

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

- Use insetImageMultiplier to determine scale
- Zoom is now consistent between 4.0 and legacy camera FOV


## Questions:

The minZoomScale and maxZoomScale are still not accurately respected as per https://github.com/cornerstonejs/cornerstone3D/issues/1963 
- Is this a floating point precision issue?
- Is there something in `_dragParallelProjection` that I'm not understanding resulting in a slight rounding issue? 


Below screenshots have minZoomScale = 1, maxZoomScale = 10
**Legacy FOV:**

<img width="1147" height="756" alt="Screenshot 2025-09-01 at 3 24 30 pm" src="https://github.com/user-attachments/assets/0b30683c-3205-4f4b-b935-cedc209cfca0" />

**4.0 FOV:** 

<img width="1063" height="744" alt="Screenshot 2025-09-01 at 3 22 50 pm" src="https://github.com/user-attachments/assets/01e346aa-8412-43dd-8732-55cfcb94e8a8" />

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing


in stackManipulationTools/index.ts, add:
```
  addButtonToToolbar({
    title: 'Log current zoom',
    onClick: () => {
      console.log(viewport.getZoom())
    },
  });
```
in src/tools/ZoomTool.ts, change the constructor to: (adding min/max ZoomScale)
```
  constructor(
    toolProps: PublicToolProps = {},
    defaultToolProps: ToolProps = {
      supportedInteractionTypes: ['Mouse', 'Touch'],
      configuration: {
        // whether zoom to the center of the image OR zoom to the mouse position
        zoomToCenter: false,
        // Use large ranges to allow for microscopy viewing.
        // TODO: Change the definitions of these to be relative to 1:1 pixel and
        // relative to scale to fit sizing
        minZoomScale: 1,
        maxZoomScale: 5,
        pinchToZoom: true,
        pan: true,
        invert: true,
      },
    }
  )
```
- Run the example
- Log the zoom value on load
- Zoom in all the way
- Log the zoom value
- Zoom out all the way
- Log the zoom value
- Repeat with the below on csRenderInit
```
    rendering: {
      useLegacyCameraFOV: false,
    },
```


<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Mac OS15.6.1
- [x] Node version: v22.15.1
- [x] Browser: Chrome 139.0.7258.139 
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
