### PR TITLE
fix: NaN window level

### DIFF
--- a/packages/core/src/RenderingEngine/helpers/setDefaultVolumeVOI.ts
+++ b/packages/core/src/RenderingEngine/helpers/setDefaultVolumeVOI.ts
@@ -91,6 +91,7 @@ function getVOIFromMetadata(imageVolume: IImageVolume): VOIRange | undefined {
         voi.voiLUTFunction = voiLutModule?.voiLUTFunction;
       }
       const { windowWidth, windowCenter } = voiLutModule;
+
       const width = Array.isArray(windowWidth) ? windowWidth[0] : windowWidth;
       const center = Array.isArray(windowCenter)
         ? windowCenter[0]
@@ -111,6 +112,11 @@ function getVOIFromMetadata(imageVolume: IImageVolume): VOIRange | undefined {
       Number(voi.windowCenter),
       voi.voiLUTFunction
     );
+
+    if (isNaN(lower) || isNaN(upper)) {
+      return;
+    }
+
     return { lower, upper };
   }
 


### PR DESCRIPTION
### Context

If for some reason the voiLutModule windowWidth or windowCenter are empty arrays the fallback isn't working and it is returning NaN's.

### Changes & Results

With this change we now check if either of these values are NaN's, then we just return undefined which will allow the fallback to run and return correct window level values.

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
