### PR TITLE
fix(SegmentationState): only activate first segment if it exists

### DIFF
--- a/packages/tools/src/stateManagement/segmentation/internalAddSegmentationRepresentation.ts
+++ b/packages/tools/src/stateManagement/segmentation/internalAddSegmentationRepresentation.ts
@@ -54,8 +54,8 @@ function internalAddSegmentationRepresentation(
       const segmentKeys = Object.keys(segmentation.segments);
       if (segmentKeys.length > 0) {
         firstSegmentIndex = segmentKeys.map((k) => Number(k)).sort()[0];
+        setActiveSegmentIndex(segmentationId, firstSegmentIndex);
       }
-      setActiveSegmentIndex(segmentationId, firstSegmentIndex);
     }
   }
 


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

This change was already there in a previous version: https://github.com/cornerstonejs/cornerstone3D/blob/b1979f6092bd59358ba840a4ba4356ef915b8073/packages/tools/src/stateManagement/segmentation/internalAddSegmentationRepresentation.ts#L37-L44 

But was removed again in the current `main` branch (via https://github.com/cornerstonejs/cornerstone3D/commit/a1ed21861779b52257557ab5c3928c492fd238a8): 
https://github.com/cornerstonejs/cornerstone3D/blob/e7b0cea10f4ceb71710d3f01eaead75152180b7a/packages/tools/src/stateManagement/segmentation/internalAddSegmentationRepresentation.ts#L53-L60

-> this breaks the expected behavior of segmentations, as they now always load with an empty segment with index 1, because `activateSegmentIndex` is called and this creates the non-existing segment with an empty label `''`. We should not do this, and rather expect the application to handle the case of an initially empty segmentation. 

If we add an empty segment automatically, it is harder for the application to handle the initial state for empty segmentations -> they might need to always remove this segment if it exists, e.g., if they want to check if no segment exists yet. Otherwise the user might start drawing with a non-existent segment index.

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

Before: empty segmentations are loaded with an empty segment with index 1.
After: empty segmentations are empty after loading (contain no segments).

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"--> ubuntu 24
- [x] "Node version: <!--[e.g. 16.14.0]"--> v22.7.0
- [x] "Browser: Brave / Chromium (latest)
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
