### PR TITLE
feature updated volumecroppintoolexample

### DIFF
--- a/packages/tools/examples/volumeCroppingTool/index.ts
+++ b/packages/tools/examples/volumeCroppingTool/index.ts
@@ -351,6 +351,7 @@ async function run(numViewports = getNumViewportsFromUrl()) {
   toolGroupVRT.setToolActive(ZoomTool.toolName, {
     bindings: [
       {
+        // scroll wheel for zoom
         mouseButton: MouseBindings.Wheel,
       },
     ],
@@ -359,6 +360,7 @@ async function run(numViewports = getNumViewportsFromUrl()) {
   toolGroupVRT.setToolActive(PanTool.toolName, {
     bindings: [
       {
+        //updated to right mouse button for pan
         mouseButton: MouseBindings.Secondary,
       },
     ],


### PR DESCRIPTION
Context :  updtaed the example of volumecropping tool with sight changes in zoom and pan 
  Clear separation of mouse responsibilities in the 3D viewport
Changes & Results
  Primary mouse button → only Volume Cropping (handles & planes)-also rotate
  Mouse wheel → Zoom
  Secondary (right) mouse button → Pan
  This removes overlapping behaviours and makes interactions predictable.
  Together, these changes reduce mode confusion and make the demo much easier to learn without instructions.
Testing
    same as before .Just run the volumecroppingtool index file packages\tools\examples\volumeCroppingTool\index.ts
Checklist
PR
[] My Pull Request title is descriptive, accurate and follows the
semantic-release format and guidelines.
Code
[] My code has been well-documented
Tested Environment
[] "OS:Windows
[] "Node version:v22.15.1
[] "Browser:chrome