### PR TITLE
fix(tools): prevent ANNOTATION_COMPLETED re-firing when clicking PlanarFreehandROI text 

### DIFF
--- a/packages/tools/src/tools/annotation/planarFreehandROITool/drawLoop.ts
+++ b/packages/tools/src/tools/annotation/planarFreehandROITool/drawLoop.ts
@@ -237,7 +237,7 @@ function completeDrawClosedContour(
     return false;
   }
 
-  const { annotation, viewportIdsToRender } = this.commonData;
+  const { annotation, viewportIdsToRender, movingTextBox } = this.commonData;
   const enabledElement = getEnabledElement(element);
   const { viewport } = enabledElement;
 
@@ -267,7 +267,7 @@ function completeDrawClosedContour(
 
   const { textBox } = annotation.data.handles;
 
-  if (!textBox?.hasMoved) {
+  if (!textBox?.hasMoved && !movingTextBox) {
     triggerContourAnnotationCompleted(annotation, contourHoleProcessingEnabled);
   }
 
@@ -330,7 +330,7 @@ function completeDrawOpenContour(
     return false;
   }
 
-  const { annotation, viewportIdsToRender } = this.commonData;
+  const { annotation, viewportIdsToRender, movingTextBox } = this.commonData;
   const enabledElement = getEnabledElement(element);
   const { viewport } = enabledElement;
 
@@ -379,7 +379,7 @@ function completeDrawOpenContour(
     );
   }
 
-  if (!textBox.hasMoved) {
+  if (!textBox.hasMoved && !movingTextBox) {
     triggerContourAnnotationCompleted(annotation, contourHoleProcessingEnabled);
   }
 


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

When a user clicks on the text/label of a Planar Freehand ROI, the tool fires ANNOTATION_COMPLETED again. 
**Root Cause**
Clicking the label runs `handleSelectedCallback` → `activateOpenContourEndEdit` with the text box handle, which sets `movingTextBox: true` and reuses the draw loop. On mouse up, `mouseUpDrawCallback` runs and calls `completeDrawOpenContour` / `completeDrawClosedContour`. The code only checked !textBox.hasMoved before calling `triggerContourAnnotationCompleted`, so it still fired even when the user had only clicked the text. 

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
Add a `movingTextBox` guard in `completeDrawOpenContour` and `completeDrawClosedContour` so we do not fire `triggerContourAnnotationCompleted` when the user only clicked the text box

**Before**
https://github.com/user-attachments/assets/f10b5404-ef05-41bd-86b1-667b3b02d358)

**After**
Clicking the text no longer fires `ANNOTATION_COMPLETED`
https://github.com/user-attachments/assets/5e1592eb-accc-4442-a321-efef0132e94f


<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
- Draw a Planar Freehand ROI (open and closed). 
- Click on its text/label
- Verify no event is fired.
 
 ### Steps to reproduce the issue: 
1. open study : https://viewer.ohif.org/viewer?StudyInstanceUIDs=2.16.840.1.114362.1.11972228.22789312658.616067305.306.2
2. Select Freehand ROI tool
3. Draw a measurement (line or a closed circle)
4. Select yes
5. Click on the text associated with the measurement on the viewport.  
6. Notice that each time the user click on the text, it will log in the console "Measurement added. "
- Note: This behavior happens only if the text has NOT moved yet on the viewport. 
<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: macOS 10.15.4
- [x] "Node version: v22.12.0
- [x] "Browser: Chrome 83.0.4103.116
  

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
