### PR TITLE
Feature/pan axis controls

### DIFF
--- a/packages/ai/examples/autoSegmentAI/index.ts
+++ b/packages/ai/examples/autoSegmentAI/index.ts
@@ -23,7 +23,7 @@ const { ViewportType, OrientationAxis } = Enums;
 
 const { segmentation } = cornerstoneTools;
 const { segmentation: segmentationUtils } = cornerstoneTools.utilities;
-const currentViewportType = ViewportType.ORTHOGRAPHIC;
+const currentViewportType = ViewportType.STACK;
 
 setTitleAndDescription(
   'Segment Assistant',
@@ -76,8 +76,7 @@ const toolGroup =
 
 toolGroup.addTool(cornerstoneTools.ZoomTool.toolName);
 toolGroup.addTool(cornerstoneTools.StackScrollTool.toolName);
-toolGroup.addTool(cornerstoneTools.PanTool.toolName, {
-});
+toolGroup.addTool(cornerstoneTools.PanTool.toolName);
 toolGroup.addTool(cornerstoneTools.ProbeTool.toolName);
 toolGroup.addTool(LabelmapSlicePropagationTool.toolName);
 


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->
I added a new option to allow restricting PAN movements to specific axes (X, Y, or Z).
This provides more flexibility and control when integrating Cornerstone3D in custom environments where certain movement directions should be locked.

This feature enables more precise interactions and prevents unwanted camera/volume movements.
No existing issue was opened for this request.

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->
Changes introduced:

Added a new configuration option for the Pan Tool that allows specifying which axes are enabled

Updated the internal pan logic to apply these axis constraints

Ensured full backward compatibility — default behavior remains unchanged (all axes enabled)

Improved clarity through inline documentation and comments

Results:

Improved control when performing pan interactions

Developers can now limit movements to:

Only X

Only Y

Only Z

Any combination (e.g., X + Y)

This enables more tailored UI/UX interactions depending on the application needs

Inside the Pan Tool logic, the panning movement is represented by a vector called deltaPointsWorld, which contains the X, Y, and Z movement components:

```
deltaPointsWorld[0] → X-axis movement  
deltaPointsWorld[1] → Y-axis movement  
deltaPointsWorld[2] → Z-axis movement
```

The new configuration options ignoreX, ignoreY, and ignoreZ are used to selectively disable one or more axes.

The logic applied is simple and non-breaking:

```
if (this.configuration.ignoreX) {
  deltaPointsWorld[0] = 0;
}

if (this.configuration.ignoreY) {
  deltaPointsWorld[1] = 0;
}

if (this.configuration.ignoreZ) {
  deltaPointsWorld[2] = 0;
}
```

When an axis is ignored, the corresponding component of the pan vector is set to 0, effectively blocking movement along that axis.
If none of the options are provided, the behavior remains unchanged (all axes enabled), ensuring full backward compatibility.
### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->
To test this feature:

Load a 2D or 3D scene in Cornerstone3D.

Enable the Pan Tool with the new configuration. For example, to allow only Z-axis movement:

{
  ignoreX: true,
  ignoreY: true,
}


Try panning the camera/volume in all directions.

Confirm that:

Movements along the X-axis are blocked

Movements along the Y-axis are blocked

Only Z-axis movement is allowed

Test additional combinations, such as:

Allow only X-axis:
```
 ignoreY: true 
 ignoreZ: true
```

Allow only Y-axis:
```
 ignoreX: true 
 ignoreZ: true
 ```
### Checklist

#### PR


feat(PanTool): add customizable axis constraints for pan movements
<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Linux, Ubuntu 24.04 <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [x] "Node version: v24.11.0 <!--[e.g. 16.14.0]"-->
- [x] "Browser:
  Chrome 142.0.7444.134 <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
