### PR TITLE
fix(Volume viewport): Image shift in mpr when measurement is loaded.

### DIFF
--- a/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
@@ -804,19 +804,14 @@ abstract class BaseVolumeViewport extends Viewport {
     this.setBestOrentation(inPlaneVector1, inPlaneVector2);
 
     const { focalPoint, viewPlaneNormal } = this.getCamera();
-    const normalizedViewPlaneNormal = vec3.normalize(
-      vec3.create(),
-      viewPlaneNormal
-    );
     const deltaFocal = vec3.subtract(vec3.create(), point, focalPoint);
-    const alongNormal = vec3.dot(deltaFocal, normalizedViewPlaneNormal);
+    const alongNormal = vec3.dot(deltaFocal, viewPlaneNormal);
     const deltaNormal = vec3.scaleAndAdd(
       vec3.create(),
       focalPoint,
-      normalizedViewPlaneNormal,
+      viewPlaneNormal,
       alongNormal
     ) as Point3;
-
     this.setViewReference({
       FrameOfReferenceUID,
       cameraFocalPoint: deltaNormal,


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
This PR resolves image shifting in MPR viewports when loading or selecting measurements. This issue was observed with multiframe datasets.

Fixes:  https://github.com/OHIF/Viewers/issues/5684

This PR has been incorporated by [FlyWheel.io](https://flywheel.io/)

### Changes & Results
 The setViewPlane() method was updated to compute a view plane that is the correct distance but centered on the same spot as it was previously.  This does not resolve the underlying issue, but is a correct fix for newly loaded SRs that can change the focal position relative to the image.
 
 Before:
 

https://github.com/user-attachments/assets/3de6706d-4d6c-43a4-8731-5e5b77d6ba91

After:

https://github.com/user-attachments/assets/398a8e68-a272-4a5b-a7bf-a04d7f67e376


<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

- Launch a data : https://viewer-dev.ohif.org/segmentation?StudyInstanceUIDs=1.2.826.0.1.3680043.2.1125.1.11608962641993666019702920539307840
- Switch to Advanced Layout (multi-viewport).
- Load SR to the viewport.
- Confirm that the image loads as expected.

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->Windows 11 10.0.22631
- [x] Node version: <!--[e.g. 16.14.0]"-->20.17.0
- [x] Browser: Chrome: 143.0.7499.170
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
