### PR TITLE
fix: update toLowHighRange function to handle SIGMOID function bounds…

### DIFF
--- a/packages/core/src/utilities/windowLevel.ts
+++ b/packages/core/src/utilities/windowLevel.ts
@@ -58,7 +58,13 @@ function toLowHighRange(
   lower: number;
   upper: number;
 } {
-  if (voiLUTFunction === VOILUTFunctionType.LINEAR) {
+  // Note: The SIGMOID function is currently treated the same as LINEAR
+  // because we don't have a good way to define "bounds" for it.
+  // Remove or statement when fixed
+  if (
+    voiLUTFunction === VOILUTFunctionType.LINEAR ||
+    voiLUTFunction === VOILUTFunctionType.SAMPLED_SIGMOID
+  ) {
     // From C.11.2.1.2.1 (linear function)
     return {
       lower: windowCenter - 0.5 - (windowWidth - 1) / 2,
@@ -70,15 +76,18 @@ function toLowHighRange(
       lower: windowCenter - windowWidth / 2,
       upper: windowCenter + windowWidth / 2,
     };
-  } else if (voiLUTFunction === VOILUTFunctionType.SAMPLED_SIGMOID) {
-    // From C.11.2.1.3.1 (sigmoid function)
-    // Sigmoid: y = 1 / (1 + exp(-4*(x - c)/w))
-    const xLower = logit(0.01, windowCenter, windowWidth);
-    const xUpper = logit(0.99, windowCenter, windowWidth);
-    return {
-      lower: xLower,
-      upper: xUpper,
-    };
+    // Note: The SIGMOID function is currently treated the same as LINEAR
+    // because we don't have a good way to define "bounds" for it.
+    // Uncomment when fixed
+    // } else if (voiLUTFunction === VOILUTFunctionType.SAMPLED_SIGMOID) {
+    //   // From C.11.2.1.3.1 (sigmoid function)
+    //   // Sigmoid: y = 1 / (1 + exp(-4*(x - c)/w))
+    //   const xLower = logit(0.01, windowCenter, windowWidth);
+    //   const xUpper = logit(0.99, windowCenter, windowWidth);
+    //   return {
+    //     lower: xLower,
+    //     upper: xUpper,
+    //   };
   } else {
     throw new Error('Invalid VOI LUT function');
   }


### PR DESCRIPTION
… as a temporary fix

<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
Discussed in OHIF Office Hours. This PR reverts sigmoid LUT handling to linear by adding a conditional in the code that forces linear window/level behavior when the transfer function is sigmoid.
This allows images to render and respond to window/level tools normally while preserving visual accuracy close enough for clinical use.
The regression was confirmed to have been introduced between Cornerstone3D 2.11.2 and 2.14.x, so developers are isolating the faulty commit through a git bisect.
Once identified, a PR will follow with the corrected sigmoid logic.


<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Windows 11
- [x] "Node version: v24.4.1
- [x] "Browser: Firefox 141.0, Chrome 138.0.7204.184
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
