### PR TITLE
feat(Stackprefetch): add event that is triggered when the stack prefetch for a viewport has completed

### DIFF
--- a/packages/core/src/enums/Events.ts
+++ b/packages/core/src/enums/Events.ts
@@ -213,11 +213,6 @@ enum Events {
   STACK_SCROLL_OUT_OF_BOUNDS = 'STACK_SCROLL_OUT_OF_BOUNDS',
 
   /**
-   * Triggers on the eventTarget when a stack prefetch has been completed (i.e., the indicesToRequest list has been emptied).
-   */
-  STACK_PREFETCH_COMPLETE = 'CORNERSTONE_STACK_PREFETCH_COMPLETE',
-
-  /**
    * Triggers on the eventTarget when a new geometry is added to the geometry cache
    */
   GEOMETRY_CACHE_GEOMETRY_ADDED = 'CORNERSTONE_GEOMETRY_CACHE_GEOMETRY_ADDED',

--- a/packages/core/src/enums/Events.ts
+++ b/packages/core/src/enums/Events.ts
@@ -213,6 +213,11 @@ enum Events {
   STACK_SCROLL_OUT_OF_BOUNDS = 'STACK_SCROLL_OUT_OF_BOUNDS',
 
   /**
+   * Triggers on the eventTarget when a stack prefetch has been completed (i.e., the indicesToRequest list has been emptied).
+   */
+  STACK_PREFETCH_COMPLETE = 'CORNERSTONE_STACK_PREFETCH_COMPLETE',
+
+  /**
    * Triggers on the eventTarget when a new geometry is added to the geometry cache
    */
   GEOMETRY_CACHE_GEOMETRY_ADDED = 'CORNERSTONE_GEOMETRY_CACHE_GEOMETRY_ADDED',

--- a/packages/tools/src/enums/Events.ts
+++ b/packages/tools/src/enums/Events.ts
@@ -39,6 +39,13 @@ enum Events {
 
   VOLUMECROPPING_TOOL_CHANGED = 'CORNERSTONE_TOOLS_VOLUMECROPPING_TOOL_CHANGED',
 
+  /**
+   * Triggers on the eventTarget when a stack prefetch has been completed (i.e., the indicesToRequest list
+   * has been emptied). It is triggered both by the stackPrefetch and stackContextPrefetch mechanism.
+   * See what event detail is included in {@link EventTypes.StackPrefetchCompleteEventDetail | Stack Prefetch Complete Event Detail}.
+   */
+  STACK_PREFETCH_COMPLETE = 'CORNERSTONE_TOOLS_STACK_PREFETCH_COMPLETE',
+
   ///////////////////////////////////////
   //            Annotations
   ///////////////////////////////////////

--- a/packages/tools/src/types/EventTypes.ts
+++ b/packages/tools/src/types/EventTypes.ts
@@ -470,10 +470,10 @@ type MouseWheelEventDetail = NormalizedInteractionEventDetail &
  * Event detail for STACK_PREFETCH_COMPLETE events
  */
 type StackPrefetchCompleteEventDetail = {
-  /** The imageId of the last prefetched image before completion */
-  imageId: string;
   /** The viewport element that requested the prefetch */
   element: HTMLDivElement;
+  /** The imageId of the last prefetched image before completion */
+  lastPrefetchedImageId: string;
 };
 
 /////////////////////////////

--- a/packages/tools/src/types/EventTypes.ts
+++ b/packages/tools/src/types/EventTypes.ts
@@ -466,6 +466,16 @@ type MouseWheelEventDetail = NormalizedInteractionEventDetail &
     points: IPoints;
   };
 
+/**
+ * Event detail for STACK_PREFETCH_COMPLETE events
+ */
+type StackPrefetchCompleteEventDetail = {
+  /** The imageId of the last prefetched image before completion */
+  imageId: string;
+  /** The viewport element that requested the prefetch */
+  element: HTMLDivElement;
+};
+
 /////////////////////////////
 //
 //
@@ -780,4 +790,5 @@ export type {
   MouseWheelEventType,
   SegmentationAddedEventDetail,
   SegmentationAddedEventType,
+  StackPrefetchCompleteEventDetail,
 };

--- a/packages/tools/src/utilities/stackPrefetch/stackContextPrefetch.ts
+++ b/packages/tools/src/utilities/stackPrefetch/stackContextPrefetch.ts
@@ -6,6 +6,7 @@ import {
   cache,
   metaData,
   utilities,
+  triggerEvent,
 } from '@cornerstonejs/core';
 import { addToolState, getToolState, type StackPrefetchData } from './state';
 import {
@@ -14,6 +15,8 @@ import {
   clearFromImageIds,
   getPromiseRemovedHandler,
 } from './stackPrefetchUtils';
+import { Events } from '../../enums';
+import type { EventTypes } from '../../types';
 
 const { imageRetrieveMetadataProvider } = utilities;
 
@@ -221,6 +224,17 @@ function prefetch(element, priority = 0) {
           // );
         }
       }
+    }
+
+    // If all requests are complete, trigger the STACK_PREFETCH_COMPLETE event,
+    // providing the last imageId and triggering element so that the stack can
+    // be identified
+    if (stackPrefetch.indicesToRequest.length === 0) {
+      const eventDetail: EventTypes.StackPrefetchCompleteEventDetail = {
+        imageId: imageId,
+        element: element,
+      };
+      triggerEvent(eventTarget, Events.STACK_PREFETCH_COMPLETE, eventDetail);
     }
   }
 

--- a/packages/tools/src/utilities/stackPrefetch/stackContextPrefetch.ts
+++ b/packages/tools/src/utilities/stackPrefetch/stackContextPrefetch.ts
@@ -231,8 +231,8 @@ function prefetch(element, priority = 0) {
     // be identified
     if (stackPrefetch.indicesToRequest.length === 0) {
       const eventDetail: EventTypes.StackPrefetchCompleteEventDetail = {
-        imageId: imageId,
         element: element,
+        lastPrefetchedImageId: imageId,
       };
       triggerEvent(eventTarget, Events.STACK_PREFETCH_COMPLETE, eventDetail);
     }

--- a/packages/tools/src/utilities/stackPrefetch/stackPrefetch.ts
+++ b/packages/tools/src/utilities/stackPrefetch/stackPrefetch.ts
@@ -17,6 +17,8 @@ import {
   nearestIndex,
   range,
 } from './stackPrefetchUtils';
+import { Events } from '../../enums';
+import type { EventTypes } from '../../types';
 
 const { imageRetrieveMetadataProvider } = utilities;
 
@@ -130,11 +132,14 @@ function prefetch(element) {
     removeFromList(imageIdIndex);
 
     // If all requests are complete, trigger the STACK_PREFETCH_COMPLETE event,
-    // providing the last imageId so that the stack can be identified
+    // providing the last imageId and triggering element so that the stack can
+    // be identified
     if (stackPrefetch.indicesToRequest.length === 0) {
-      triggerEvent(eventTarget, Enums.Events.STACK_PREFETCH_COMPLETE, {
+      const eventDetail: EventTypes.StackPrefetchCompleteEventDetail = {
         imageId: imageId,
-      });
+        element: element,
+      };
+      triggerEvent(eventTarget, Events.STACK_PREFETCH_COMPLETE, eventDetail);
     }
   }
 

--- a/packages/tools/src/utilities/stackPrefetch/stackPrefetch.ts
+++ b/packages/tools/src/utilities/stackPrefetch/stackPrefetch.ts
@@ -6,6 +6,7 @@ import {
   cache,
   metaData,
   utilities,
+  triggerEvent,
 } from '@cornerstonejs/core';
 import { addToolState, getToolState, type StackPrefetchData } from './state';
 import {
@@ -127,6 +128,14 @@ function prefetch(element) {
     const imageIdIndex = stack.imageIds.indexOf(imageId);
 
     removeFromList(imageIdIndex);
+
+    // If all requests are complete, trigger the STACK_PREFETCH_COMPLETE event,
+    // providing the last imageId so that the stack can be identified
+    if (stackPrefetch.indicesToRequest.length === 0) {
+      triggerEvent(eventTarget, Enums.Events.STACK_PREFETCH_COMPLETE, {
+        imageId: imageId,
+      });
+    }
   }
 
   // Prefetch images around the current image (before and after)

--- a/packages/tools/src/utilities/stackPrefetch/stackPrefetch.ts
+++ b/packages/tools/src/utilities/stackPrefetch/stackPrefetch.ts
@@ -136,8 +136,8 @@ function prefetch(element) {
     // be identified
     if (stackPrefetch.indicesToRequest.length === 0) {
       const eventDetail: EventTypes.StackPrefetchCompleteEventDetail = {
-        imageId: imageId,
         element: element,
+        lastPrefetchedImageId: imageId,
       };
       triggerEvent(eventTarget, Events.STACK_PREFETCH_COMPLETE, eventDetail);
     }


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->
When using the prefetch mechanism for stack viewports, it is often desirable to give the user visual feedback regarding the prefetching progress, so that the user can see when a series has been completely loaded and scrolling across the stack is possible. Currently, it is possible to monitor the load progress via events triggered by the dicom-image-loader but the images still need to be decoded afterwards, which can take a moment for large series. The IMAGE_LOAD event on the eventTarget, on the other hand, triggers for also for scroll events. Thus, hooking into this event could have performance implications. Therefore, this PR adds a new event that is triggered from the DoneCallback function of the StackPrefetch mechanism when the prefetching list has been emptied. The last-loaded imageId is provided in the event details, so that the viewport displaying the series can be easily determined. 

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->
* Added the new event type to Events.ts
* Added the triggerEvent function to the DoneCallback function in StackPrefetch.ts

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->
* Add event listener for the new event to the eventTarget:
`eventTarget.addEventListener(EVENTS.STACK_PREFETCH_COMPLETE, someCallbackFunction);`
* Create a viewport and load a image series with stack prefetching enabled
* Validate that the callback function gets triggered when the prefetching is complete

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Windows 11<!--[e.g. Windows 10, macOS 10.15.4]"-->
- [x] "Node version: 22.17.0<!--[e.g. 16.14.0]"-->
- [x] "Browser: Chrome 142.0, Firefox 143.0
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
