### PR TITLE
fix(measurements): measurements were being shown in px when pixel spacing is defined

### DIFF
--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -3448,10 +3448,7 @@ class StackViewport extends Viewport {
   private _getImagePlaneModule(imageId: string): ImagePlaneModule {
     const imagePlaneModule = getImagePlaneModule(imageId);
 
-    this.hasPixelSpacing =
-      !imagePlaneModule.usingDefaultValues ||
-      this.calibration?.scale > 0 ||
-      this.calibration?.rowPixelSpacing > 0;
+    this.hasPixelSpacing = this.calibration?.scale > 0 || imagePlaneModule?.rowPixelSpacing > 0;
 
     this.calibration ||= imagePlaneModule.calibration;
 


### PR DESCRIPTION
## Context

using default values to decide if pixel spacing is present is wrong, cuz it gets set to true when other fields are not present that are not pixel spacing