### PR TITLE
docs(Synchronizers) update incorrect example in synchronizers.md

### DIFF
--- a/packages/docs/docs/concepts/cornerstone-tools/synchronizers.md
+++ b/packages/docs/docs/concepts/cornerstone-tools/synchronizers.md
@@ -80,9 +80,8 @@ const ptAxial = {
   },
 };
 
-const axialSync = createCameraPositionSynchronizer('axialSync')[
-  (ctAxial, ptAxial)
-].forEach((vp) => {
+const axialSync = createCameraPositionSynchronizer('axialSync');
+[ctAxial, ptAxial].forEach((vp) => {
   const { renderingEngineId, viewportId } = vp;
   axialSync.add({ renderingEngineId, viewportId });
 });


### PR DESCRIPTION
Fixed incorrect example code

<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

The synchronizers page in the docs contains an incorrect example.

### Changes & Results
- Changed the example code to reflect the indented behaviour.

### Testing

View the change in this PR

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [x] "Node version: <!--[e.g. 16.14.0]"-->
- [x] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
