### PR TITLE
fix(NiftiVolumeLoader): add float64 support to nifti volume loader

### DIFF
--- a/packages/core/src/types/PixelDataTypedArray.ts
+++ b/packages/core/src/types/PixelDataTypedArray.ts
@@ -1,5 +1,6 @@
 export type PixelDataTypedArray =
   | Float32Array
+  | Float64Array
   | Int16Array
   | Uint16Array
   | Uint8Array
@@ -10,6 +11,7 @@ export type PixelDataTypedArray =
 
 export type PixelDataTypedArrayString =
   | 'Float32Array'
+  | 'Float64Array'
   | 'Int16Array'
   | 'Uint16Array'
   | 'Uint8Array'

--- a/packages/core/src/utilities/generateVolumePropsFromImageIds.ts
+++ b/packages/core/src/utilities/generateVolumePropsFromImageIds.ts
@@ -150,6 +150,9 @@ function _determineDataType(
     case 32:
       return 'Float32Array';
 
+    case 64:
+      return 'Float64Array';
+
     default:
       throw new Error(
         `Bits allocated of ${BitsAllocated} is not defined to generate scalarData for the volume.`

--- a/packages/nifti-volume-loader/src/helpers/dataTypeCodeHelper.ts
+++ b/packages/nifti-volume-loader/src/helpers/dataTypeCodeHelper.ts
@@ -17,6 +17,8 @@ export function getArrayConstructor(datatypeCode: number): unknown {
       return Uint16Array;
     case NIFTICONSTANTS.NIFTI_TYPE_UINT32:
       return Uint32Array;
+    case NIFTICONSTANTS.NIFTI_TYPE_FLOAT64:
+      return Float64Array;
     default:
       throw new Error(
         `NIFTI datatypeCode ${datatypeCode} is not yet supported`

--- a/packages/nifti-volume-loader/src/helpers/modalityScaleNifti.ts
+++ b/packages/nifti-volume-loader/src/helpers/modalityScaleNifti.ts
@@ -82,6 +82,10 @@ export default function modalityScaleNifti(
       niiBuffer = new Uint32Array(niftiImageBuffer);
       scalarData = allocateScalarData('Float32Array', niiBuffer);
       break;
+    case NIFTICONSTANTS.NIFTI_TYPE_FLOAT64:
+      niiBuffer = new Float64Array(niftiImageBuffer);
+      scalarData = allocateScalarData('Float64Array', niiBuffer);
+      break;
     default:
       throw new Error(
         `NIFTI datatypeCode ${datatypeCode} is not yet supported`
@@ -150,6 +154,11 @@ function allocateScalarData(
       bitsAllocated = 8;
       checkCacheAvailable(bitsAllocated, nVox);
       scalarData = new Uint8Array(nVox);
+      break;
+    case 'Float64Array':
+      bitsAllocated = 64;
+      checkCacheAvailable(bitsAllocated, nVox);
+      scalarData = new Float64Array(nVox);
       break;
     default:
       throw new Error(`TypedArray ${types} is not yet supported`);


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

Fixes #2314 

Adds support for NIFTI datatype 64 (float64/double precision) to cornerstone3D's NIFTI volume loader, fixing the error "NIFTI datatypeCode 64 is not yet supported".

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

*Core Package (packages/core/)*

- `src/types/PixelDataTypedArray.ts`: Added Float64Array to PixelDataTypedArray and PixelDataTypedArrayString type definitions
-  `src/utilities/generateVolumePropsFromImageIds.ts`: Added case for 64-bit allocation to return 'Float64Array' in the bits allocation switch statement

*NIFTI Volume Loader (packages/nifti-volume-loader/)*

- `src/helpers/dataTypeCodeHelper.ts`: Added support for NIFTI_TYPE_FLOAT64 constant to return Float64Array constructor
- `src/helpers/modalityScaleNifti.ts`:
    - Added case for NIFTI_TYPE_FLOAT64 to create
  Float64Array buffer and allocate scalar data
    - Added 'Float64Array' case in allocateScalarData
  function with proper 64-bit allocation

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

- Download the test float64 nifti from GDrive: https://drive.google.com/file/d/1h0wJAIYRr2YsaWqI-2x5N1pGgB8ArOyL/view?usp=sharing
- Patch the `packages/nifti-volume-loader/examples/niftiBasic/index.ts` L39: `const niftiURL =
  'http://localhost:8080/pat_01_ct_0001_float64.nii.gz';`
- Install, build:
```bash
cornerstone3D
yarn install
cd packages/core && yarn build
cd ../nifti-volume-loader && yarn build
```
- Start http server in the location of the downloaded file:
```bash
npm install -g http-server

# Serve the file with CORS enabled
cd packages/nifti-volume-loader
http-server -p 8080 --cors
```
- Build static examples: `yarn run build-and-serve-static-examples`
- Navigate to `niftiBasic` -> should render the volume without the error.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: Linux 6.8 Ubuntu 24.04.2 LTS 24.04.2 LTS (Noble Numbat)
- [x] Node version: 22.19.0
- [x] Browser: Chrome 139.0.7258.157

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
