### PR TITLE
fix(segmentation): getClosestImageId should proceed to calculate the closest imageId if imageIds is not empty.

### DIFF
--- a/packages/core/src/utilities/getClosestImageId.ts
+++ b/packages/core/src/utilities/getClosestImageId.ts
@@ -35,7 +35,7 @@ export default function getClosestImageId(
   const { direction, spacing, imageIds } = imageVolume;
   const { ignoreSpacing = false } = options || {};
 
-  if (imageIds?.length) {
+  if (!imageIds?.length) {
     return;
   }
 


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
PR #2485 created a regression whereby jump to world coordinates/point stopped working. In particular this [change](https://github.com/cornerstonejs/cornerstone3D/pull/2485/files#diff-ab751156dac58056e164ddc3d3ee5cd3b4e14756dd9286d75897647c9ee7023a) was at fault.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
Undid that one change of that PR that caused the problem.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
For any given viewport, execute `jumpToWorld` with a world point and the viewport should navigate.

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

  System:
    OS: Windows 11 10.0.26200
    CPU: (20) x64 12th Gen Intel(R) Core(TM) i7-12700H
    Memory: 5.00 GB / 31.68 GB
  Binaries:
    Node: 23.9.0 - ~\AppData\Local\fnm_multishells\52784_1765830696412\node.EXE
    Yarn: 1.22.22 - C:\Program Files (x86)\Yarn\bin\yarn.CMD
    npm: 10.9.2 - ~\AppData\Local\fnm_multishells\52784_1765830696412\npm.CMD
    bun: 1.2.23 - ~\.bun\bin\bun.EXE
  Browsers:
    Edge: Chromium (140.0.3485.54)
    Internet Explorer: 11.0.26100.7309
    Chrome: 143.0.7499.41 (Official Build) (64-bit)

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
