### PR TITLE
Fix Segment Opacity Update When Adjusting Fill in Segmentation Styles

### DIFF
--- a/packages/docs/docs/concepts/cornerstone-tools/segmentation/config.md
+++ b/packages/docs/docs/concepts/cornerstone-tools/segmentation/config.md
@@ -84,6 +84,34 @@ const hasCustomStyle = segmentation.hasCustomStyle({
 });
 ```
 
+## Restore style API
+
+The `createRestoreFunction` API enables temporary style modifications that can be safely reverted later.
+It is typically used to handle transient visual states, such as segment highlighting, without permanently altering configuration values.
+
+```js
+// Create a restore function capturing current style values
+const restore = segmentation.createRestoreFunction({
+  viewportId: 'viewport1',
+  segmentationId: 'segmentation1',
+  type: Enums.SegmentationRepresentations.Labelmap,
+  styleKeys: ['fillAlpha', 'outlineWidth'],
+});
+
+// Apply temporary changes
+segmentation.setStyle(
+  {
+    viewportId: 'viewport1',
+    segmentationId: 'segmentation1',
+    type: Enums.SegmentationRepresentations.Labelmap,
+  },
+  { fillAlpha: 1.0, outlineWidth: 6 }
+);
+
+// Restore previous values when done
+restore();
+```
+
 ### Inactive Segmentations
 
 The rendering of inactive segmentations is now controlled per viewport:

--- a/packages/docs/docs/concepts/cornerstone-tools/segmentation/config.md
+++ b/packages/docs/docs/concepts/cornerstone-tools/segmentation/config.md
@@ -84,34 +84,6 @@ const hasCustomStyle = segmentation.hasCustomStyle({
 });
 ```
 
-## Restore style API
-
-The `createRestoreFunction` API enables temporary style modifications that can be safely reverted later.
-It is typically used to handle transient visual states, such as segment highlighting, without permanently altering configuration values.
-
-```js
-// Create a restore function capturing current style values
-const restore = segmentation.createRestoreFunction({
-  viewportId: 'viewport1',
-  segmentationId: 'segmentation1',
-  type: Enums.SegmentationRepresentations.Labelmap,
-  styleKeys: ['fillAlpha', 'outlineWidth'],
-});
-
-// Apply temporary changes
-segmentation.setStyle(
-  {
-    viewportId: 'viewport1',
-    segmentationId: 'segmentation1',
-    type: Enums.SegmentationRepresentations.Labelmap,
-  },
-  { fillAlpha: 1.0, outlineWidth: 6 }
-);
-
-// Restore previous values when done
-restore();
-```
-
 ### Inactive Segmentations
 
 The rendering of inactive segmentations is now controlled per viewport:

--- a/packages/tools/src/stateManagement/segmentation/SegmentationStyle.ts
+++ b/packages/tools/src/stateManagement/segmentation/SegmentationStyle.ts
@@ -12,7 +12,30 @@ import { utilities } from '@cornerstonejs/core';
 
 export type RepresentationStyle = LabelmapStyle | ContourStyle | SurfaceStyle;
 
+export type RepresentationStyleKeys =
+  | keyof LabelmapStyle
+  | keyof ContourStyle
+  | keyof SurfaceStyle;
+
 export type BaseRepresentationStyle = BaseLabelmapStyle | BaseContourStyle;
+
+type StyleSpecifier = {
+  type: SegmentationRepresentations;
+  segmentIndex?: number;
+  segmentationId?: string;
+  viewportId?: string;
+};
+
+enum ConfigLevel {
+  Default = 0,
+  Global = 1,
+  Segmentation = 2,
+  Viewport = 4,
+}
+interface RestoreEntry {
+  value: unknown;
+  level: ConfigLevel;
+}
 
 interface SegmentationStyleConfig {
   global: {
@@ -44,6 +67,8 @@ interface SegmentationStyleConfig {
     };
   };
 }
+
+const ALL_SEGMENTATIONS_KEY = '__allSegmentations__';
 
 /**
  * This class handles the configuration of segmentation styles. It supports
@@ -84,15 +109,7 @@ class SegmentationStyle {
    * @param specifier.segmentIndex - Optional. The index of the specific segment to style.
    * @param styles - The styles to set.
    */
-  setStyle(
-    specifier: {
-      type: SegmentationRepresentations;
-      viewportId?: string;
-      segmentationId?: string;
-      segmentIndex?: number;
-    },
-    styles: RepresentationStyle
-  ): void {
+  setStyle(specifier: StyleSpecifier, styles: RepresentationStyle): void {
     const { viewportId, segmentationId, type, segmentIndex } = specifier;
 
     const currentStyles = this.getStyle(specifier);
@@ -155,7 +172,6 @@ class SegmentationStyle {
         }
       } else {
         // Viewport-specific style for all segmentations of a type
-        const ALL_SEGMENTATIONS_KEY = '__allSegmentations__';
         if (!representations[ALL_SEGMENTATIONS_KEY]) {
           representations[ALL_SEGMENTATIONS_KEY] = {};
         }
@@ -236,12 +252,7 @@ class SegmentationStyle {
    * @param specifier.segmentIndex - Optional. The index of the specific segment.
    * @returns An object containing the combined style and renderInactiveSegmentations flag for the viewport.
    */
-  getStyle(specifier: {
-    viewportId?: string;
-    segmentationId?: string;
-    type?: SegmentationRepresentations;
-    segmentIndex?: number;
-  }): RepresentationStyle {
+  getStyle(specifier: StyleSpecifier): RepresentationStyle {
     const { viewportId, segmentationId, type, segmentIndex } = specifier;
     let combinedStyle = this.getDefaultStyle(type);
     let renderInactiveSegmentations = false;
@@ -281,16 +292,15 @@ class SegmentationStyle {
         this.config.viewportsStyle[viewportId].renderInactiveSegmentations;
 
       // Apply viewport-specific styles for all segmentations of this representation type
-      const allSegmentationsKey = '__allSegmentations__';
       if (
         this.config.viewportsStyle[viewportId].representations[
-          allSegmentationsKey
+          ALL_SEGMENTATIONS_KEY
         ]?.[type]
       ) {
         combinedStyle = {
           ...combinedStyle,
           ...this.config.viewportsStyle[viewportId].representations[
-            allSegmentationsKey
+            ALL_SEGMENTATIONS_KEY
           ][type].allSegments,
         };
       }
@@ -432,17 +442,217 @@ class SegmentationStyle {
    * @param specifier - The specifier object containing viewportId, segmentationId, type, and segmentIndex.
    * @returns True if there is a non-global style, false otherwise.
    */
-  hasCustomStyle(specifier: {
-    viewportId?: string;
-    segmentationId?: string;
-    type?: SegmentationRepresentations;
-    segmentIndex?: number;
-  }): boolean {
+  hasCustomStyle(specifier: StyleSpecifier): boolean {
     const { type } = specifier;
     const style = this.getStyle(specifier);
     // Perform a deep comparison between the style and the default style
     const defaultStyle = this.getDefaultStyle(type);
     return !utilities.deepEqual(style, defaultStyle);
+  }
+
+  /**
+   * Creates a restore function that captures the current effective values of
+   * Specific style keys and their config levels.
+   * When the returned function is invoked, it restores the stored configuration by
+   * reapplying the captured values at their stored config levels and removing override configs.
+   *
+   * @param specifier - An object containing the specifications for the segmentation style.
+   * @param styleKeys - List of style property keys to capture and later restore.
+   * @returns A function that restores captured style values to their original levels.
+   */
+  createRestoreFunction(
+    specifier: StyleSpecifier,
+    styleKeys: RepresentationStyleKeys[]
+  ): () => void {
+    const restoreMap = new Map<RepresentationStyleKeys, RestoreEntry>();
+
+    // Capture current values and levels
+    for (const key of styleKeys) {
+      const entry = this._getCurrentValueForRestore(specifier, key);
+      restoreMap.set(key, entry);
+    }
+
+    return () => {
+      for (const [key, { level, value }] of restoreMap.entries()) {
+        this._removeStyleFromHigherLevels(specifier, key, level);
+        this._applyStyleValueAtLevel(specifier, key, level, value);
+      }
+    };
+  }
+
+  /**
+   * Removes a style key from configuration levels higher than the target restore level.
+   * This ensures that restored values at their original level are not overridden
+   * by higher-priority configs.
+   */
+  private _removeStyleFromHigherLevels(
+    specifier: StyleSpecifier,
+    key: RepresentationStyleKeys,
+    restoreLevel: ConfigLevel
+  ): void {
+    const { viewportId, segmentationId, segmentIndex, type } = specifier;
+    // Remove only from higher levels
+    if (restoreLevel < ConfigLevel.Viewport) {
+      const viewportConfig =
+        this.config.viewportsStyle?.[viewportId]?.representations?.[
+          segmentationId ?? ALL_SEGMENTATIONS_KEY
+        ]?.[type];
+
+      if (viewportConfig) {
+        const target =
+          segmentIndex === undefined
+            ? viewportConfig.allSegments
+            : viewportConfig.perSegment?.[segmentIndex];
+
+        if (target && key in target) {
+          delete target[key];
+        }
+      }
+    }
+    if (restoreLevel < ConfigLevel.Segmentation) {
+      const segConfig = this.config.segmentations?.[segmentationId]?.[type];
+      if (segConfig) {
+        const target =
+          segmentIndex === undefined
+            ? segConfig.allSegments
+            : segConfig.perSegment?.[segmentIndex];
+
+        if (target && key in target) {
+          delete target[key];
+        }
+      }
+    }
+    if (restoreLevel < ConfigLevel.Global) {
+      delete this.config.global?.[type]?.[key];
+    }
+  }
+
+  /**
+   * Applies a captured value back to its original configuration level.
+   */
+  private _applyStyleValueAtLevel(
+    specifier: StyleSpecifier,
+    key: RepresentationStyleKeys,
+    level: ConfigLevel,
+    value: unknown
+  ): void {
+    const { viewportId, segmentationId, segmentIndex, type } = specifier;
+
+    if (level === ConfigLevel.Default) {
+      return;
+    }
+    const specifierToPass: StyleSpecifier = { type, segmentIndex };
+
+    if (level & ConfigLevel.Viewport && viewportId) {
+      specifierToPass.viewportId = viewportId;
+      if (segmentationId) {
+        specifierToPass.segmentationId = segmentationId;
+      }
+    } else if (level & ConfigLevel.Segmentation && segmentationId) {
+      specifierToPass.segmentationId = segmentationId;
+    }
+
+    if (value !== undefined) {
+      this.setStyle(specifierToPass, { [key]: value });
+    }
+  }
+
+  /**
+   * Retrieves the current style value and its configuration level.
+   * Checks hierarchy: viewport → segmentation → global → default.
+   */
+  private _getCurrentValueForRestore(
+    specifier: StyleSpecifier,
+    key: RepresentationStyleKeys
+  ): RestoreEntry {
+    const { segmentationId, segmentIndex, type } = specifier;
+    // Viewport-level lookup
+    const viewportValue = this._getViewportLevelValue(specifier, key);
+    if (viewportValue) {
+      return viewportValue;
+    }
+
+    // Segmentation-level lookup
+    const segmentationValue = this._getSegmentationLevelValue(
+      { segmentationId, segmentIndex, type },
+      key
+    );
+    if (segmentationValue) {
+      return segmentationValue;
+    }
+
+    // Global-level lookup
+    const globalValue = this._getGlobalLevelValue(key, type);
+    if (globalValue) {
+      return globalValue;
+    }
+
+    // Default fallback
+    return {
+      level: ConfigLevel.Default,
+      value: this.getDefaultStyle(type)?.[key],
+    };
+  }
+
+  /**
+   * Returns the style value from the viewport-level configuration, if present.
+   */
+  private _getViewportLevelValue(
+    { viewportId, segmentationId, segmentIndex, type }: StyleSpecifier,
+    key: RepresentationStyleKeys
+  ): RestoreEntry | undefined {
+    const reps = this.config.viewportsStyle[viewportId]?.representations;
+    if (!reps) {
+      return;
+    }
+
+    const segCfg = segmentationId ? reps[segmentationId]?.[type] : undefined;
+
+    const value =
+      segCfg?.perSegment?.[segmentIndex]?.[key] ??
+      segCfg?.allSegments?.[key] ??
+      reps[ALL_SEGMENTATIONS_KEY]?.[type]?.allSegments?.[key];
+
+    if (value !== undefined) {
+      return { level: ConfigLevel.Viewport, value };
+    }
+  }
+
+  /**
+   * Returns the style value from the segmentation-level configuration, if present.
+   */
+  private _getSegmentationLevelValue(
+    { segmentationId, segmentIndex, type }: StyleSpecifier,
+    key: RepresentationStyleKeys
+  ): RestoreEntry | undefined {
+    const segCfg = segmentationId
+      ? this.config.segmentations?.[segmentationId]?.[type]
+      : undefined;
+
+    if (!segCfg) {
+      return;
+    }
+
+    const value =
+      segCfg.perSegment?.[segmentIndex]?.[key] ?? segCfg.allSegments?.[key];
+
+    if (value !== undefined) {
+      return { level: ConfigLevel.Segmentation, value };
+    }
+  }
+
+  /**
+   * Returns the style value from the global-level configuration, if present.
+   */
+  private _getGlobalLevelValue(
+    key: RepresentationStyleKeys,
+    type?: SegmentationRepresentations
+  ): RestoreEntry | undefined {
+    const globalCfg = this.config.global?.[type];
+
+    if (globalCfg?.[key] !== undefined) {
+      return { level: ConfigLevel.Global, value: globalCfg[key] };
+    }
   }
 }
 

--- a/packages/tools/src/stateManagement/segmentation/SegmentationStyle.ts
+++ b/packages/tools/src/stateManagement/segmentation/SegmentationStyle.ts
@@ -109,7 +109,15 @@ class SegmentationStyle {
    * @param specifier.segmentIndex - Optional. The index of the specific segment to style.
    * @param styles - The styles to set.
    */
-  setStyle(specifier: StyleSpecifier, styles: RepresentationStyle): void {
+  setStyle(
+    specifier: {
+      type: SegmentationRepresentations;
+      viewportId?: string;
+      segmentationId?: string;
+      segmentIndex?: number;
+    },
+    styles: RepresentationStyle
+  ): void {
     const { viewportId, segmentationId, type, segmentIndex } = specifier;
 
     const currentStyles = this.getStyle(specifier);
@@ -252,7 +260,12 @@ class SegmentationStyle {
    * @param specifier.segmentIndex - Optional. The index of the specific segment.
    * @returns An object containing the combined style and renderInactiveSegmentations flag for the viewport.
    */
-  getStyle(specifier: StyleSpecifier): RepresentationStyle {
+  getStyle(specifier: {
+    viewportId?: string;
+    segmentationId?: string;
+    type?: SegmentationRepresentations;
+    segmentIndex?: number;
+  }): RepresentationStyle {
     const { viewportId, segmentationId, type, segmentIndex } = specifier;
     let combinedStyle = this.getDefaultStyle(type);
     let renderInactiveSegmentations = false;

--- a/packages/tools/src/stateManagement/segmentation/SegmentationStyle.ts
+++ b/packages/tools/src/stateManagement/segmentation/SegmentationStyle.ts
@@ -82,6 +82,7 @@ class SegmentationStyle {
    * @param specifier.viewportId - Optional. The ID of the viewport.
    * @param specifier.segmentationId - Optional. The ID of the segmentation.
    * @param specifier.segmentIndex - Optional. The index of the specific segment to style.
+   * @param specifier.merge - Whether to merge the provided styles with existing ones. Defaults to `true`
    * @param styles - The styles to set.
    */
   setStyle(
@@ -90,28 +91,30 @@ class SegmentationStyle {
       viewportId?: string;
       segmentationId?: string;
       segmentIndex?: number;
+      merge?: boolean;
     },
     styles: RepresentationStyle
   ): void {
-    const { viewportId, segmentationId, type, segmentIndex } = specifier;
+    const {
+      viewportId,
+      segmentationId,
+      type,
+      segmentIndex,
+      merge = true,
+    } = specifier;
 
     const currentStyles = this.getStyle(specifier);
+    const mergedStyles = merge ? { ...currentStyles, ...styles } : styles;
 
     let updatedStyles: RepresentationStyle;
 
     if (!viewportId && !segmentationId) {
       // Global style setting
-      updatedStyles = {
-        ...currentStyles,
-        ...styles,
-      };
-    } else {
+      updatedStyles = mergedStyles;
+    } else if (merge) {
       // Per segmentation or per viewport style setting
       updatedStyles = this.copyActiveToInactiveIfNotProvided(
-        {
-          ...currentStyles,
-          ...styles,
-        },
+        mergedStyles,
         type
       );
     }

--- a/packages/tools/src/stateManagement/segmentation/SegmentationStyle.ts
+++ b/packages/tools/src/stateManagement/segmentation/SegmentationStyle.ts
@@ -12,30 +12,7 @@ import { utilities } from '@cornerstonejs/core';
 
 export type RepresentationStyle = LabelmapStyle | ContourStyle | SurfaceStyle;
 
-export type RepresentationStyleKeys =
-  | keyof LabelmapStyle
-  | keyof ContourStyle
-  | keyof SurfaceStyle;
-
 export type BaseRepresentationStyle = BaseLabelmapStyle | BaseContourStyle;
-
-type StyleSpecifier = {
-  type: SegmentationRepresentations;
-  segmentIndex?: number;
-  segmentationId?: string;
-  viewportId?: string;
-};
-
-enum ConfigLevel {
-  Default = 0,
-  Global = 1,
-  Segmentation = 2,
-  Viewport = 4,
-}
-interface RestoreEntry {
-  value: unknown;
-  level: ConfigLevel;
-}
 
 interface SegmentationStyleConfig {
   global: {
@@ -67,8 +44,6 @@ interface SegmentationStyleConfig {
     };
   };
 }
-
-const ALL_SEGMENTATIONS_KEY = '__allSegmentations__';
 
 /**
  * This class handles the configuration of segmentation styles. It supports
@@ -180,6 +155,7 @@ class SegmentationStyle {
         }
       } else {
         // Viewport-specific style for all segmentations of a type
+        const ALL_SEGMENTATIONS_KEY = '__allSegmentations__';
         if (!representations[ALL_SEGMENTATIONS_KEY]) {
           representations[ALL_SEGMENTATIONS_KEY] = {};
         }
@@ -305,15 +281,16 @@ class SegmentationStyle {
         this.config.viewportsStyle[viewportId].renderInactiveSegmentations;
 
       // Apply viewport-specific styles for all segmentations of this representation type
+      const allSegmentationsKey = '__allSegmentations__';
       if (
         this.config.viewportsStyle[viewportId].representations[
-          ALL_SEGMENTATIONS_KEY
+          allSegmentationsKey
         ]?.[type]
       ) {
         combinedStyle = {
           ...combinedStyle,
           ...this.config.viewportsStyle[viewportId].representations[
-            ALL_SEGMENTATIONS_KEY
+            allSegmentationsKey
           ][type].allSegments,
         };
       }
@@ -466,211 +443,6 @@ class SegmentationStyle {
     // Perform a deep comparison between the style and the default style
     const defaultStyle = this.getDefaultStyle(type);
     return !utilities.deepEqual(style, defaultStyle);
-  }
-
-  /**
-   * Creates a restore function that captures the current effective values of
-   * Specific style keys and their config levels.
-   * When the returned function is invoked, it restores the stored configuration by
-   * reapplying the captured values at their stored config levels and removing override configs.
-   *
-   * @param specifier - An object containing the specifications for the segmentation style.
-   * @param styleKeys - List of style property keys to capture and later restore.
-   * @returns A function that restores captured style values to their original levels.
-   */
-  createRestoreFunction(
-    specifier: StyleSpecifier,
-    styleKeys: RepresentationStyleKeys[]
-  ): () => void {
-    const restoreMap = new Map<RepresentationStyleKeys, RestoreEntry>();
-
-    // Capture current values and levels
-    for (const key of styleKeys) {
-      const entry = this._getCurrentValueForRestore(specifier, key);
-      restoreMap.set(key, entry);
-    }
-
-    return () => {
-      for (const [key, { level, value }] of restoreMap.entries()) {
-        this._removeStyleFromHigherLevels(specifier, key, level);
-        this._applyStyleValueAtLevel(specifier, key, level, value);
-      }
-    };
-  }
-
-  /**
-   * Removes a style key from configuration levels higher than the target restore level.
-   * This ensures that restored values at their original level are not overridden
-   * by higher-priority configs.
-   */
-  private _removeStyleFromHigherLevels(
-    specifier: StyleSpecifier,
-    key: RepresentationStyleKeys,
-    restoreLevel: ConfigLevel
-  ): void {
-    const { viewportId, segmentationId, segmentIndex, type } = specifier;
-    // Remove only from higher levels
-    if (restoreLevel < ConfigLevel.Viewport) {
-      const viewportConfig =
-        this.config.viewportsStyle?.[viewportId]?.representations?.[
-          segmentationId ?? ALL_SEGMENTATIONS_KEY
-        ]?.[type];
-
-      if (viewportConfig) {
-        const target =
-          segmentIndex === undefined
-            ? viewportConfig.allSegments
-            : viewportConfig.perSegment?.[segmentIndex];
-
-        if (target && key in target) {
-          delete target[key];
-        }
-      }
-    }
-    if (restoreLevel < ConfigLevel.Segmentation) {
-      const segConfig = this.config.segmentations?.[segmentationId]?.[type];
-      if (segConfig) {
-        const target =
-          segmentIndex === undefined
-            ? segConfig.allSegments
-            : segConfig.perSegment?.[segmentIndex];
-
-        if (target && key in target) {
-          delete target[key];
-        }
-      }
-    }
-    if (restoreLevel < ConfigLevel.Global) {
-      delete this.config.global?.[type]?.[key];
-    }
-  }
-
-  /**
-   * Applies a captured value back to its original configuration level.
-   */
-  private _applyStyleValueAtLevel(
-    specifier: StyleSpecifier,
-    key: RepresentationStyleKeys,
-    level: ConfigLevel,
-    value: unknown
-  ): void {
-    const { viewportId, segmentationId, segmentIndex, type } = specifier;
-
-    if (level === ConfigLevel.Default) {
-      return;
-    }
-    const specifierToPass: StyleSpecifier = { type, segmentIndex };
-
-    if (level & ConfigLevel.Viewport && viewportId) {
-      specifierToPass.viewportId = viewportId;
-      if (segmentationId) {
-        specifierToPass.segmentationId = segmentationId;
-      }
-    } else if (level & ConfigLevel.Segmentation && segmentationId) {
-      specifierToPass.segmentationId = segmentationId;
-    }
-
-    if (value !== undefined) {
-      this.setStyle(specifierToPass, { [key]: value });
-    }
-  }
-
-  /**
-   * Retrieves the current style value and its configuration level.
-   * Checks hierarchy: viewport → segmentation → global → default.
-   */
-  private _getCurrentValueForRestore(
-    specifier: StyleSpecifier,
-    key: RepresentationStyleKeys
-  ): RestoreEntry {
-    const { segmentationId, segmentIndex, type } = specifier;
-    // Viewport-level lookup
-    const viewportValue = this._getViewportLevelValue(specifier, key);
-    if (viewportValue) {
-      return viewportValue;
-    }
-
-    // Segmentation-level lookup
-    const segmentationValue = this._getSegmentationLevelValue(
-      { segmentationId, segmentIndex, type },
-      key
-    );
-    if (segmentationValue) {
-      return segmentationValue;
-    }
-
-    // Global-level lookup
-    const globalValue = this._getGlobalLevelValue(key, type);
-    if (globalValue) {
-      return globalValue;
-    }
-
-    // Default fallback
-    return {
-      level: ConfigLevel.Default,
-      value: this.getDefaultStyle(type)?.[key],
-    };
-  }
-
-  /**
-   * Returns the style value from the viewport-level configuration, if present.
-   */
-  private _getViewportLevelValue(
-    { viewportId, segmentationId, segmentIndex, type }: StyleSpecifier,
-    key: RepresentationStyleKeys
-  ): RestoreEntry | undefined {
-    const reps = this.config.viewportsStyle[viewportId]?.representations;
-    if (!reps) {
-      return;
-    }
-
-    const segCfg = segmentationId ? reps[segmentationId]?.[type] : undefined;
-
-    const value =
-      segCfg?.perSegment?.[segmentIndex]?.[key] ??
-      segCfg?.allSegments?.[key] ??
-      reps[ALL_SEGMENTATIONS_KEY]?.[type]?.allSegments?.[key];
-
-    if (value !== undefined) {
-      return { level: ConfigLevel.Viewport, value };
-    }
-  }
-
-  /**
-   * Returns the style value from the segmentation-level configuration, if present.
-   */
-  private _getSegmentationLevelValue(
-    { segmentationId, segmentIndex, type }: StyleSpecifier,
-    key: RepresentationStyleKeys
-  ): RestoreEntry | undefined {
-    const segCfg = segmentationId
-      ? this.config.segmentations?.[segmentationId]?.[type]
-      : undefined;
-
-    if (!segCfg) {
-      return;
-    }
-
-    const value =
-      segCfg.perSegment?.[segmentIndex]?.[key] ?? segCfg.allSegments?.[key];
-
-    if (value !== undefined) {
-      return { level: ConfigLevel.Segmentation, value };
-    }
-  }
-
-  /**
-   * Returns the style value from the global-level configuration, if present.
-   */
-  private _getGlobalLevelValue(
-    key: RepresentationStyleKeys,
-    type?: SegmentationRepresentations
-  ): RestoreEntry | undefined {
-    const globalCfg = this.config.global?.[type];
-
-    if (globalCfg?.[key] !== undefined) {
-      return { level: ConfigLevel.Global, value: globalCfg[key] };
-    }
   }
 }
 

--- a/packages/tools/src/stateManagement/segmentation/SegmentationStyle.ts
+++ b/packages/tools/src/stateManagement/segmentation/SegmentationStyle.ts
@@ -455,7 +455,12 @@ class SegmentationStyle {
    * @param specifier - The specifier object containing viewportId, segmentationId, type, and segmentIndex.
    * @returns True if there is a non-global style, false otherwise.
    */
-  hasCustomStyle(specifier: StyleSpecifier): boolean {
+  hasCustomStyle(specifier: {
+    viewportId?: string;
+    segmentationId?: string;
+    type?: SegmentationRepresentations;
+    segmentIndex?: number;
+  }): boolean {
     const { type } = specifier;
     const style = this.getStyle(specifier);
     // Perform a deep comparison between the style and the default style

--- a/packages/tools/src/stateManagement/segmentation/SegmentationStyle.ts
+++ b/packages/tools/src/stateManagement/segmentation/SegmentationStyle.ts
@@ -82,8 +82,8 @@ class SegmentationStyle {
    * @param specifier.viewportId - Optional. The ID of the viewport.
    * @param specifier.segmentationId - Optional. The ID of the segmentation.
    * @param specifier.segmentIndex - Optional. The index of the specific segment to style.
-   * @param specifier.merge - Whether to merge the provided styles with existing ones. Defaults to `true`
    * @param styles - The styles to set.
+   * @param merge - If `true` (default), merges the new styles with existing ones; otherwise, replaces them entirely.
    */
   setStyle(
     specifier: {
@@ -91,17 +91,11 @@ class SegmentationStyle {
       viewportId?: string;
       segmentationId?: string;
       segmentIndex?: number;
-      merge?: boolean;
     },
-    styles: RepresentationStyle
+    styles: RepresentationStyle,
+    merge: boolean = true
   ): void {
-    const {
-      viewportId,
-      segmentationId,
-      type,
-      segmentIndex,
-      merge = true,
-    } = specifier;
+    const { viewportId, segmentationId, type, segmentIndex } = specifier;
 
     const currentStyles = this.getStyle(specifier);
     const mergedStyles = merge ? { ...currentStyles, ...styles } : styles;

--- a/packages/tools/src/stateManagement/segmentation/config/styleHelpers.ts
+++ b/packages/tools/src/stateManagement/segmentation/config/styleHelpers.ts
@@ -13,6 +13,7 @@ type BaseSpecifier = {
   viewportId?: string;
   segmentationId?: string;
   segmentIndex?: number;
+  merge?: boolean;
 };
 
 type SpecifierWithType<T extends SegmentationRepresentations> =

--- a/packages/tools/src/stateManagement/segmentation/config/styleHelpers.ts
+++ b/packages/tools/src/stateManagement/segmentation/config/styleHelpers.ts
@@ -6,7 +6,10 @@ import { getSegmentations } from '../getSegmentations';
 import { getViewportSegmentations } from '../getViewportSegmentations';
 import { triggerSegmentationRender } from '../SegmentationRenderingEngine';
 import { segmentationStyle } from '../SegmentationStyle';
-import type { RepresentationStyle } from '../SegmentationStyle';
+import type {
+  RepresentationStyle,
+  RepresentationStyleKeys,
+} from '../SegmentationStyle';
 import { triggerSegmentationRepresentationModified } from '../triggerSegmentationEvents';
 
 type BaseSpecifier = {
@@ -131,6 +134,18 @@ function hasCustomStyle(specifier: {
   return segmentationStyle.hasCustomStyle(specifier);
 }
 
+function createRestoreFunction(
+  specifier: {
+    viewportId?: string;
+    segmentationId?: string;
+    type: SegmentationRepresentations;
+    segmentIndex?: number;
+  },
+  styleKeys: RepresentationStyleKeys[]
+): () => void {
+  return segmentationStyle.createRestoreFunction(specifier, styleKeys);
+}
+
 export {
   getStyle,
   setStyle,
@@ -138,4 +153,5 @@ export {
   getRenderInactiveSegmentations,
   resetToGlobalStyle,
   hasCustomStyle,
+  createRestoreFunction,
 };

--- a/packages/tools/src/stateManagement/segmentation/config/styleHelpers.ts
+++ b/packages/tools/src/stateManagement/segmentation/config/styleHelpers.ts
@@ -13,7 +13,6 @@ type BaseSpecifier = {
   viewportId?: string;
   segmentationId?: string;
   segmentIndex?: number;
-  merge?: boolean;
 };
 
 type SpecifierWithType<T extends SegmentationRepresentations> =
@@ -48,16 +47,19 @@ function getStyle(
  * Set the style for a given segmentation representation.
  * @param specifier The specifier object containing the viewportId, segmentationId, type, and segmentIndex.
  * @param style The style to set for the given segmentation representation.
+ * @param merge - If `true` (default), merges the new styles with existing ones; otherwise, replaces them entirely.
  */
 function setStyle<T extends SegmentationRepresentations>(
   specifier: SpecifierWithType<T>,
-  style: StyleForType<T>
+  style: StyleForType<T>,
+  merge?: boolean
 ): void;
 function setStyle(
   specifier: BaseSpecifier & { type: SegmentationRepresentations },
-  style: RepresentationStyle
+  style: RepresentationStyle,
+  merge?: boolean
 ): void {
-  segmentationStyle.setStyle(specifier, style);
+  segmentationStyle.setStyle(specifier, style, merge);
 
   // if only type is provided, we need to trigger a render for all segmentations in the viewport
   if (!specifier.viewportId && !specifier.segmentationId) {

--- a/packages/tools/src/stateManagement/segmentation/config/styleHelpers.ts
+++ b/packages/tools/src/stateManagement/segmentation/config/styleHelpers.ts
@@ -6,10 +6,7 @@ import { getSegmentations } from '../getSegmentations';
 import { getViewportSegmentations } from '../getViewportSegmentations';
 import { triggerSegmentationRender } from '../SegmentationRenderingEngine';
 import { segmentationStyle } from '../SegmentationStyle';
-import type {
-  RepresentationStyle,
-  RepresentationStyleKeys,
-} from '../SegmentationStyle';
+import type { RepresentationStyle } from '../SegmentationStyle';
 import { triggerSegmentationRepresentationModified } from '../triggerSegmentationEvents';
 
 type BaseSpecifier = {
@@ -134,18 +131,6 @@ function hasCustomStyle(specifier: {
   return segmentationStyle.hasCustomStyle(specifier);
 }
 
-function createRestoreFunction(
-  specifier: {
-    viewportId?: string;
-    segmentationId?: string;
-    type: SegmentationRepresentations;
-    segmentIndex?: number;
-  },
-  styleKeys: RepresentationStyleKeys[]
-): () => void {
-  return segmentationStyle.createRestoreFunction(specifier, styleKeys);
-}
-
 export {
   getStyle,
   setStyle,
@@ -153,5 +138,4 @@ export {
   getRenderInactiveSegmentations,
   resetToGlobalStyle,
   hasCustomStyle,
-  createRestoreFunction,
 };


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
This PR addresses the issue where, after clicking on segments and adjusting the segmentation's fill, the opacity of the clicked segments doesn't update as expected. The root cause was that the fillAlpha value was being applied at the per-segment level during highlighting, but the corresponding per-segment entry in the config was not being cleared afterward. As a result, the global-level opacity (fillAlpha) setting was not taking effect correctly.
 
Fixes: https://github.com/OHIF/Viewers/issues/4977

This PR is incorporated by [FlyWheel.io](https://flywheel.io/)

Dependent PR : https://github.com/OHIF/Viewers/pull/4978

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

- Added a new style restoration mechanism for segmentation configurations.
- Implemented createRestoreFunction to capture and restore style values for specific keys.
- Added internal helpers:
      - `_removeStyleFromHigherLevels` — Removes higher-level overrides before restoration.
      - `_applyStyleValueAtLevel` — Reapplies captured style values at their original configuration level.
      - `_getCurrentValueForRestore` — Determines current style value and its hierarchy level.
      - `_getViewportLevelValue, _getSegmentationLevelValue, _getGlobalLevelValue` — Level-specific lookup helpers.

Before

- Clicking on a segment applied highlight at the per-segment level, but opacity was applied at the global level.
- This caused mismatches where opacity updates were not reflected correctly after interaction.

After

- Highlight and opacity changes now behave consistently across interactions.
- Temporary style overrides (e.g., during highlight) are cleaned up when restored.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

1. Locally link the OHIF `abhijith-trenser:fix/segmentation-fill-not-working-after-loading-seg-and-click-segments` branch with the cornerstone3D branch `Devu-trenser:fix/seg-fill-not-working-after-segment-click`.
2. Launch the study that contains segmentation and load it or draw new segmentation.
3. Click on some segments.
4. Adjust the Fill in the segmentation settings.
5. Verify that the opacity of the clicked segment is correctly changing.


<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Linux 6.11 Ubuntu 24.10 24.10 (Oracular Oriole)
- [x] "Node version: 22.16.0
- [x] "Browser: Chrome: 139.0.7258.154

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
