### PR TITLE
fix(drawLine): SVG line disappeared on Firefox

### DIFF
--- a/packages/tools/src/drawingSvg/drawLine.ts
+++ b/packages/tools/src/drawingSvg/drawLine.ts
@@ -48,7 +48,7 @@ export default function drawLine(
   const svgNodeHash = _getHash(annotationUID, 'line', lineUID);
   const existingLine = svgDrawingHelper.getSvgNode(svgNodeHash);
   const layerId = svgDrawingHelper.svgLayerElement.id;
-  const dropShadowStyle = shadow ? `filter:url(#shadow-${layerId});` : '';
+  const dropShadowStyle = shadow ? `url(#shadow-${layerId});` : '';
 
   const attributes = {
     x1: `${start[0]}`,
@@ -56,7 +56,7 @@ export default function drawLine(
     x2: `${end[0]}`,
     y2: `${end[1]}`,
     stroke: textBoxLinkLineColor || color,
-    style: dropShadowStyle,
+    filter: dropShadowStyle,
     'stroke-width': strokeWidth,
     'stroke-dasharray': lineDash,
     'marker-start': markerStartId ? `url(#${markerStartId})` : '',


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

**On Firefox only**

When updating the image index shown in a `StackViewport` with a reference line (not set as current viewport), the reference line disappeared in Firefox.

> Can't reproduce in a minimal example. Seems to depend on the redrawing order.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

By setting the filter through the `filter` attribute instead of the `style` attribute, everything is displayed correctly.

I would like to know if there was a reason the `filter` was defined through the `style` attribute. Could there be a bug somewhere else ?

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- OS: Windows 11
- Node version: 24.12
- Browser: Firefox 
  <!--[e.g. Chrome 83.0.4103.116, Firefox 147.0, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
