### PR TITLE
 Applied a deliberately constrained VOI range

### DIFF
--- a/packages/core/examples/volumeVoiSigmoid/index.ts
+++ b/packages/core/examples/volumeVoiSigmoid/index.ts
@@ -50,8 +50,10 @@ addButtonToToolbar({
     ) as Types.IVolumeViewport;
 
     // Set a range to highlight bones
-    viewport.setProperties({ VOILUTFunction: Enums.VOILUTFunctionType.LINEAR });
-
+    viewport.setProperties({
+      VOILUTFunction: Enums.VOILUTFunctionType.LINEAR,
+      voiRange: { lower: -1000, upper: 3000 },
+    });
     viewport.render();
   },
 });
@@ -70,6 +72,7 @@ addButtonToToolbar({
     // Set a range to highlight bones
     viewport.setProperties({
       VOILUTFunction: Enums.VOILUTFunctionType.SAMPLED_SIGMOID,
+      voiRange: { lower: 300, upper: 1200 },
     });
 
     viewport.render();


### PR DESCRIPTION
Context

bugfix for https://github.com/cornerstonejs/cornerstone3D/issues/2458 
I went through the code and saw that

      1.Neither button changes window width/center
      2.Neither button resets or constrains the VOI range
      3.The WindowLevelTool continues to dominate visual behaviour ( Window/Level interaction is enabled by default via WindowLevelTool)

So visually:

Buttons don't change anything upon clicked
Dragging causes contrast change in all cases
The difference between linear and sigmoid LUTs is subtle
Users reasonably conclude “nothing changed”

Why does no button appear “active”?

Button state is not tracked , No UI feedback exists , No overlay or label indicates the active VOI mode
So even though internal state does change, the UI gives zero confirmation.

Changes & Results

User get the direct feed back of change when explicitly setting voiRange: Input range becomes fixed. Only the mapping function changes. The effect of the LUT becomes observable
It makes Sigmoid VOI perceptually distinguishable

By constraining voiRange:

Linear VOI → harsh clipping + uniform contrast
Sigmoid VOI → smooth transitions + mid-range emphasis
It creates an immediate, visible response to button clicks

Testing
User can go to the same volumesigmoidexample and click either buttons .Change is directly visible and they can still do drag operations

Checklist

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

Tested Environment
OS:Winodws
Browser :Chrome and edge


