### PR TITLE
fix: CS3D version commits to single version

### DIFF
--- a/publish-version.mjs
+++ b/publish-version.mjs
@@ -111,19 +111,14 @@ async function run() {
   // Maybe we need to hook the netlify deploy preview
   // await execa('yarn', ['run', 'build']);
 
-  console.log('Committing and pushing changes...');
-  await execa('git', ['add', '-A']);
-  await execa('git', [
-    'commit',
-    '--no-verify',
-    '-m',
-    'chore(version): version.json [skip ci]',
-  ]);
-  await execa('git', ['push', 'origin', branchName]);
-
   console.log('Setting the version using lerna...');
 
-  // add a message to the commit to indicate that the version was set using lerna
+  // Stage all changes (version.json, peer dependency updates, .npmrc deletion)
+  // before lerna runs so they're included in lerna's commit
+  await execa('git', ['add', '-A']);
+
+  // Run lerna version without pushing
+  // lerna will update package.json files and create a commit
   await execa('npx', [
     'lerna',
     'version',
@@ -132,26 +127,47 @@ async function run() {
     '--exact',
     '--force-publish',
     '--message',
-    'chore(version): Update package versions [skip ci]',
+    `chore(version): Update package versions to ${nextVersion} [skip ci]`,
     '--conventional-commits',
     '--create-release',
     'github',
+    '--no-push',
   ]);
 
-  console.log('Version set using lerna');
-
+  // Generate version files for each package
   for (const pkg of packages) {
     await execa('node', ['./scripts/generate-version.js', pkg]);
   }
 
-  await execa('git', ['add', '.']);
-  await execa('git', [
-    'commit',
-    '--no-verify',
-    '-m',
-    'chore: update generated version file [skip ci]',
-  ]);
+  // Stage any files that need to be included in the amended commit. Lerna commits the package.json
+  // files it modifies, but may not include other files that were staged before it ran (like
+  // version.json or .npmrc deletion) or generated version files. Since we're amending the commit to
+  // combine all version-related changes into a single commit, we need to ensure these files are included.
+  await execa('git', ['add', '-A']);
+
+  // Amend the last commit to include all changes. The commit message is already set by lerna
+  // and is the same, so we use --no-edit to keep the existing message.
+  // This combines the version.json commit and package version updates into one commit
+  await execa('git', ['commit', '--amend', '--no-edit']);
+
+  // Lerna created a local tag (e.g. v4.16.0) pointing to the pre-amend commit.
+  // Move the tag to the amended commit so the release tag matches what we push.
+  const tagName = `v${nextVersion}`;
+  await execa('git', ['tag', '-f', tagName]);
+
+  console.log('Pushing changes...');
+
+  // Note: Force push is not necessary here because:
+  // 1. Lerna is called with --no-push, so the commit created by lerna is never pushed to remote
+  // 2. We amend the commit locally before pushing, so it's a new commit from the remote's perspective
+  // 3. This script runs on a single branch locally, so there's no history rewrite on the remote
+  // A regular push is sufficient since we're pushing a commit that doesn't exist on the remote yet
   await execa('git', ['push', 'origin', branchName]);
+
+  console.log('Pushing tag...');
+  await execa('git', ['push', 'origin', tagName]);
+
+  console.log('Version set using lerna');
 }
 
 async function unlinkFile(filePath) {


### PR DESCRIPTION

### Context

CS3D creates 3 commits for every version of master.   Change it to 1 commit that does all 3 parts.
No functional changes.

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
