### PR TITLE
fix(SplineROITool): Do not reset the cursor for the SplineROITool because it was never set in the first place.

### DIFF
--- a/packages/tools/src/tools/annotation/LivewireContourTool.ts
+++ b/packages/tools/src/tools/annotation/LivewireContourTool.ts
@@ -16,7 +16,6 @@ import {
 } from '../../drawingSvg';
 import { state } from '../../store/state';
 import { Events, KeyboardBindings, ChangeTypes } from '../../enums';
-import { resetElementCursor } from '../../cursors/elementCursor';
 import type {
   EventTypes,
   ToolHandle,
@@ -459,8 +458,6 @@ class LivewireContourTool extends ContourSegmentationBaseTool {
     this._deactivateModify(element);
     this._deactivateDraw(element);
 
-    resetElementCursor(element);
-
     const enabledElement = getEnabledElement(element);
 
     if (
@@ -813,7 +810,6 @@ class LivewireContourTool extends ContourSegmentationBaseTool {
     this.isDrawing = false;
     this._deactivateDraw(element);
     this._deactivateModify(element);
-    resetElementCursor(element);
 
     const { annotation, viewportIdsToRender, newAnnotation } = this.editData;
 

--- a/packages/tools/src/tools/annotation/SplineROITool.ts
+++ b/packages/tools/src/tools/annotation/SplineROITool.ts
@@ -24,7 +24,6 @@ import {
   KeyboardBindings,
   ChangeTypes,
 } from '../../enums';
-import { resetElementCursor } from '../../cursors/elementCursor';
 import type {
   Annotation,
   EventTypes,


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
When using the `SplineROITool` or any of its extensions (e.g. `SplineContourSegmentationTool`) immediately after using a tool that uses/sets `cursor:none` (e.g. `EllipticalROITool`), the mouse cursor disappears as soon as the last point of the spline is placed.
<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
The `SplineROITool` does not set a cursor when it is first applied, so there is no reason to reset the cursor when the tool is finished being applied. Thus the code was altered to no longer reset the cursor for the SplineROITool.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
1. Apply a tool (e.g. EllipticalROITool)
2. Switch to and apply the SplineROITool.
3. Ensure that the mouse cursor does not disappear.

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Windows 11<!--[e.g. Windows 10, macOS 10.15.4]"-->
- [x] "Node version: 23.9.0<!--[e.g. 16.14.0]"-->
- [x] "Browser: Chrome 142.0.7444.60
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
