### PR TITLE
fix(US): Set US Modality Pixel Spacing to 1:1 for Rendering

### DIFF
--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -2452,6 +2452,12 @@ class StackViewport extends Viewport {
     // or the size has changed), create a new one
 
     const pixelArray = image.voxelManager.getScalarData();
+
+    if (this.modality === 'US') {
+            spacing[1] = 1
+            spacing[0] = 1
+    }
+    
     this._createVTKImageData({
       origin,
       direction,


### PR DESCRIPTION
This PR standardizes ultrasound (US) image rendering by enforcing a pixel spacing of 1.0 x 1.0, independent of any region-based calibration metadata (e.g., Physical Delta X/Y from the Ultrasound Region Calibration Module).

DICOM-compliant ultrasound images typically do not define global Pixel Spacing. Instead, calibration is region-specific and intended for quantitative measurements, not geometric rescaling. Applying PhysicalDeltaX/Y to image rendering leads to incorrect aspect ratios, as spacing often varies per region and may encode non-spatial units (e.g., time, velocity).

The recommended practice is to use ultrasound pixel spacing (Physical Delta X/Y from the calibration data) only for measurement calibration, and not for altering the fundamental display of the image

Fixes:

- Prevents geometric distortion and rendering artifacts in US images
- Ensures visual consistency with scanner-native appearance
- Aligns rendering logic with DICOM guidelines and clinical interpretation standards

Measurement tools can still consume the region calibration for accurate physical units without affecting the visual presentation.

<img width="3102" height="1570" alt="CleanShot 2025-10-20 at 17 13 49@2x" src="https://github.com/user-attachments/assets/96ab1efd-2704-4771-a66a-1f621b16fccd" />

<img width="3092" height="1568" alt="CleanShot 2025-10-20 at 17 13 58@2x" src="https://github.com/user-attachments/assets/f5a4714e-0365-41e1-86ab-e7925dfd3114" />
