### PR TITLE
Fix cursor freeze with modifier keys

### DIFF
--- a/packages/tools/src/eventListeners/keyboard/keyDownListener.ts
+++ b/packages/tools/src/eventListeners/keyboard/keyDownListener.ts
@@ -48,7 +48,20 @@ function keyListener(evt: KeyboardEvent): void {
   state.key = evt.key;
   state.keyCode = evt.keyCode;
 
-  evt.preventDefault();
+  // Don't prevent default behavior for modifier-only keys (Shift, Control, Alt, Meta, AltGraph)
+  // as this can interfere with mouse cursor movement and other browser behaviors.
+  // Preventing default on these keys can block browser features and mouse tracking.
+  const isModifierOnlyKey = 
+    evt.key === 'Shift' || 
+    evt.key === 'Control' || 
+    evt.key === 'Alt' || 
+    evt.key === 'Meta' ||
+    evt.key === 'AltGraph';
+  
+  if (!isModifierOnlyKey) {
+    evt.preventDefault();
+  }
+  
   const eventDetail: KeyDownEventDetail = {
     renderingEngineId: state.renderingEngineId,
     viewportId: state.viewportId,


### PR DESCRIPTION
Prevent `preventDefault()` for modifier-only keys to fix mouse cursor freezing when modifiers are pressed.

Previously, `evt.preventDefault()` was called indiscriminately for all keydown events, including modifier keys. This blocked the browser's default handling of these keys, which interfered with mouse movement events, causing the cursor to stop responding. This change ensures that only non-modifier keys have their default behavior prevented, allowing modifier keys to function correctly alongside mouse interactions.

---
Linear Issue: [OHI-1994](https://linear.app/ohif/issue/OHI-1994)

<a href="https://cursor.com/background-agent?bcId=bc-efaaa5cc-5c8b-4394-9445-0ca163601886"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-efaaa5cc-5c8b-4394-9445-0ca163601886"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

