### PR TITLE
fix: Fix potential divide by 0 in Viewport.resetCamera

### DIFF
--- a/packages/core/src/RenderingEngine/Viewport.ts
+++ b/packages/core/src/RenderingEngine/Viewport.ts
@@ -1138,8 +1138,8 @@ class Viewport {
       const extent = imageData.getExtent();
       const spacing = imageData.getSpacing();
 
-      widthWorld = (extent[1] - extent[0]) * spacing[0];
-      heightWorld = (extent[3] - extent[2]) * spacing[1];
+      widthWorld = (1 + extent[1] - extent[0]) * spacing[0];
+      heightWorld = (1 + extent[3] - extent[2]) * spacing[1];
     } else {
       ({ widthWorld, heightWorld } = this._getWorldDistanceViewUpAndViewRight(
         bounds,


### PR DESCRIPTION
getExtent returns array indices, not dimensions. This fixes a division by zero when displaying 1x1 pixel images.

<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

Displaying 1x1 pixel images fails

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

`Viewport.resetCamera` computes widths/heights using VTK's `getExtent` function, but that function return indices, not dimensions. This PR fixes the computation to correct the off-by-one error.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [ ] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: macOS <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [x] Node version: 22 <!--[e.g. 16.14.0]"-->
- [x] Browser: Firefox 146
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
