### PR TITLE
feat(WindowLevelTool): added options for inverting the direction of window center and width adjustment

### DIFF
--- a/packages/tools/src/tools/WindowLevelTool.ts
+++ b/packages/tools/src/tools/WindowLevelTool.ts
@@ -74,8 +74,8 @@ class WindowLevelTool extends BaseTool {
     }
 
     // If modality is PT and the viewport is pre-scaled (SUV),
-    // treat it special to not include the canvas delta in
-    // the x direction. For other modalities, use the canvas delta in both
+    // treat it special to not include the canvas delta in the
+    // x direction. For other modalities, use the canvas delta in both
     // directions, and if the viewport is a volumeViewport, the multiplier
     // is calculated using the volume min and max.
     if (modality === PT && isPreScaled) {


### PR DESCRIPTION

<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->
Most tools, including the Stack Scroll and Zoom tool, allow adjusting the mouse-movement direction via the tool configuration (typically by the setting "invert"). The WindowLevelTool currently does not have this flexibility. This small PR adds this functionality, allowing the mouse movement direction to be adjusted separately for the window center and window width.


### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->
Added tool configuration with members "invertWidth" and "invertCenter", and adjusted the event handler for mouse movement accordingly.

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->
* Run the "Basic Stack Manipulation" example
* Add a configuration for the WindowLevelTool with:
`toolGroup.addTool(WindowLevelTool.toolName, { invertCenter: true, invertWidth: true });`
* Validate that the mouse directions for changing the window level have flipped

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Windows 11"<!--[e.g. Windows 10, macOS 10.15.4]-->
- [x] "Node version: 22.17.0"<!--[e.g. 16.14.0]"-->
- [x] "Browser: Chrome 142.0, Firefox 143.0"
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
