### PR TITLE
fix(CrosshairTool): Fix "setToolCenter" to apply the modification to the viewports camera

### DIFF
--- a/packages/tools/src/tools/CrosshairsTool.ts
+++ b/packages/tools/src/tools/CrosshairsTool.ts
@@ -430,15 +430,15 @@ class CrosshairsTool extends AnnotationTool {
 
       // Project this vector onto the view plane normal.
       // This isolates the component of the movement that corresponds to the "scroll" (slice change).
-      const dotProduct =
+      const scroll =
         delta[0] * viewPlaneNormal[0] +
         delta[1] * viewPlaneNormal[1] +
         delta[2] * viewPlaneNormal[2];
 
       const scrollDelta = [
-        dotProduct * viewPlaneNormal[0],
-        dotProduct * viewPlaneNormal[1],
-        dotProduct * viewPlaneNormal[2],
+        scroll * viewPlaneNormal[0],
+        scroll * viewPlaneNormal[1],
+        scroll * viewPlaneNormal[2],
       ];
 
       // Apply this "scroll" to the position and focal point of the camera.


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
Right now if you use `setToolCenter`, it will correctly change the center of the crosshair but it wont apply the modification to the camera of each viewports.

You can see it here, when the crosshair mooves, the viewports camera won't follow :

https://github.com/user-attachments/assets/19c08593-071b-4bed-8559-39c5ffebeae7



<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
- Added handle to modify the viewport camera following the movement of the crosshair center.

We can see now the center follow the camera : 

https://github.com/user-attachments/assets/930e916e-22ed-4426-b8ec-48e13a8d7b3d



<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
