### PR TITLE
fix(SculptorTool): Restored the dynamic cursor size functionality that was undone by PR 2484.

### DIFF
--- a/packages/tools/src/tools/SculptorTool.ts
+++ b/packages/tools/src/tools/SculptorTool.ts
@@ -99,6 +99,7 @@ class SculptorTool extends BaseTool {
         ],
         toolShape: 'circle',
         referencedToolName: 'PlanarFreehandROI',
+        updateCursorSize: 'dynamic',
       },
     }
   ) {
@@ -490,7 +491,11 @@ class SculptorTool extends BaseTool {
     } else {
       const cursorShape = this.registeredShapes.get(this.selectedShape);
       const canvasCoords = eventData.currentPoints.canvas;
-      cursorShape.updateToolSize(canvasCoords, viewport, activeAnnotation);
+
+      // Only call updateToolSize when updateCursorSize is set to 'dynamic'
+      if (this.configuration.updateCursorSize === 'dynamic') {
+        cursorShape.updateToolSize(canvasCoords, viewport, activeAnnotation);
+      }
     }
 
     triggerAnnotationRenderForViewportIds(this.commonData.viewportIdsToRender);


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
Fixes OHIF issue https://github.com/OHIF/Viewers/issues/5639.
Reverts a small part of PR #2484 that removed the ability to turn off dynamic cursor size.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
Reverts a small part of PR #2484 that removed the ability to turn off dynamic cursor size.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
See OHIF issue https://github.com/OHIF/Viewers/issues/5639

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

  System:
    OS: Windows 11 10.0.26200
    CPU: (20) x64 12th Gen Intel(R) Core(TM) i7-12700H
    Memory: 6.59 GB / 31.68 GB
  Binaries:
    Node: 22.17.0 - C:\Users\joebo\AppData\Local\fnm_multishells\33444_1767618650410\node.EXE
    Yarn: 1.22.22 - C:\Program Files (x86)\Yarn\bin\yarn.CMD
    npm: 11.6.2 - C:\Users\joebo\AppData\Local\fnm_multishells\33444_1767618650410\npm.CMD
    bun: 1.2.23 - C:\Users\joebo\.bun\bin\bun.EXE
  Browsers:
    Chrome: 143.0.7499.193  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
