### PR TITLE
feat(crosshair): toggle slab handles while keeping slab lines

### DIFF
--- a/packages/tools/src/tools/CrosshairsTool.ts
+++ b/packages/tools/src/tools/CrosshairsTool.ts
@@ -112,6 +112,7 @@ class CrosshairsTool extends AnnotationTool {
   _getReferenceLineControllable?: (viewportId: string) => boolean;
   _getReferenceLineDraggableRotatable?: (viewportId: string) => boolean;
   _getReferenceLineSlabThicknessControlsOn?: (viewportId: string) => boolean;
+  _slabThicknessHandlesEnabled = true;
   _volumeViewportNewVolumeListeners = new Map<
     string,
     {
@@ -151,6 +152,8 @@ class CrosshairsTool extends AnnotationTool {
         handleRadius: 3,
         // Enable HDPI rendering for handles using devicePixelRatio
         enableHDPIHandles: false,
+        // Toggle for slab thickness handles
+        slabThicknessHandles: true,
         // radius of the area around the intersection of the planes, in which
         // the reference lines will not be rendered. This is only used when
         // having 3 viewports in the toolGroup.
@@ -193,6 +196,9 @@ class CrosshairsTool extends AnnotationTool {
     this._getReferenceLineDraggableRotatable =
       toolProps.configuration?.getReferenceLineDraggableRotatable ||
       defaultReferenceLineDraggableRotatable;
+    this._slabThicknessHandlesEnabled =
+      this.configuration.slabThicknessHandles ?? true;
+
     this._getReferenceLineSlabThicknessControlsOn =
       toolProps.configuration?.getReferenceLineSlabThicknessControlsOn ||
       defaultReferenceLineSlabThicknessControlsOn;
@@ -1196,6 +1202,8 @@ class CrosshairsTool extends AnnotationTool {
       const viewportSlabThicknessControlsOn =
         this._getReferenceLineSlabThicknessControlsOn(otherViewport.id) ||
         this.configuration.mobile?.enabled;
+      const viewportSlabThicknessHandlesOn =
+        this._slabThicknessHandlesEnabled && viewportSlabThicknessControlsOn;
       const selectedViewportId = data.activeViewportIds.find(
         (id) => id === otherViewport.id
       );
@@ -1326,7 +1334,7 @@ class CrosshairsTool extends AnnotationTool {
           !rotHandlesActive &&
           !slabThicknessHandlesActive &&
           viewportDraggableRotatable &&
-          viewportSlabThicknessControlsOn
+          viewportSlabThicknessHandlesOn
         ) {
           // draw all handles inactive (rotation and slab thickness)
           let handleUID = `${lineIndex}One`;
@@ -1379,7 +1387,7 @@ class CrosshairsTool extends AnnotationTool {
           selectedViewportId &&
           !rotHandlesActive &&
           !slabThicknessHandlesActive &&
-          viewportSlabThicknessControlsOn
+          viewportSlabThicknessHandlesOn
         ) {
           const handleUID = `${lineIndex}`;
           // draw slab thickness handles inactive
@@ -1418,7 +1426,7 @@ class CrosshairsTool extends AnnotationTool {
         } else if (
           slabThicknessHandlesActive &&
           selectedViewportId &&
-          viewportSlabThicknessControlsOn
+          viewportSlabThicknessHandlesOn
         ) {
           const handleRadius =
             this.configuration.handleRadius *
@@ -2279,10 +2287,13 @@ class CrosshairsTool extends AnnotationTool {
           );
           const otherViewportSlabThicknessControlsOn =
             this._getReferenceLineSlabThicknessControlsOn(otherViewport.id);
+          const otherViewportSlabThicknessHandlesOn =
+            this._slabThicknessHandlesEnabled &&
+            otherViewportSlabThicknessControlsOn;
 
           return (
             otherViewportControllable === true &&
-            otherViewportSlabThicknessControlsOn === true &&
+            otherViewportSlabThicknessHandlesOn === true &&
             viewportAnnotation.data.activeViewportIds.find(
               (id) => id === otherViewport.id
             )
@@ -2660,7 +2671,9 @@ class CrosshairsTool extends AnnotationTool {
 
       const viewportSlabThicknessControlsOn =
         this._getReferenceLineSlabThicknessControlsOn(otherViewport.id);
-      if (!viewportSlabThicknessControlsOn) {
+      const viewportSlabThicknessHandlesOn =
+        this._slabThicknessHandlesEnabled && viewportSlabThicknessControlsOn;
+      if (!viewportSlabThicknessHandlesOn) {
         continue;
       }
 
@@ -2760,8 +2773,10 @@ class CrosshairsTool extends AnnotationTool {
       );
       const viewportSlabThicknessControlsOn =
         this._getReferenceLineSlabThicknessControlsOn(otherViewport.id);
+      const viewportSlabThicknessHandlesOn =
+        this._slabThicknessHandlesEnabled && viewportSlabThicknessControlsOn;
 
-      if (!viewportControllable || !viewportSlabThicknessControlsOn) {
+      if (!viewportControllable || !viewportSlabThicknessHandlesOn) {
         continue;
       }
 


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

I want to manage slab thickness programmatically via a select list, so while we still want the dashed slab lines to show the current thickness, we need the handles to stay hidden when the UI makes the change for us. The existing getReferenceLineSlabThicknessControlsOn callback kept the whole thickness interaction tied together, so handles would disappear only when we disabled the entire thickness controls.

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

Added _slabThicknessHandlesEnabled and a slabThicknessHandles configuration flag so the dashed slab lines keep rendering while the handle rendering/hit testing is gated independently. The SLAB logic still consults getReferenceLineSlabThicknessControlsOn, but we now only block handles when the new flag is false while leaving the lines visible for reference.

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
