### PR TITLE
(fix) Prevent maximum call stack exceeded error when jumping to measurement with crosshair enabled

### DIFF
--- a/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
@@ -160,7 +160,8 @@ abstract class BaseVolumeViewport extends Viewport {
 
   protected applyViewOrientation(
     orientation: OrientationAxis | OrientationVectors,
-    resetCamera = true
+    resetCamera = true,
+    suppressEvents = false
   ) {
     const { viewPlaneNormal, viewUp } =
       this._getOrientationVectors(orientation) || {};
@@ -178,7 +179,11 @@ abstract class BaseVolumeViewport extends Viewport {
 
     if (resetCamera) {
       const t = this as unknown as IVolumeViewport;
-      t.resetCamera({ resetOrientation: false, resetRotation: false });
+      t.resetCamera({
+        resetOrientation: false,
+        resetRotation: false,
+        suppressEvents,
+      });
     }
   }
 
@@ -870,7 +875,11 @@ abstract class BaseVolumeViewport extends Viewport {
       if (refViewPlaneNormal && !isNegativeNormal && !isSameNormal) {
         // Need to update the orientation vectors correctly for this case
         // this.setCameraNoEvent({ viewPlaneNormal: refViewPlaneNormal, viewUp });
-        this.setOrientation({ viewPlaneNormal: refViewPlaneNormal, viewUp });
+        this.setOrientation(
+          { viewPlaneNormal: refViewPlaneNormal, viewUp },
+          true,
+          true
+        );
         this.setViewReference(viewRef);
         return;
       }
@@ -1510,7 +1519,8 @@ abstract class BaseVolumeViewport extends Viewport {
    */
   public setOrientation(
     _orientation: OrientationAxis | OrientationVectors,
-    _immediate = true
+    _immediate = true,
+    _suppressEvents = false
   ): void {
     console.warn('Method "setOrientation" needs implementation');
   }

--- a/packages/core/src/RenderingEngine/VolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/VolumeViewport.ts
@@ -190,7 +190,8 @@ class VolumeViewport extends BaseVolumeViewport {
    */
   public setOrientation(
     orientation: OrientationAxis | OrientationVectors,
-    immediate = true
+    immediate = true,
+    suppressEvents = false
   ): void {
     let viewPlaneNormal, viewUp;
 
@@ -223,7 +224,7 @@ class VolumeViewport extends BaseVolumeViewport {
       this.resetCamera();
     } else {
       ({ viewPlaneNormal, viewUp } = orientation);
-      this.applyViewOrientation(orientation);
+      this.applyViewOrientation(orientation, true, suppressEvents);
     }
 
     if (immediate) {


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

- When crosshair is enabled and a measurement jump is triggered, navigating to the target view causes a recursive camera reset, eventually resulting in a **“Maximum call stack exceeded”** error.
- This PR has been incorporated by [FlyWheel.io](https://flywheel.io/).

During measurement navigation, the following sequence occurs:

- `setViewReference` invokes `setOrientation`
- `setOrientation` calls `applyViewOrientation`
- `applyViewOrientation` triggers `resetCamera` with `{ resetOrientation: false, resetRotation: false }`
- `resetCamera` emits a `CAMERA_RESET` event
- The crosshair listener responds to `CAMERA_RESET` by resetting the camera again with `resetRotation: true`

After applying the orientation, `setViewReference` continues under the assumption that the viewport is aligned with the measurement’s orientation. However, the repeated camera resets triggered by the crosshair revert the orientation. This causes `setViewReference` to continuously reapply the orientation, resulting in an infinite loop and eventually a maximum call stack exceeded error.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

<img width="774" height="569" alt="image" src="https://github.com/user-attachments/assets/2b9ca3be-7f39-468f-8000-78edbc556885" />

https://github.com/user-attachments/assets/ba00814c-0ec1-4842-8b96-d63d28b278af

### Changes & Results
Camera reset events are now suppressed while applying orientation changes during measurement navigation, preventing recursive resets and eliminating the call stack overflow.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"--> Windows 11
- [x] "Node version: <!--[e.g. 16.14.0]"--> 22.19.0
- [x] "Browser: Chrome 143.0.7499.109
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
