### PR TITLE
fix(WSIViewport): add event listener for annotation removal

### DIFF
--- a/packages/core/src/RenderingEngine/WSIViewport.ts
+++ b/packages/core/src/RenderingEngine/WSIViewport.ts
@@ -1,6 +1,5 @@
 import { vec3, mat4 } from 'gl-matrix';
-import EVENTS from '../enums/Events';
-import MetadataModules from '../enums/MetadataModules';
+import { Events as EVENTS, MetadataModules } from '../enums';
 import type {
   WSIViewportProperties,
   Point3,
@@ -25,6 +24,7 @@ import imageIdToURI from '../utilities/imageIdToURI';
 
 let WSIUtilFunctions = null;
 const EVENT_POSTRENDER = 'postrender';
+const ANNOTATION_REMOVED = 'CORNERSTONE_TOOLS_ANNOTATION_REMOVED';
 /**
  * A viewport which shows a microscopy view using the dicom-microscopy-viewer
  * library.  This viewport accepts standard CS3D annotations, and responds
@@ -171,7 +171,7 @@ class WSIViewport extends Viewport {
       this.elementDisabledHandler
     );
     eventTarget.addEventListener(
-      EVENTS.ANNOTATION_REMOVED,
+      ANNOTATION_REMOVED,
       this.annotationRemovedListener
     );
   }
@@ -182,7 +182,7 @@ class WSIViewport extends Viewport {
       this.elementDisabledHandler
     );
     eventTarget.removeEventListener(
-      EVENTS.ANNOTATION_REMOVED,
+      ANNOTATION_REMOVED,
       this.annotationRemovedListener
     );
   }

--- a/packages/core/src/enums/Events.ts
+++ b/packages/core/src/enums/Events.ts
@@ -74,10 +74,6 @@ enum Events {
    */
   IMAGE_RENDERED = 'CORNERSTONE_IMAGE_RENDERED',
   /**
-   * Triggers when a tools annotation has been removed.
-   */
-  ANNOTATION_REMOVED = 'CORNERSTONE_TOOLS_ANNOTATION_REMOVED',
-  /**
    * Triggers on the eventTarget when the image volume data is modified. This happens
    * in the streamingImageLoader when each frame is loaded and inserted into a volume.
    *


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

ticket: 18378695060

Measurement is deleted but the canvas is not refreshed.

https://github.com/user-attachments/assets/775f88b7-e9ab-4963-bf70-25a8cc4c0501



### Changes & Results

Added listener for delete annotation that calls postRender.

### Testing
Use patient SIIM, Ravi 

https://github.com/user-attachments/assets/5f7f8888-5d6e-4ae4-b665-6aebfb846d21




<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR


- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)


