### PR TITLE
feat(dicomImageLoader): option to enable decoding of JPEG8BitColor images with webworkers

### DIFF
--- a/packages/dicomImageLoader/src/imageLoader/decodeImageFrame.ts
+++ b/packages/dicomImageLoader/src/imageLoader/decodeImageFrame.ts
@@ -102,16 +102,16 @@ function decodeImageFrame(
       );
     case '1.2.840.10008.1.2.4.50':
       // JPEG Baseline lossy process 1 (8 bit)
-
-      // Handle 8-bit JPEG Baseline color images using the browser's built-in
-      // JPEG decoding
-      if (
-        imageFrame.bitsAllocated === 8 &&
-        (imageFrame.samplesPerPixel === 3 || imageFrame.samplesPerPixel === 4)
-      ) {
-        return decodeJPEGBaseline8BitColor(imageFrame, pixelData, canvas);
+      if (!decodeConfig?.useJPEGBaseline8BitColorWebWorker) {
+        // Handle 8-bit JPEG Baseline color images using the browser's built-in JPEG decoding,
+        // unless it has been configured to use the web-worker decoder instead.
+        if (
+          imageFrame.bitsAllocated === 8 &&
+          (imageFrame.samplesPerPixel === 3 || imageFrame.samplesPerPixel === 4)
+        ) {
+          return decodeJPEGBaseline8BitColor(imageFrame, pixelData, canvas);
+        }
       }
-
       return processDecodeTask(
         imageFrame,
         transferSyntax,


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

JPEG 8bit color images are currently decoded using a browser built-in algorithm. To this end, the pixel data is stored in a Blob and copied into an HTML image object (in file decodeJPEGBaseline8BitColor.ts). However, when loading a large number of color images (e.g., a long series of US captures), the processing becomes slow and leads to blocking of the UI. One reason is that the decoding is done by the browser's UI thread instead of a webworker (which is necessary because DOM elements and functions are not available from webworkers).

This PR introduces an option to the dicomImageLoader's decodeConfig that enables using the (existing) webworker-based JPEG decoder also for 8bit color images, resulting in much faster processing times. The change allows specifying during application initialization that the browser-based decoding should not be used.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

* Added a condition to decodeImageFrame.ts that checks if decodeOption.useJPEGBaseline8BitColorWebWorker was set during the init call
* If the flag is set, all JPEG decoding tasks are delegated to the webworker, including 8bit color images, which are otherwise decoded with the browser-based code

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

* Load a large series of JPEG color images (e.g., captures from an US scanner) into a stack viewport with enabled prefetching.
* Scroll through the stack and compare responsiveness.

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Windows 11"<!--[e.g. Windows 10, macOS 10.15.4]-->
- [x] "Node version: 22.17.0"<!--[e.g. 16.14.0]"-->
- [x] "Browser: Chrome 142.0, Firefox 143.0"
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
