### PR TITLE
fix: handle missing labelmap image ids in stack labelmap example

### DIFF
--- a/packages/tools/src/stateManagement/segmentation/getCurrentLabelmapImageIdForViewport.ts
+++ b/packages/tools/src/stateManagement/segmentation/getCurrentLabelmapImageIdForViewport.ts
@@ -14,11 +14,15 @@ import { defaultSegmentationStateManager } from './SegmentationStateManager';
 export function getCurrentLabelmapImageIdForViewport(
   viewportId: string,
   segmentationId: string
-) {
+): string | undefined {
   const imageIds = getCurrentLabelmapImageIdsForViewport(
     viewportId,
     segmentationId
   );
+
+  if (!imageIds?.length) {
+    return;
+  }
 
   return imageIds[0];
 }


### PR DESCRIPTION
### Context

Guard getCurrentLabelmapImageIdForViewport when no imageIds exist so stack drawing simply refuses instead of crashing on unseen slices.

This fixes one of the problem [reported here](https://github.com/cornerstonejs/cornerstone3D/pull/2459#issuecomment-3599677066).

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
