### PR TITLE
fix: add pixel spacing extraction fallback to Imager Pixel Spacing tag

### DIFF
--- a/packages/dicomImageLoader/src/imageLoader/wadouri/metaData/extractPositioningFromDataset.ts
+++ b/packages/dicomImageLoader/src/imageLoader/wadouri/metaData/extractPositioningFromDataset.ts
@@ -158,6 +158,12 @@ function extractSpacingFromDataset(dataSet: DataSet) {
     );
   }
 
+  // If pixelSpacing not valid to this point, trying to get the spacing
+  // from the Imager Pixel Spacing tag
+  if (!pixelSpacing && dataSet.elements.x00181164) {
+    pixelSpacing = getNumberValues(dataSet, 'x00181164', 2);
+  }
+
   return pixelSpacing;
 }
 


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

In some MG datasets, `PixelSpacing (0028,0030)` is missing but
`ImagerPixelSpacing (0018,1164)` is present (e.g., 0.1, 0.1). The loader
currently only checks `0028,0030`, so `imagePlaneModule.usingDefaultValues`
becomes `true`, `hasPixelSpacing` is `false`, and measurement tools fall back
to `px`. This change adds a fallback to read `0018,1164` so pixel spacing is
recognized and measurements use real-world units.

No issue was filed; this was identified while debugging `LengthTool` units
showing `px` despite valid spacing in the DICOM header.

### Changes & Results

- Add a fallback to read `ImagerPixelSpacing (0018,1164)` when
  `PixelSpacing (0028,0030)` is missing in WADO-URI metadata extraction.
- Before: `hasPixelSpacing = false`, measurements display in `px`.
- After: `hasPixelSpacing = true`, measurements use mm based on 0.1 spacing.
- No UI or public API changes.

### Testing

Manual:
1. Load an MG study that lacks `0028,0030` but has `0018,1164 = [0.1, 0.1]`.
2. Inspect `imagePlaneModule.pixelSpacing` and verify it is `[0.1, 0.1]`.
3. Use `LengthTool` and confirm the unit is `mm` (not `px`).
4. Load a study that already provides `0028,0030` and confirm behavior is unchanged.

Automated tests not added (metadata extraction path only).

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.).

#### Public Documentation Updates

- [x] The documentation page has been updated as necessary for any public API
  additions or removals. (N/A, no public API changes)

#### Tested Environment

- [x] "OS: Linux 6.6.87.2-microsoft-standard-WSL2"
- [x] "Node version: 24.5.0"
- [x] "Browser: N/A (not tested)"

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
