### PR TITLE
fix(segmentation): In segmentationEventManager, call the update function only if the requested representation type is available.

### DIFF
--- a/packages/tools/src/stateManagement/segmentation/segmentationEventManager.ts
+++ b/packages/tools/src/stateManagement/segmentation/segmentationEventManager.ts
@@ -5,6 +5,7 @@ import debounce from '../../utilities/debounce';
 import surfaceDisplay from '../../tools/displayTools/Surface/surfaceDisplay';
 import contourDisplay from '../../tools/displayTools/Contour/contourDisplay';
 import labelmapDisplay from '../../tools/displayTools/Labelmap/labelmapDisplay';
+import { getSegmentation } from './getSegmentation';
 
 const renderers = {
   [SegmentationRepresentations.Labelmap]: labelmapDisplay,
@@ -65,6 +66,7 @@ function addSegmentationListener(
   // Create and register a new debounced listener
   const listener = createDebouncedSegmentationListener(
     segmentationId,
+    representationType,
     updateFunction
   );
   eventTarget.addEventListener(Events.SEGMENTATION_DATA_MODIFIED, listener);
@@ -130,6 +132,7 @@ function removeAllSegmentationListeners(segmentationId: string): void {
  */
 function createDebouncedSegmentationListener(
   segmentationId: string,
+  representationType: string,
   updateFunction: (segmentationId: string) => Promise<void>
 ): EventListener {
   // Debounced function ensures that frequent segmentation updates
@@ -137,8 +140,14 @@ function createDebouncedSegmentationListener(
   const debouncedHandler = debounce((event: CustomEvent) => {
     const eventSegmentationId = event.detail?.segmentationId;
 
-    // Execute only if the event is relevant to this segmentation
-    if (eventSegmentationId === segmentationId) {
+    const segmentation = getSegmentation(eventSegmentationId);
+
+    // Execute only if the event is relevant to this segmentation and
+    // it has the representation type.
+    if (
+      eventSegmentationId === segmentationId &&
+      !!segmentation?.representationData?.[representationType]
+    ) {
       updateFunction(segmentationId);
       triggerSegmentationModified(segmentationId);
     }


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
`updateFunction` was throwing an exception because the label map to surface conversion was not yet completed.

The problem was introduced by #2426. FYI @Devu-trenser

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
Only call the `updateFunction` if the representation type requested is present in the segmentation.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

