### PR TITLE
fix: Several exceptions loading rtstruct

### DIFF
--- a/packages/polymorphic-segmentation/src/Surface/createAndCacheSurfacesFromRaw.ts
+++ b/packages/polymorphic-segmentation/src/Surface/createAndCacheSurfacesFromRaw.ts
@@ -44,6 +44,9 @@ export async function createAndCacheSurfacesFromRaw(
       );
     }
 
+    if (!rawSurfaceData.data?.points) {
+      throw new Error('No points found for surface');
+    }
     const closedSurface = {
       id: `segmentation_${segmentation.segmentationId}_surface_${segmentIndex}`,
       color,

--- a/packages/tools/src/stateManagement/annotation/annotationState.ts
+++ b/packages/tools/src/stateManagement/annotation/annotationState.ts
@@ -161,7 +161,10 @@ function addAnnotation(
 
   // if the annotation manager selector is an element, trigger the
   // annotation added event for that element.
-  if (annotationGroupSelector instanceof HTMLDivElement) {
+  if (
+    annotationGroupSelector instanceof HTMLDivElement &&
+    !annotation.metadata?.FrameOfReferenceUID
+  ) {
     const groupKey = manager.getGroupKey(annotationGroupSelector);
     manager.addAnnotation(annotation, groupKey);
     triggerAnnotationAddedForElement(annotation, annotationGroupSelector);

--- a/packages/tools/src/tools/displayTools/Contour/contourDisplay.ts
+++ b/packages/tools/src/tools/displayTools/Contour/contourDisplay.ts
@@ -77,11 +77,19 @@ async function render(
   ) {
     polySegConversionInProgressForViewportId.set(viewport.id, true);
 
-    contourData = await computeAndAddRepresentation(
-      segmentationId,
-      Representations.Contour,
-      () => polySeg.computeContourData(segmentationId, { viewport })
-    );
+    try {
+      contourData = await computeAndAddRepresentation(
+        segmentationId,
+        Representations.Contour,
+        () => polySeg.computeContourData(segmentationId, { viewport })
+      );
+    } catch (error) {
+      console.warn(
+        'Unable to compute contour data for segmentationId',
+        segmentationId,
+        error
+      );
+    }
 
     polySegConversionInProgressForViewportId.set(viewport.id, false);
   } else if (!contourData && !getPolySeg()) {

--- a/packages/tools/src/tools/segmentation/LabelmapBaseTool.ts
+++ b/packages/tools/src/tools/segmentation/LabelmapBaseTool.ts
@@ -293,6 +293,9 @@ export default class LabelmapBaseTool extends BaseTool {
       const { volumeId } = representationData[
         SegmentationRepresentations.Labelmap
       ] as LabelmapSegmentationDataVolume;
+      if (!volumeId) {
+        return;
+      }
       const actors = viewport.getActors();
 
       const isStackViewport = viewport instanceof StackViewport;
@@ -311,9 +314,9 @@ export default class LabelmapBaseTool extends BaseTool {
 
       // we used to take the first actor here but we should take the one that is
       // probably the same size as the segmentation volume
-      const volumes = actors.map((actorEntry) =>
-        cache.getVolume(actorEntry.referencedId)
-      );
+      const volumes = actors
+        .filter((actorEntry) => actorEntry.referencedId)
+        .map((actorEntry) => cache.getVolume(actorEntry.referencedId));
 
       const segmentationVolume = cache.getVolume(volumeId);
 


### PR DESCRIPTION
### Context

There are a number of exceptions trying to load rtstruct into volumes.  This PR fixes several of them, although it appears there are still others to resolve.

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
