### PR TITLE
feat(exports): decoder functions

### DIFF
--- a/packages/dicomImageLoader/src/index.ts
+++ b/packages/dicomImageLoader/src/index.ts
@@ -21,7 +21,7 @@ import { internal } from './imageLoader/internal/index';
 import * as constants from './constants';
 import type * as Types from './types';
 import { decodeImageFrame } from './decodeImageFrameWorker';
-import { initializers } from './shared/decoders';
+import { initializers, decoders } from './shared/decoders';
 
 const cornerstoneDICOMImageLoader = {
   constants,
@@ -44,6 +44,7 @@ const cornerstoneDICOMImageLoader = {
   internal,
   decodeImageFrame,
   initializers,
+  decoders,
 };
 
 export {
@@ -67,6 +68,7 @@ export {
   internal,
   decodeImageFrame,
   initializers,
+  decoders,
 };
 
 export type { Types };

--- a/packages/dicomImageLoader/src/shared/decoders/index.ts
+++ b/packages/dicomImageLoader/src/shared/decoders/index.ts
@@ -5,6 +5,16 @@ import { initialize as initializeJPEGBaseline12Bit } from './decodeJPEGBaseline1
 import { initialize as initializeJPEGLossless } from './decodeJPEGLossless';
 import { initialize as initLibjpegTurbo } from './decodeJPEGBaseline8Bit';
 
+import decodeHTJ2K from './decodeHTJ2K';
+import decodeJPEG2000 from './decodeJPEG2000';
+import decodeJPEGLS from './decodeJPEGLS';
+import decodeJPEGBaseline12Bit from './decodeJPEGBaseline12Bit-js';
+import decodeJPEGLossless from './decodeJPEGLossless';
+import decodeJPEGBaseline8Bit from './decodeJPEGBaseline8Bit';
+import decodeBigEndian from './decodeBigEndian';
+import decodeLittleEndian from './decodeLittleEndian';
+import decodeRLE from './decodeRLE';
+
 const initializers = {
   HTJ2K: initializeHTJ2K,
   JPEG2000: initializeJPEG2000,
@@ -14,4 +24,16 @@ const initializers = {
   JPEGBaseline8Bit: initLibjpegTurbo,
 };
 
-export { initializers };
+const decoders = {
+  HTJ2K: decodeHTJ2K,
+  JPEG2000: decodeJPEG2000,
+  JPEGLS: decodeJPEGLS,
+  JPEGBaseline12Bit: decodeJPEGBaseline12Bit,
+  JPEGLossless: decodeJPEGLossless,
+  JPEGBaseline8Bit: decodeJPEGBaseline8Bit,
+  BigEndian: decodeBigEndian,
+  LittleEndian: decodeLittleEndian,
+  RLE: decodeRLE,
+};
+
+export { initializers, decoders };


### PR DESCRIPTION
### Description

Adds exports for all decoders so they can be used externally if needed