### PR TITLE
fix(ImageVolume): replace deprecated numTimePoints with a getter and update isDynamicVolume logic

### DIFF
--- a/packages/core/src/cache/classes/ImageVolume.ts
+++ b/packages/core/src/cache/classes/ImageVolume.ts
@@ -85,10 +85,10 @@ export class ImageVolume {
 
   // @deprecated
   get numTimePoints(): number {
-    // Return numDimensionGroups if defined, otherwise default to 1
     // @ts-expect-error
     return typeof this.numDimensionGroups === 'number'
-      ? (this as any).numDimensionGroups
+    // @ts-expect-error
+      ? this.numDimensionGroups
       : 1;
   }
   numFrames = null as number;


### PR DESCRIPTION
fixes https://github.com/cornerstonejs/cornerstone3D/issues/2506 
fixes https://github.com/cornerstonejs/cornerstone3D/issues/2506

This pull request updates the `ImageVolume` class to improve the handling of time points and dynamic volume detection. The most important changes are:

**Refactoring and API Improvements:**

* Changed the deprecated `numTimePoints` property from a field to a getter that returns the value of `numDimensionGroups`, ensuring consistency and up-to-date values.

**Bug Fixes and Logic Improvements:**

* Updated the `isDynamicVolume` method to safely check `numTimePoints` before comparing, and to explicitly return `false` if `numTimePoints` is not set, making the logic more robust.