### PR TITLE
fix(nifti-volume-loader): add check and clear for orphaned interval at waitForNiftiData function

### DIFF
--- a/packages/nifti-volume-loader/src/cornerstoneNiftiImageLoader.ts
+++ b/packages/nifti-volume-loader/src/cornerstoneNiftiImageLoader.ts
@@ -148,7 +148,7 @@ export default function cornerstoneNiftiImageLoader(
 
   return {
     promise: promise as Promise<Types.IImage>,
-    cancelFn: undefined,
+    cancelFn: undefined, // TODO: add proper cancel function
     decache: () => {
       dataFetchStateMap.delete(url);
     },
@@ -198,10 +198,18 @@ function waitForNiftiData(
   imagePixelModule: Types.ImagePixelModule,
   imagePlaneModule: Types.ImagePlaneModule
 ): Promise<Types.IImage> {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const intervalId = setInterval(() => {
       const dataFetchState = dataFetchStateMap.get(url);
-      if (dataFetchState.status === 'fetched') {
+
+      if (!dataFetchState) {
+        clearInterval(intervalId);
+        reject(
+          `dataFetchState for ${url} is not found. The cache was purged before it completed loading.`
+        );
+      }
+
+      if (dataFetchState?.status === 'fetched') {
         clearInterval(intervalId);
         resolve(
           createImage(


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

Fixes #2065 

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

Add check for `dataFetchState` entry exist, if not we don't need to keep interval to check it again.
Reject promise for waiting nifti data with explanation why this load is not successful.

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

Based on @pcanas [reproduction steps](https://github.com/cornerstonejs/cornerstone3D/issues/2065#issuecomment-3219643125).

From the examples, modify initDemo.ts to add a nifti loader.

```
import { cornerstoneNiftiImageLoader } from '@cornerstonejs/nifti-volume-loader';
...

// at the end of function initDemo
  imageLoader.registerImageLoader('nifti', (imageId: string) => {
  const imageLoadObject = cornerstoneNiftiImageLoader(imageId);
  return {
    ...imageLoadObject,
    promise: imageLoadObject.promise
      .then((image) => image as unknown as Record<string, unknown>)
      .catch((e) => console.error(e)), // Cathes exceptions if loading is failed
  };
});
```

Then modify one example with the following index.ts:

```
import type { Types } from '@cornerstonejs/core';
import {
  cache,
  RenderingEngine,
  Enums,
  volumeLoader,
  getRenderingEngine,
} from '@cornerstonejs/core';
import {
  initDemo,
  setTitleAndDescription,
  addButtonToToolbar,
  setCtTransferFunctionForVolumeActor,
} from '../../../../utils/demo/helpers';
import { createNiftiImageIdsAndCacheMetadata } from '@cornerstonejs/nifti-volume-loader';

// This is for debugging purposes
console.warn(
  'Click on index.ts to open source code for this example --------->'
);

const { ViewportType } = Enums;

const renderingEngineId = 'myRenderingEngine';
const viewportId = 'CT_SAGITTAL_STACK';

const URL1 = 'https://stroke.blob.core.windows.net/stroke/database/lvo_trial/73648/1.3.12.2.1107.5.1.4.122284.30000023121807571949600011240/image_NCCT_viewer_20240901_185634.nii.gz?sp=r&st=2025-01-13T12:47:48Z&se=2026-03-14T20:47:48Z&sv=2022-11-02&sr=b&sig=%2FXTqWU3M1PqIpwEQYG2L21XA82HjPErxV7wmMI3m4V8%3D'
const URL2 = 'https://stroke.blob.core.windows.net/stroke/database/dev_test/eba01/2.25.124678287130056338078625675539439911629/image_CTA_HD_viewer_20240430_091038.nii.gz?sp=r&st=2025-01-31T07:44:05Z&se=2026-03-14T15:44:05Z&sv=2022-11-02&sr=b&sig=clyBf6xyJ79VE%2Bvcxc416wYX1omU5xvcd5GLUe6%2FWVY%3D'

// ======== Set up page ======== //
setTitleAndDescription(
  'Volume Viewport API',
  'Demonstrates how to interact with a Volume viewport.'
);

const content = document.getElementById('content');
const element = document.createElement('div');
element.id = 'cornerstone-element';
element.style.width = '500px';
element.style.height = '500px';

content.appendChild(element);
// ============================= //

async function loadVolume(url: string) {
  await cache.purgeCache();

  const renderingEngine = getRenderingEngine(renderingEngineId);
    const viewport = renderingEngine.getViewport(
      viewportId
    ) as Types.IVolumeViewport;

    const mainImageIds = await createNiftiImageIdsAndCacheMetadata({
      url: url,
    });
    const volumeId = `nifti:${url}`;
    const volume = await volumeLoader.createAndCacheVolume(volumeId, {
      imageIds: mainImageIds,
    });

    // Set the volume to load
    await volume.load();

    // Set the volume on the viewport and it's default properties
    await viewport
      .setVolumes([{ volumeId, callback: setCtTransferFunctionForVolumeActor }])

    // Render the image
    await viewport.render();
}

addButtonToToolbar({
  title: 'Change to 1st Volume',
  onClick: async () => {
    console.log('Loading 1st volume');
    await loadVolume(URL1);
    console.log('1st volume loaded');
  },
});

addButtonToToolbar({
  title: 'Change to 2nd Volume',
  onClick: async () => {
    console.log('Loading 2nd volume');
    await loadVolume(URL2);
    console.log('2nd volume loaded');
  },
});

/**
 * Runs the demo
 */
async function run() {
  // Init Cornerstone and related libraries
  await initDemo();

  // Get Cornerstone imageIds and fetch metadata into RAM
  // Instantiate a rendering engine
  const renderingEngine = new RenderingEngine(renderingEngineId);

  // Create a stack viewport
  const viewportInput = {
    viewportId,
    type: ViewportType.ORTHOGRAPHIC,
    element,
    defaultOptions: {
      orientation: Enums.OrientationAxis.AXIAL
    },
  };

  renderingEngine.enableElement(viewportInput);

  console.log('Loading 1st volume');
  await loadVolume(URL1);
  console.log('1st volume loaded');
}

run();
```

Instructions to reproduce the issue:

1. Run the example.
2. Click on "Change to 2nd Volume"
3. While it is loading, click on "Change to 1st Volume"

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Windows 11 <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [x] "Node version: v22.11.0 <!--[e.g. 16.14.0]"-->
- [x] "Browser: 139.0.7258.155
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
