### PR TITLE
fix(dicomImageLoader): :bug: Prevent error if ImagePositionPatient can not be read

### DIFF
--- a/packages/core/test/dicomImageLoader_wadouri_test.js
+++ b/packages/core/test/dicomImageLoader_wadouri_test.js
@@ -242,6 +242,9 @@ describe('dicomImageLoader - WADO-URI', () => {
        * causes the extraction to fail. This test ensures that even if
        * .PlanePositionSequence is empty, the ImagePlaneModule metadata is still
        * returned.
+       *
+       * The same can occur for other shared sequences such as
+       * PlaneOrientationSequence, PixelMeasuresSequence, etc.
        */
 
       // Use the US Multiframe Test Images
@@ -261,6 +264,14 @@ describe('dicomImageLoader - WADO-URI', () => {
           PlanePositionSequence: [],
         },
       ];
+      // modify the dataset to set
+      // SharedFunctionalGroupsSequence[0].PlaneOrientationSequence to be empty
+      dataset.SharedFunctionalGroupsSequence[0].PlaneOrientationSequence = [];
+      // modify the dataset to set
+      // SharedFunctionalGroupsSequence[0].PixelMeasuresSequence to be empty
+      dataset.SharedFunctionalGroupsSequence[0].PixelMeasuresSequence = [];
+
+      // Denaturalize the dataset back to dicom format
       const modifiedDicomData =
         dcmjs.data.DicomMetaDictionary.denaturalizeDataset(dataset);
       dicomDataset.dict = modifiedDicomData;

--- a/packages/dicomImageLoader/src/imageLoader/wadouri/metaData/extractPositioningFromDataset.ts
+++ b/packages/dicomImageLoader/src/imageLoader/wadouri/metaData/extractPositioningFromDataset.ts
@@ -1,12 +1,13 @@
-import getNumberValues from './getNumberValues';
+import type { DataSet } from 'dicom-parser';
 import isNMReconstructable from '../../isNMReconstructable';
+import getNumberValues from './getNumberValues';
 
 /**
  * Get a subpart of Image Type dicom tag defined by index
  * @param {*} dataSet
  * @param {*} index 0 based index of the subtype
  */
-function getImageTypeSubItemFromDataset(dataSet, index) {
+function getImageTypeSubItemFromDataset(dataSet: DataSet, index: number) {
   const imageType = dataSet.string('x00080008');
 
   if (imageType) {
@@ -25,8 +26,8 @@ function getImageTypeSubItemFromDataset(dataSet, index) {
  * @param {*} dataSet
  * @returns
  */
-function extractOrientationFromNMMultiframeDataset(dataSet) {
-  let imageOrientationPatient;
+function extractOrientationFromNMMultiframeDataset(dataSet: DataSet) {
+  let imageOrientationPatient: number[] | undefined;
   const modality = dataSet.string('x00080060');
 
   if (modality?.includes('NM')) {
@@ -52,8 +53,8 @@ function extractOrientationFromNMMultiframeDataset(dataSet) {
  * @param {*} dataSet
  * @returns
  */
-function extractPositionFromNMMultiframeDataset(dataSet) {
-  let imagePositionPatient;
+function extractPositionFromNMMultiframeDataset(dataSet: DataSet) {
+  let imagePositionPatient: number[] | undefined;
   const modality = dataSet.string('x00080060');
 
   if (modality?.includes('NM')) {
@@ -80,11 +81,14 @@ function extractPositionFromNMMultiframeDataset(dataSet) {
  * @param {*} dataSet
  * @returns
  */
-function extractOrientationFromDataset(dataSet) {
+function extractOrientationFromDataset(dataSet: DataSet) {
   let imageOrientationPatient = getNumberValues(dataSet, 'x00200037', 6);
 
   // Trying to get the orientation from the Plane Orientation Sequence
-  if (!imageOrientationPatient && dataSet.elements.x00209116) {
+  if (
+    !imageOrientationPatient &&
+    dataSet.elements.x00209116?.items?.[0]?.dataSet
+  ) {
     imageOrientationPatient = getNumberValues(
       dataSet.elements.x00209116.items[0].dataSet,
       'x00200037',
@@ -111,7 +115,7 @@ function extractOrientationFromDataset(dataSet) {
  * @param {*} dataSet
  * @returns
  */
-function extractPositionFromDataset(dataSet) {
+function extractPositionFromDataset(dataSet: DataSet) {
   let imagePositionPatient = getNumberValues(dataSet, 'x00200032', 3);
 
   // Trying to get the position from the Plane Position Sequence
@@ -141,12 +145,12 @@ function extractPositionFromDataset(dataSet) {
  * @param {*} dataSet
  * @returns
  */
-function extractSpacingFromDataset(dataSet) {
+function extractSpacingFromDataset(dataSet: DataSet) {
   let pixelSpacing = getNumberValues(dataSet, 'x00280030', 2);
 
   // If pixelSpacing not valid to this point, trying to get the spacing
   // from the Pixel Measures Sequence
-  if (!pixelSpacing && dataSet.elements.x00289110) {
+  if (!pixelSpacing && dataSet.elements.x00289110?.items?.[0]?.dataSet) {
     pixelSpacing = getNumberValues(
       dataSet.elements.x00289110.items[0].dataSet,
       'x00280030',
@@ -163,8 +167,8 @@ function extractSpacingFromDataset(dataSet) {
  * @param {*} dataSet
  * @returns
  */
-function extractSliceThicknessFromDataset(dataSet) {
-  let sliceThickness;
+function extractSliceThicknessFromDataset(dataSet: DataSet) {
+  let sliceThickness: number | undefined;
 
   if (dataSet.elements.x00180050) {
     sliceThickness = dataSet.floatString('x00180050');
@@ -181,9 +185,9 @@ function extractSliceThicknessFromDataset(dataSet) {
 }
 
 export {
-  getImageTypeSubItemFromDataset,
   extractOrientationFromDataset,
   extractPositionFromDataset,
-  extractSpacingFromDataset,
   extractSliceThicknessFromDataset,
+  extractSpacingFromDataset,
+  getImageTypeSubItemFromDataset,
 };


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

When loading multi-frame images using the wado-uri image loader, Image Position Patient is read from the SharedFunctionalGroupSequence or PerFrameFunctionalGroupSequence from either
`SharedFunctionalGroupsSequence[0].PlanePositionSequence[0].ImagePositionPatient` or `PerFrameFunctionalGroupSequence[:frameId].PlanePositionSequence[0].ImagePositionPatient`

However if `PlanePositionSequence` was empty an error is thrown by `extractPositionFromDataset` causing loading the image to fail.

This PR includes optional chaining checks to prevent an error in `extractPositionFromDataset` if ImagePositionPatient doesn't exist.

The PR also includes additional checks in `extractOrientationFromDataset`, `extractSliceThicknessFromDataset`, `extractSpacingFromDataset`. The tests added cover these changes as well.

### Changes & Results

calling `metadata.get(Enums.MetadataModules.IMAGE_PLANE, imageId)` previously would throw an error for some files. No error is now thrown.

### Testing

A unit test has been added for this change.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [X] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [X] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [N/A] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [X] "OS: MacOS 15.7.1"
- [X] "Node version:22"
- [X] "Browser: Brave"

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
