### PR TITLE
fix(AnnotationTool) styles not applied on first render of annotations

### DIFF
--- a/packages/tools/src/drawingSvg/drawTextBox.ts
+++ b/packages/tools/src/drawingSvg/drawTextBox.ts
@@ -143,7 +143,7 @@ function _drawTextGroup(
 
     textGroup.appendChild(textElement);
     svgDrawingHelper.appendNode(textGroup, svgNodeHash);
-    textGroupBoundingBox = _drawTextBackground(textGroup, background);
+    textGroupBoundingBox = _drawTextBackground(textGroup, backgroundStyles);
   }
 
   // We translate the group using `position`


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

- New styles were added to the annotation tool in https://github.com/cornerstonejs/cornerstone3D/pull/2455
- One call to `_drawTextBackground` was missed and did not add the `backgroundStyles` arg
- This meant that styles were added on subsequent renders of the textBox, but not the very first - when drawing the annotation the styles appear. When scrolling away and back the styles are not present, further changes causing the box to rerender adds the styles again.

This fix is simple - just add the `backgroundStyles` arg to the second call (when the text element does NOT exist) to ensure styles are added from the very first render

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

🐛 **Before:**

https://github.com/user-attachments/assets/8ef1c048-f0c6-459f-9698-34067eba3270

**After:**

https://github.com/user-attachments/assets/51283d5c-a75a-4a8a-bbd6-adb72ed16545

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing


- Run the `volumeAnnotationTools` example
- Add the below to Line 100 of the example index.ts: 
```
  annotationTool.config.style.setToolGroupToolStyles(toolGroupId,
    {
      [LengthTool.toolName]: {
        textBoxFontFamily: 'Helvetica Neue, Helvetica, Arial, sans-serif',
        textBoxFontSize: '14px',
        textBoxColorLocked: 'rgb(255, 255, 0)',
        textBoxBackground: 'rgb(0,255,  255, 0.5)',
        textBoxLinkLineWidth: '2',
        textBoxLinkLineDash: '2,3',
        textBoxMargin: 10,
        textBoxBorderRadius: 5,
      }
    }
  )
 ```
- Add an annotation, scroll away, scroll back, observe the changes.
- Repeat with changes from this branch - Annotation should render as expected


<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: macOS Tahoe 26.1,
- [x] "Node version: 22.15
- [x] "Browser:Chrome 142.0.7444.135, Firefox 143.0.1, Safari 26.1
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

 
 
 "Browser: Chrome 142.0.7444.135, Firefox 143.0.1, Safari 26.1
<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
