### PR TITLE
feat(decoders): decode color baseline JPEGs in worker

### DIFF
--- a/packages/dicomImageLoader/src/decodeImageFrameWorker.js
+++ b/packages/dicomImageLoader/src/decodeImageFrameWorker.js
@@ -7,6 +7,7 @@ import decodeLittleEndian from './shared/decoders/decodeLittleEndian';
 import decodeBigEndian from './shared/decoders/decodeBigEndian';
 import decodeRLE from './shared/decoders/decodeRLE';
 import decodeJPEGBaseline8Bit from './shared/decoders/decodeJPEGBaseline8Bit';
+import decodeJPEGBaseline8BitColorOffscreen from './shared/decoders/decodeJPEGBaseline8BitColorOffscreen';
 // import decodeJPEGBaseline12Bit from './shared/decoders/decodeJPEGBaseline12Bit';
 import decodeJPEGBaseline12Bit from './shared/decoders/decodeJPEGBaseline12Bit-js';
 import decodeJPEGLossless from './shared/decoders/decodeJPEGLossless';
@@ -395,7 +396,21 @@ export async function decodeImageFrame(
         ...imageFrame,
       };
 
-      decodePromise = decodeJPEGBaseline8Bit(pixelData, opts);
+      const bitsAllocated = imageFrame.bitsAllocated ?? imageFrame.BitsAllocated;
+      const samplesPerPixel =
+        imageFrame.samplesPerPixel ?? imageFrame.SamplesPerPixel;
+
+      if (
+        bitsAllocated === 8 &&
+        (samplesPerPixel === 3 || samplesPerPixel === 4)
+      ) {
+        decodePromise = decodeJPEGBaseline8BitColorOffscreen(
+          imageFrame,
+          pixelData
+        );
+      } else {
+        decodePromise = decodeJPEGBaseline8Bit(pixelData, opts);
+      }
       break;
     case '1.2.840.10008.1.2.4.51':
       // JPEG Baseline lossy process 2 & 4 (12 bit)

--- a/packages/dicomImageLoader/src/imageLoader/createImage.ts
+++ b/packages/dicomImageLoader/src/imageLoader/createImage.ts
@@ -81,7 +81,6 @@ function createImage(
     imageFrame,
     transferSyntax,
     pixelData,
-    canvas,
     options,
     decodeConfig
   );

--- a/packages/dicomImageLoader/src/imageLoader/decodeImageFrame.ts
+++ b/packages/dicomImageLoader/src/imageLoader/decodeImageFrame.ts
@@ -1,5 +1,3 @@
-import decodeJPEGBaseline8BitColor from './decodeJPEGBaseline8BitColor';
-
 // dicomParser requires pako for browser-side decoding of deflate transfer syntax
 // We only need one function though, so lets import that so we don't make our bundle
 // too large.
@@ -50,7 +48,6 @@ function decodeImageFrame(
   imageFrame,
   transferSyntax,
   pixelData,
-  canvas,
   options = {},
   decodeConfig
 ) {
@@ -102,16 +99,6 @@ function decodeImageFrame(
       );
     case '1.2.840.10008.1.2.4.50':
       // JPEG Baseline lossy process 1 (8 bit)
-
-      // Handle 8-bit JPEG Baseline color images using the browser's built-in
-      // JPEG decoding
-      if (
-        imageFrame.bitsAllocated === 8 &&
-        (imageFrame.samplesPerPixel === 3 || imageFrame.samplesPerPixel === 4)
-      ) {
-        return decodeJPEGBaseline8BitColor(imageFrame, pixelData, canvas);
-      }
-
       return processDecodeTask(
         imageFrame,
         transferSyntax,

--- a/packages/dicomImageLoader/src/shared/decoders/decodeJPEGBaseline8BitColorOffscreen.ts
+++ b/packages/dicomImageLoader/src/shared/decoders/decodeJPEGBaseline8BitColorOffscreen.ts
@@ -1,0 +1,37 @@
+import type { ByteArray } from 'dicom-parser';
+import type { Types } from '@cornerstonejs/core';
+import getMinMax from '../getMinMax';
+
+async function decodeJPEGBaseline8BitColorOffscreen(
+  imageFrame: Types.IImageFrame,
+  pixelData: ByteArray
+): Promise<Types.IImageFrame> {
+  const blob = new Blob([pixelData], { type: 'image/jpeg' });
+  const bitmap = await createImageBitmap(blob);
+  const canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
+  const ctx = canvas.getContext('2d');
+
+  if (!ctx) {
+    bitmap.close();
+    throw new Error('Failed to obtain OffscreenCanvas 2D context');
+  }
+
+  ctx.drawImage(bitmap, 0, 0);
+  bitmap.close();
+
+  const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  const rgbaPixels = new Uint8Array(imageData.data);
+  const { min, max } = getMinMax(rgbaPixels);
+
+  imageFrame.rows = canvas.height;
+  imageFrame.columns = canvas.width;
+  imageFrame.pixelData = rgbaPixels;
+  imageFrame.pixelDataLength = rgbaPixels.length;
+  imageFrame.smallestPixelValue = min;
+  imageFrame.largestPixelValue = max;
+  imageFrame.imageData = imageData;
+
+  return imageFrame;
+}
+
+export default decodeJPEGBaseline8BitColorOffscreen;


### PR DESCRIPTION
## Summary
- Add an OffscreenCanvas-based JPEG Baseline color decoder to the worker decoders.
- Route 8-bit color JPEGs through it so the full decode stays in the worker instead of bouncing back to the main thread
- Simplify the browser entry point since it no longer needs to pass a canvas down to the worker

That keeps the fast path but avoids running the browser decoder on the main thread for color JPEGs.