### PR TITLE
fix(sr): adapt 3.10 SR reports to new DCMJS structural changes

### DIFF
--- a/packages/adapters/src/adapters/Cornerstone3D/PlanarFreehandROI.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/PlanarFreehandROI.ts
@@ -95,7 +95,9 @@ class PlanarFreehandROI extends BaseAdapter3D {
     if (referencedImageId) {
       state.annotation.data.cachedStats = {
         [`imageId:${referencedImageId}`]: {
-          area: NUMGroup ? NUMGroup.MeasuredValueSequence.NumericValue : null,
+          ...(!isOpenContour && NUMGroup
+            ? { area: NUMGroup.MeasuredValueSequence.NumericValue }
+            : {}),
           ...restoreAdditionalMetrics(measurementNUMGroups),
         },
       };

--- a/packages/adapters/src/adapters/Cornerstone3D/RectangleROI.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/RectangleROI.ts
@@ -4,6 +4,7 @@ import { toScoords } from '../helpers';
 import MeasurementReport from './MeasurementReport';
 import BaseAdapter3D from './BaseAdapter3D';
 import { extractAllNUMGroups, restoreAdditionalMetrics } from './metricHandler';
+import { mapUnitFromUCUM } from './unitMapper';
 
 const { Polyline: TID300Polyline } = utilities.TID300;
 
@@ -55,14 +56,20 @@ export class RectangleROI extends BaseAdapter3D {
     );
     const measurementNUMGroups = allNUMGroups[referencedSOPInstanceUID] || {};
 
+    const restoredMetrics = restoreAdditionalMetrics(measurementNUMGroups);
+    const rawAreaUnit =
+      areaGroup?.MeasuredValueSequence?.[0]?.MeasurementUnitsCodeSequence;
+    const areaUnitFromSR = rawAreaUnit?.CodeValue;
+    const mappedAreaUnit = areaUnitFromSR
+      ? mapUnitFromUCUM(areaUnitFromSR)
+      : restoredMetrics.areaUnit;
+
     const cachedStats = referencedImageId
       ? {
           [`imageId:${referencedImageId}`]: {
             area: areaGroup?.MeasuredValueSequence?.[0]?.NumericValue || 0,
-            areaUnit:
-              areaGroup?.MeasuredValueSequence?.[0]
-                ?.MeasurementUnitsCodeSequence?.CodeValue,
-            ...restoreAdditionalMetrics(measurementNUMGroups),
+            areaUnit: mappedAreaUnit,
+            ...restoredMetrics,
           },
         }
       : {};

--- a/packages/adapters/src/adapters/Cornerstone3D/metricHandler.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/metricHandler.ts
@@ -1,3 +1,12 @@
+import { mapUnitFromUCUM } from './unitMapper';
+
+const INTENSITY_METRICS = new Set([
+  'Mean',
+  'Standard Deviation',
+  'Maximum',
+  'Minimum',
+]);
+
 export interface AdditionalMetrics {
   mean?: number;
   stdDev?: number;
@@ -45,9 +54,14 @@ export function extractAllNUMGroups(
             numGroupsBySOPInstanceUID[referencedSOPInstanceUID] = {};
           }
 
+          let unit = '';
+          if (unitCode) {
+            unit = resolveUnit(codeMeaning, unitCode);
+          }
+
           numGroupsBySOPInstanceUID[referencedSOPInstanceUID][codeMeaning] = {
             value: numericValue,
-            unit: unitCode || '',
+            unit,
           };
         }
       }
@@ -91,8 +105,14 @@ export function restoreAdditionalMetrics(numGroups): AdditionalMetrics {
 
   // Define what kind of unit each metric type should use
   const unitCategory = {
+    mean: 'modalityUnit',
+    stdDev: 'modalityUnit',
+    max: 'modalityUnit',
+    min: 'modalityUnit',
     area: 'areaUnit',
     radius: 'radiusUnit',
+    perimeter: 'unit',
+    length: 'unit',
     width: 'widthUnit',
   };
 
@@ -112,21 +132,60 @@ export function restoreAdditionalMetrics(numGroups): AdditionalMetrics {
     if (!unit) {
       continue;
     }
-    if (!modalityUnit) {
-      modalityUnit = unit;
+
+    const mappedUnit = mapUnitFromUCUM(unit);
+
+    if (!mappedUnit) {
+      continue;
+    }
+
+    if (INTENSITY_METRICS.has(codeMeaning) && !modalityUnit) {
+      modalityUnit = mappedUnit;
     }
 
     const category = unitCategory[metricKey];
     if (category) {
       if (!additionalMetrics[category]) {
-        additionalMetrics[category] = unit;
+        additionalMetrics[category] = mappedUnit;
       }
     } else {
-      additionalMetrics[`${metricKey}Unit`] = unit;
+      additionalMetrics[`${metricKey}Unit`] = mappedUnit;
     }
   }
 
   additionalMetrics.modalityUnit = modalityUnit;
 
   return additionalMetrics;
+}
+
+/**
+ * Handles dimensionless UCUM units ("1"), intensity metrics (unitless),
+ * and geometric metrics such as Area (squared units).
+ *
+ * @param codeMeaning - DICOM Concept Name (e.g. "Mean", "Area")
+ * @param unitCode - Measurement Units Code Sequence
+ * @returns Formatted unit string or empty string if unitless
+ */
+
+function resolveUnit(
+  codeMeaning: string,
+  unitCode?: {
+    CodeValue: string;
+    CodeMeaning: string;
+  }
+): string {
+  if (!unitCode) {
+    return '';
+  }
+
+  const { CodeValue, CodeMeaning } = unitCode;
+
+  if (CodeValue === '1') {
+    if (!INTENSITY_METRICS.has(codeMeaning) && codeMeaning === 'Area') {
+      return `${CodeMeaning}\u00B2`;
+    }
+    return INTENSITY_METRICS.has(codeMeaning) ? '' : CodeMeaning;
+  }
+
+  return CodeValue;
 }

--- a/packages/adapters/src/adapters/Cornerstone3D/unitMapper.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/unitMapper.ts
@@ -1,0 +1,26 @@
+export const UCUM_HOUNSFIELD_UNIT = "[hnsf'U]";
+export const DISPLAY_HOUNSFIELD_UNIT = 'HU';
+export const UCUM_SQUARE_MILLIMETER = 'mm2';
+export const DISPLAY_SQUARE_MILLIMETER = 'mm²';
+
+/**
+ * Mapping from UCUM codes to display units.
+ */
+const UNIT_MAP_FROM_UCUM: Record<string, string> = {
+  [UCUM_HOUNSFIELD_UNIT]: DISPLAY_HOUNSFIELD_UNIT,
+  [UCUM_SQUARE_MILLIMETER]: DISPLAY_SQUARE_MILLIMETER,
+};
+
+/**
+ * Converts a UCUM code to display format.
+ * If no mapping exists, returns the original unit.
+ *
+ * @param unit - The UCUM code (e.g., "[hnsf'U]")
+ * @returns The display unit (e.g., "HU") or original unit if no mapping
+ */
+export function mapUnitFromUCUM(unit: string | undefined): string | undefined {
+  if (!unit) {
+    return unit;
+  }
+  return UNIT_MAP_FROM_UCUM[unit] || unit;
+}


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

* Restore SR reports created in 3.10 with updated DCMJS structural changes

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
* Updated SR parsing to match latest DCMJS changes
* Added backward compatibility for older SRs
* Fixed unit handling (removed incorrect default units)
* Corrected measurement statistics extraction
* Prevented invalid stats (e.g., area for open shapes)
* Ensured proper annotation loading from SR
* Maintained consistency of stats and units after SR reload

Before changes:

https://github.com/user-attachments/assets/9c5b9f0b-455d-4be3-8c1d-00dcdb5f319d

https://github.com/user-attachments/assets/1b767d61-0468-4526-b5e6-7530f2a0556f

https://github.com/user-attachments/assets/cb4a9df3-639b-4234-91d0-849b3c31c7a5


After changes:

https://github.com/user-attachments/assets/5ffd981d-0884-4f1b-ae3a-253c20011761

https://github.com/user-attachments/assets/33323ae3-f11c-4073-b1ed-ed02badf85d9




<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
- Load a study
- Draw a Rectangle ROI measurement and verify its statistics units
- Save the measurement as an SR
- Reload the saved SR and verify that the rectangle’s statistics units are preserved correctly
- Repeat the validation using MR modality data
- Verify the behavior with the following tools:
   - Length
   - Bidirectional
   - Annotate
   - Rectangle ROI
   - Freehand ROI
   - Ellipse ROI
   - Circle


<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Windows 11
- [x] "Node version: 22.20.0
- [x] "Browser: Chrome 145.0.7632.119
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
