### PR TITLE
fix(AdvancedMagnifyTool): Exceptions are no longer thrown for the AdvancedMagnifyTool

### DIFF
--- a/packages/tools/src/stateManagement/segmentation/internalAddSegmentationRepresentation.ts
+++ b/packages/tools/src/stateManagement/segmentation/internalAddSegmentationRepresentation.ts
@@ -40,8 +40,8 @@ function internalAddSegmentationRepresentation(
       if (segmentKeys.length > 0) {
         firstSegmentIndex = segmentKeys.map((k) => Number(k)).sort()[0];
       }
+      setActiveSegmentIndex(segmentationId, firstSegmentIndex);
     }
-    setActiveSegmentIndex(segmentationId, firstSegmentIndex);
   }
 
   if (representationInput.type === SegmentationRepresentations.Contour) {

--- a/packages/tools/src/tools/AdvancedMagnifyTool.ts
+++ b/packages/tools/src/tools/AdvancedMagnifyTool.ts
@@ -68,7 +68,7 @@ const MAGNIFY_VIEWPORT_INITIAL_RADIUS = 125;
 const { Events: csEvents } = Enums;
 
 // TODO: find a better to identify segmentation actors
-const isSegmentation = (actor) => actor.uid !== actor.referencedId;
+const isSegmentation = (actor) => !!actor.representationUID;
 
 export type AutoPanCallbackData = {
   points: {
@@ -1355,7 +1355,7 @@ class AdvancedMagnifyViewport {
     const actors = sourceViewport.getActors();
     const volumeInputArray: Types.IVolumeInput[] = actors
       .filter((actor) => !isSegmentation(actor))
-      .map((actor) => ({ volumeId: actor.uid }));
+      .map((actor) => ({ volumeId: actor.referencedId }));
 
     magnifyViewport.setVolumes(volumeInputArray).then(() => {
       this._isViewportReady = true;


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
#2412

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
Upon investigation, it was determined that in part changes in #2322 contributed to #2412. So we only set the active segment index if there is a segmentation representation.

Further investigation showed that the AdvancedMagnifyTool has NOT been working on volume viewports for at least since February of 2025. In general, the click to apply the AdvancedMagnifyTool on a volume viewport would immediately throw an exception. So, in AdvancedMagnifyTool, we now use better detection for segmentation actors. Now the exception is gone, the magnify glass is displayed, but behaviour is still not equivalent to that for a stack viewport. A new issue will be logged soon.

See #2428.
<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
See #2412 
<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Windows 11<!--[e.g. Windows 10, macOS 10.15.4]"-->
- [x] "Node version: 23.9.0<!--[e.g. 16.14.0]"-->
- [x] "Browser: Chrome 141.0.7390.123
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
