### PR TITLE
fix: render color points with negative indices

### DIFF
--- a/packages/tools/src/utilities/voi/colorbar/ColorbarCanvas.ts
+++ b/packages/tools/src/utilities/voi/colorbar/ColorbarCanvas.ts
@@ -221,6 +221,10 @@ class ColorbarCanvas {
     let previousColorPoint = undefined;
     let currentColorPoint = getColorPoint(0);
 
+    const minPosition = rgbPoints[0];
+    const maxPosition = rgbPoints[rgbPoints.length - 4];
+    const colormapRange = maxPosition - minPosition;
+
     // Starts from `range.lower` incrementing by incRawPixelValue on each iteration
     const incRawPixelValue = (range.upper - range.lower) / (maxValue - 1);
     let rawPixelValue = range.lower;
@@ -230,12 +234,14 @@ class ColorbarCanvas {
         (rawPixelValue - voiRange.lower) /
         Math.abs(voiRange.upper - voiRange.lower);
 
+      const tColormapPosition = minPosition + tVoiRange * colormapRange;
+
       // Find the color in a linear way (O(n) complexity).
-      // currentColorPoint shall move to the next color until tVoiRange is smaller
+      // currentColorPoint shall move to the next color until tColormapPosition is smaller
       // than or equal to next color position.
       if (currentColorPoint) {
         for (let i = currentColorPoint.index; i < colorsCount; i++) {
-          if (tVoiRange <= currentColorPoint.position) {
+          if (tColormapPosition <= currentColorPoint.position) {
             break;
           }
 
@@ -262,7 +268,7 @@ class ColorbarCanvas {
         normColor = [...previousColorPoint.color];
       } else {
         const tColorRange =
-          (tVoiRange - previousColorPoint.position) /
+          (tColormapPosition - previousColorPoint.position) /
           (currentColorPoint.position - previousColorPoint.position);
 
         normColor = interpolateVec3(


### PR DESCRIPTION
Fixed an issue where color points with negative indices were not rendered when rendering the colorbar.

<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->
When I used the PET CT blending mode and compared the relationship between image intensity and colorbar, I found that some color information seemed to be missing.
<img width="1127" height="1050" alt="image" src="https://github.com/user-attachments/assets/51f543a7-1c11-4367-a429-8b1117f01081" />



### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->
changes:
- change the rendering code of colorbar canvas 

results:
- colorbar render color with negative indices
<img width="960" height="1049" alt="image" src="https://github.com/user-attachments/assets/975f7ea0-a175-4bf3-b299-aee3f9313ce9" />

### Testing
Run command in project, open the example advancedColorbar:
```shell
npm run example advancedColorbar
```
open example page
Change pt colormap to hsv
see new rendering result of colormap 
<img width="960" height="1049" alt="image" src="https://github.com/user-attachments/assets/975f7ea0-a175-4bf3-b299-aee3f9313ce9" />

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: [Windows 11, macOS 25]"
- [] "Node version: [e.g. 20.x.x]"
- [] "Browser: chrome and safari 
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
