### PR TITLE
fix(fov): Forcing the use of legacy FOV scaling method for orthographic viewports (temporary fix)

### DIFF
--- a/packages/core/src/RenderingEngine/Viewport.ts
+++ b/packages/core/src/RenderingEngine/Viewport.ts
@@ -1134,7 +1134,13 @@ class Viewport {
     const config = getConfiguration();
     const useLegacyMethod = config.rendering?.useLegacyCameraFOV ?? false;
 
-    if (imageData && !useLegacyMethod) {
+    // Note: Force the legacy method for orthographic views as the current method
+    // does not provide correct FOV estimates for reformatted orientations.
+    if (
+      imageData &&
+      !useLegacyMethod &&
+      this.type !== ViewportType.ORTHOGRAPHIC
+    ) {
       const extent = imageData.getExtent();
       const spacing = imageData.getSpacing();
 


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->
Currently, orthographic viewports do not provide correct FOV estimates on camera reset when showing reformatted orientations of the volume. As a result, the loaded image volume is cropped and a significant number of slices can be "hidden" outside the FOV (see screenshot below). 

The problem has been addressed in the in PR #2334, but the proposed solution does not work yet.

The current PR introduces a fallback to the legacy FOV scaling method for orthographic viewports. This is intended as temporary fix until another solution has been developed. The legacy method seems to work well for the orthographic viewports (I have not noticed any issues with the FOV scaling).

<img width="3000" height="1009" alt="image" src="https://github.com/user-attachments/assets/e311bb0f-9891-46b9-a25f-9e72d28df3e5" />


### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->
In the function resetCamera() in Viewports.ts, a condition has been added that forces the fallback to the legacy scaling method for orthographic viewports when estimating the world dimensions. 

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->
* Load a volumetric dataset (e.g., CT) into a volume viewport in orthographic mode with an orientation different from the acquired orientation. 
* Zoom-out to validate that there are no hidden slices outside the FOV

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Windows 11"
- [x] "Node version: 22.17.0"
- [x] "Browser:  Chrome 142.0, Firefox 143.0"

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
