### PR TITLE
fix: Wrong position on rehydrate annotation

### DIFF
--- a/packages/adapters/src/adapters/Cornerstone3D/MeasurementReport.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/MeasurementReport.ts
@@ -309,11 +309,13 @@ export default class MeasurementReport {
         metadata
     }) {
         const { ReferencedSOPSequence } = SCOORDGroup.ContentSequence;
-        const { ReferencedSOPInstanceUID, ReferencedFrameNumber } =
+        const { ReferencedSOPInstanceUID, ReferencedFrameNumber = 1 } =
             ReferencedSOPSequence;
 
         const referencedImageId =
-            sopInstanceUIDToImageIdMap[ReferencedSOPInstanceUID];
+            sopInstanceUIDToImageIdMap[
+                `${ReferencedSOPInstanceUID}:${ReferencedFrameNumber}`
+            ];
         const imagePlaneModule = metadata.get(
             "imagePlaneModule",
             referencedImageId

--- a/packages/tools/src/utilities/planar/filterAnnotationsWithinSlice.ts
+++ b/packages/tools/src/utilities/planar/filterAnnotationsWithinSlice.ts
@@ -119,21 +119,23 @@ export default function filterAnnotationsWithinSlice(
   const annotationsWithinSlice = [];
 
   for (const annotation of annotationsWithParallelNormals) {
-    const data = annotation.data;
+    const { data, metadata, isVisible } = annotation;
 
-    const point = data.handles.points[0] || data.contour?.polyline[0];
-
-    if (!annotation.isVisible) {
+    if (!isVisible) {
       continue;
     }
+
+    const point =
+      metadata.planeRestriction?.point ||
+      data.handles.points[0] ||
+      data.contour?.polyline[0];
+
     // A = point
     // B = focal point
     // P = normal
 
     // B-A dot P  => Distance in the view direction.
     // this should be less than half the slice distance.
-
-    const dir = vec3.create();
 
     // If the handles has no values, eg a key image or other annotation, it
     // should just be included.
@@ -142,11 +144,11 @@ export default function filterAnnotationsWithinSlice(
       continue;
     }
 
-    vec3.sub(dir, focalPoint, point);
+    const dir = vec3.sub(vec3.create(), focalPoint, point);
 
-    const dot = vec3.dot(dir, viewPlaneNormal);
+    const dot = Math.abs(vec3.dot(dir, viewPlaneNormal));
 
-    if (Math.abs(dot) < halfSpacingInNormalDirection) {
+    if (dot < halfSpacingInNormalDirection) {
       annotationsWithinSlice.push(annotation);
     }
   }


### PR DESCRIPTION
### Context

When annotations are rehydrated, they need to be able to find the metadata for the correct frame.  

### Changes & Results

Change the sop uid to image id map from straight sop uid to sop uid + frame number so that different frames retrieve the right data.

### Testing

Load the study in https://github.com/OHIF/Viewers/issues/5431 and load the SR.  Switch to MPR mode.  Click on the annotations in the measurements panel.  The three measurements should appear on different slices, the same slices as from the acquisition rendering.  Needs the equivalent fix on the OHIF side.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
