### PR TITLE
feat(pixel-spacing): enhance pixel spacing calculations with new measurement messages and validation functions

### DIFF
--- a/packages/core/src/utilities/getPixelSpacingInformation.ts
+++ b/packages/core/src/utilities/getPixelSpacingInformation.ts
@@ -45,7 +45,7 @@ export function getERMF(instance) {
   }
 }
 
-const MeasurementMessages = Object.freeze({
+const MeasurementMessages = {
   NOT_CALIBRATED: 'Measurements not calibrated.',
   CORRECTED_AT_MODALITY: 'Measurements corrected at modality.',
   NOT_CORRECTED_AT_DETECTOR:
@@ -53,10 +53,12 @@ const MeasurementMessages = Object.freeze({
   CORRECTED_USING_ERMF: 'Measurements corrected using the ERMF.',
   UNCERTAIN: 'Measurements are uncertain.',
   USER_CALIBRATED: 'Measurements are user calibrated.',
-});
+};
 
 function hasSpacing(spacing) {
-  return Array.isArray(spacing) && spacing.length === 2;
+  return (
+    Array.isArray(spacing) && (spacing.length === 1 || spacing.length === 2)
+  );
 }
 
 function isValidSpacing(spacing) {
@@ -142,7 +144,7 @@ export function calculateRadiographicPixelSpacing(instance) {
     if (ermf === true) {
       // PixelSpacing already updated/correct, don't tweak it again
       return {
-        PixelSpacing: PixelSpacing || ImagerPixelSpacing,
+        PixelSpacing,
         type: CalibrationTypes.ERMF,
         isProjection,
         Message: MeasurementMessages.CORRECTED_USING_ERMF,
@@ -151,15 +153,6 @@ export function calculateRadiographicPixelSpacing(instance) {
 
     if (ermf) {
       console.error('Illegal ERMF value:', ermf);
-    }
-
-    if (hasValidImagerPixelSpacing && hasPixelSpacing) {
-      return {
-        PixelSpacing,
-        type: CalibrationTypes.PROJECTION,
-        isProjection,
-        Message: MeasurementMessages.CORRECTED_AT_MODALITY,
-      };
     }
 
     if (hasValidImagerPixelSpacing) {

--- a/packages/core/src/utilities/getPixelSpacingInformation.ts
+++ b/packages/core/src/utilities/getPixelSpacingInformation.ts
@@ -45,6 +45,29 @@ export function getERMF(instance) {
   }
 }
 
+const MeasurementMessages = Object.freeze({
+  NOT_CALIBRATED: 'Measurements not calibrated.',
+  CORRECTED_AT_MODALITY: 'Measurements corrected at modality.',
+  NOT_CORRECTED_AT_DETECTOR:
+    'Measurements not corrected. Measured size is at detector.',
+  CORRECTED_USING_ERMF: 'Measurements corrected using the ERMF.',
+  UNCERTAIN: 'Measurements are uncertain.',
+  USER_CALIBRATED: 'Measurements are user calibrated.',
+});
+
+function hasSpacing(spacing) {
+  return Array.isArray(spacing) && spacing.length === 2;
+}
+
+function isValidSpacing(spacing) {
+  return (
+    hasSpacing(spacing) &&
+    spacing.every(
+      (value) => Number.isFinite(Number(value)) && Number(value) > 0
+    )
+  );
+}
+
 /**
  * Given an instance, calculates the project (radiographic) pixel spacing
  * plus the type of calibration that got used for it.
@@ -67,37 +90,43 @@ export function calculateRadiographicPixelSpacing(instance) {
     instance;
 
   const isProjection = true;
+  const hasPixelSpacing = hasSpacing(PixelSpacing);
+  const hasImagerPixelSpacing = hasSpacing(ImagerPixelSpacing);
+  const hasValidImagerPixelSpacing = isValidSpacing(ImagerPixelSpacing);
 
-  if (PixelSpacing && PixelSpacingCalibrationType === 'GEOMETRY') {
-    if (isEqual(PixelSpacing, ImagerPixelSpacing)) {
-      console.warn(
-        'Calibration type is geometry, but pixel spacing and imager pixel spacing identical',
-        PixelSpacing,
-        ImagerPixelSpacing
-      );
-    }
-    // This tag says just trust the pixel spacing without worrying about the value
-    return {
-      PixelSpacing,
-      type: CalibrationTypes.ERMF,
-      isProjection,
-    };
-  }
-
-  if (PixelSpacing && PixelSpacingCalibrationType === 'FIDUCIAL') {
-    // This tag says that the pixel spacing has been manually calibrated
+  // This tag says that the pixel spacing has been manually calibrated
+  if (hasPixelSpacing && PixelSpacingCalibrationType === 'FIDUCIAL') {
     return {
       PixelSpacing,
       type: CalibrationTypes.CALIBRATED,
       isProjection,
+      Message: MeasurementMessages.USER_CALIBRATED,
     };
   }
 
-  if (ImagerPixelSpacing) {
+  // Explicit geometry calibration from the modality
+  if (hasPixelSpacing && PixelSpacingCalibrationType === 'GEOMETRY') {
+    if (hasImagerPixelSpacing && isEqual(PixelSpacing, ImagerPixelSpacing)) {
+      console.warn(
+        'Calibration type is geometry, but pixel spacing and imager pixel spacing are identical',
+        PixelSpacing,
+        ImagerPixelSpacing
+      );
+    }
+
+    return {
+      PixelSpacing,
+      type: CalibrationTypes.ERMF,
+      isProjection,
+      Message: MeasurementMessages.CORRECTED_AT_MODALITY,
+    };
+  }
+
+  if (hasImagerPixelSpacing) {
     const ermf = getERMF(instance);
-    if (ermf > 1) {
-      // The IHE Mammo profile specifies that the value of Imager Pixel Spacing is required to be corrected by
-      // Estimated Radiographic Magnification Factor and the user informed of that.
+    // The IHE Mammo profile specifies that the value of Imager Pixel Spacing is required to be corrected by
+    // Estimated Radiographic Magnification Factor and the user informed of that.
+    if (typeof ermf === 'number' && ermf > 1) {
       const correctedPixelSpacing = ImagerPixelSpacing.map(
         (pixelSpacing) => pixelSpacing / ermf
       );
@@ -106,33 +135,59 @@ export function calculateRadiographicPixelSpacing(instance) {
         PixelSpacing: correctedPixelSpacing,
         type: CalibrationTypes.ERMF,
         isProjection,
+        Message: MeasurementMessages.CORRECTED_USING_ERMF,
       };
     }
+
     if (ermf === true) {
-      // PixelSpacing already updated/correct, don't tweak it
+      // PixelSpacing already updated/correct, don't tweak it again
       return {
-        PixelSpacing,
+        PixelSpacing: PixelSpacing || ImagerPixelSpacing,
         type: CalibrationTypes.ERMF,
         isProjection,
+        Message: MeasurementMessages.CORRECTED_USING_ERMF,
       };
     }
+
     if (ermf) {
       console.error('Illegal ERMF value:', ermf);
     }
+
+    if (hasValidImagerPixelSpacing && hasPixelSpacing) {
+      return {
+        PixelSpacing,
+        type: CalibrationTypes.PROJECTION,
+        isProjection,
+        Message: MeasurementMessages.CORRECTED_AT_MODALITY,
+      };
+    }
+
+    if (hasValidImagerPixelSpacing) {
+      return {
+        PixelSpacing: ImagerPixelSpacing,
+        type: CalibrationTypes.PROJECTION,
+        isProjection,
+        Message: MeasurementMessages.NOT_CORRECTED_AT_DETECTOR,
+      };
+    }
+  }
+
+  // PS is present, but IPS is absent/invalid (or IPS+ERMF combination is not trustworthy)
+  if (hasPixelSpacing) {
     return {
-      PixelSpacing: PixelSpacing || ImagerPixelSpacing,
-      type: CalibrationTypes.PROJECTION,
+      PixelSpacing,
+      type: CalibrationTypes.UNKNOWN,
       isProjection,
+      Message: MeasurementMessages.UNCERTAIN,
     };
   }
 
-  // If only Pixel Spacing is present, and this is a projection radiograph,
-  // PixelSpacing should be used, but the user should be informed that
-  // what it means is unknown
+  // Neither PS nor IPS is usable
   return {
     PixelSpacing,
     type: CalibrationTypes.UNKNOWN,
     isProjection,
+    Message: MeasurementMessages.NOT_CALIBRATED,
   };
 }
 

--- a/packages/core/test/utilities/getPixelSpacingInformation.jest.js
+++ b/packages/core/test/utilities/getPixelSpacingInformation.jest.js
@@ -1,12 +1,34 @@
 import {
   getERMF,
   calculateRadiographicPixelSpacing,
+  getPixelSpacingInformation,
 } from '../../src/utilities';
-import { describe, it, expect } from '@jest/globals';
+import { CalibrationTypes } from '../../src/enums';
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from '@jest/globals';
 
 const EstimatedRadiographicMagnificationFactor = 1.1;
 const ImagerPixelSpacing = [100, 100];
 const PixelSpacing = [50, 50];
+
+const CR_SOP_CLASS_UID = '1.2.840.10008.5.1.4.1.1.1';
+const CT_SOP_CLASS_UID = '1.2.840.10008.5.1.4.1.1.2';
+
+const Messages = {
+  NOT_CALIBRATED: 'Measurements not calibrated.',
+  CORRECTED_AT_MODALITY: 'Measurements corrected at modality.',
+  NOT_CORRECTED_AT_DETECTOR:
+    'Measurements not corrected. Measured size is at detector.',
+  CORRECTED_USING_ERMF: 'Measurements corrected using the ERMF.',
+  UNCERTAIN: 'Measurements are uncertain.',
+  USER_CALIBRATED: 'Measurements are user calibrated.',
+};
 
 describe('getPixelSpacingInformation', function () {
   describe('getERMF', () => {
@@ -36,7 +58,8 @@ describe('getPixelSpacingInformation', function () {
       const ermf = getERMF(instance);
       expect(ermf).toBe(2);
     });
-    it('Should get ERMF for imager pixel spacing', () => {
+
+    it('Should get ERMF true for larger imager than pixel spacing', () => {
       const instance = {
         PixelSpacing,
         ImagerPixelSpacing,
@@ -45,46 +68,225 @@ describe('getPixelSpacingInformation', function () {
       // Returns true to indicate use original pixel spacing to avoid lossy changes
       expect(ermf).toBe(true);
     });
+
+    it('Should return undefined when no spacing information is available', () => {
+      const ermf = getERMF({});
+      expect(ermf).toBeUndefined();
+    });
   });
 
   describe('calculateRadiographicPixelSpacing', () => {
-    it('Should return ERMF for calibration type GEOMETRY', () => {
-      const instance = {
-        PixelSpacing,
-        PixelSpacingCalibrationType: 'GEOMETRY',
-      };
-      const { type } = calculateRadiographicPixelSpacing(instance);
-      expect(type).toBe('ERMF');
+    let warnSpy;
+    let errorSpy;
+
+    beforeEach(() => {
+      warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     });
-    it('Should return Calibrated for calibration type FIDUCIAL', () => {
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
+    it('Should return Calibrated for calibration type FIDUCIAL with user-calibrated message', () => {
       const instance = {
         PixelSpacing,
         PixelSpacingCalibrationType: 'FIDUCIAL',
       };
-      const { type } = calculateRadiographicPixelSpacing(instance);
-      expect(type).toBe('Calibrated');
+      const result = calculateRadiographicPixelSpacing(instance);
+      expect(result.type).toBe(CalibrationTypes.CALIBRATED);
+      expect(result.PixelSpacing).toBe(PixelSpacing);
+      expect(result.isProjection).toBe(true);
+      expect(result.Message).toBe(Messages.USER_CALIBRATED);
     });
-    it('Should return Projection for imager only', () => {
+
+    it('Should prefer FIDUCIAL over GEOMETRY if both somehow coexist', () => {
+      // Only a single calibration type can be set, but FIDUCIAL is checked first.
+      const instance = {
+        PixelSpacing,
+        PixelSpacingCalibrationType: 'FIDUCIAL',
+        ImagerPixelSpacing,
+      };
+      const { type, Message } = calculateRadiographicPixelSpacing(instance);
+      expect(type).toBe(CalibrationTypes.CALIBRATED);
+      expect(Message).toBe(Messages.USER_CALIBRATED);
+    });
+
+    it('Should return ERMF for calibration type GEOMETRY with corrected-at-modality message', () => {
+      const instance = {
+        PixelSpacing,
+        ImagerPixelSpacing,
+        PixelSpacingCalibrationType: 'GEOMETRY',
+      };
+      const result = calculateRadiographicPixelSpacing(instance);
+      expect(result.type).toBe(CalibrationTypes.ERMF);
+      expect(result.PixelSpacing).toBe(PixelSpacing);
+      expect(result.Message).toBe(Messages.CORRECTED_AT_MODALITY);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('Should warn when calibration is GEOMETRY but PixelSpacing equals ImagerPixelSpacing', () => {
+      const instance = {
+        PixelSpacing: [75, 75],
+        ImagerPixelSpacing: [75, 75],
+        PixelSpacingCalibrationType: 'GEOMETRY',
+      };
+      const { type } = calculateRadiographicPixelSpacing(instance);
+      expect(type).toBe(CalibrationTypes.ERMF);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('Should not warn when calibration is GEOMETRY and ImagerPixelSpacing is absent', () => {
+      const instance = {
+        PixelSpacing,
+        PixelSpacingCalibrationType: 'GEOMETRY',
+      };
+      const { type, Message } = calculateRadiographicPixelSpacing(instance);
+      expect(type).toBe(CalibrationTypes.ERMF);
+      expect(Message).toBe(Messages.CORRECTED_AT_MODALITY);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('Should correct ImagerPixelSpacing by ERMF when ERMF > 1', () => {
+      const instance = {
+        ImagerPixelSpacing: [2, 2],
+        EstimatedRadiographicMagnificationFactor: 2,
+      };
+      const result = calculateRadiographicPixelSpacing(instance);
+      expect(result.type).toBe(CalibrationTypes.ERMF);
+      expect(result.PixelSpacing).toEqual([1, 1]);
+      expect(result.Message).toBe(Messages.CORRECTED_USING_ERMF);
+    });
+
+    it('Should pass-through PixelSpacing when ERMF is boolean true (pre-corrected)', () => {
+      const instance = {
+        ImagerPixelSpacing,
+        PixelSpacing,
+      };
+      const result = calculateRadiographicPixelSpacing(instance);
+      // getERMF returns true here because ImagerPixelSpacing[0] > PixelSpacing[0]
+      expect(result.type).toBe(CalibrationTypes.ERMF);
+      expect(result.PixelSpacing).toBe(PixelSpacing);
+      expect(result.Message).toBe(Messages.CORRECTED_USING_ERMF);
+    });
+
+    it('Should log an error and fall through when ERMF is an illegal numeric value (<=1)', () => {
+      const instance = {
+        ImagerPixelSpacing,
+        EstimatedRadiographicMagnificationFactor: 0.5,
+      };
+      const result = calculateRadiographicPixelSpacing(instance);
+      expect(errorSpy).toHaveBeenCalledWith('Illegal ERMF value:', 0.5);
+      // Falls through to the PROJECTION branch since ImagerPixelSpacing is valid
+      expect(result.type).toBe(CalibrationTypes.PROJECTION);
+      expect(result.PixelSpacing).toBe(ImagerPixelSpacing);
+      expect(result.Message).toBe(Messages.NOT_CORRECTED_AT_DETECTOR);
+    });
+
+    it('Should return Projection using PixelSpacing when both spacings are present without ERMF', () => {
+      // Same-valued spacings and no sid/sod/ermf — getERMF is undefined
+      const instance = {
+        PixelSpacing: [0.5, 0.5],
+        ImagerPixelSpacing: [0.5, 0.5],
+      };
+      const result = calculateRadiographicPixelSpacing(instance);
+      expect(result.type).toBe(CalibrationTypes.PROJECTION);
+      expect(result.PixelSpacing).toBe(instance.PixelSpacing);
+      expect(result.Message).toBe(Messages.CORRECTED_AT_MODALITY);
+    });
+
+    it('Should return Projection using ImagerPixelSpacing when only ImagerPixelSpacing is valid', () => {
       const instance = {
         ImagerPixelSpacing,
       };
-      const { type } = calculateRadiographicPixelSpacing(instance);
-      expect(type).toBe('Proj');
+      const result = calculateRadiographicPixelSpacing(instance);
+      expect(result.type).toBe(CalibrationTypes.PROJECTION);
+      expect(result.PixelSpacing).toBe(ImagerPixelSpacing);
+      expect(result.Message).toBe(Messages.NOT_CORRECTED_AT_DETECTOR);
     });
-    it('Should return Unknown for pixel only', () => {
+
+    it('Should return Unknown/UNCERTAIN when only PixelSpacing is present', () => {
       const instance = {
         PixelSpacing,
       };
-      const { type } = calculateRadiographicPixelSpacing(instance);
-      expect(type).toBe('Unknown');
+      const result = calculateRadiographicPixelSpacing(instance);
+      expect(result.type).toBe(CalibrationTypes.UNKNOWN);
+      expect(result.PixelSpacing).toBe(PixelSpacing);
+      expect(result.Message).toBe(Messages.UNCERTAIN);
     });
-    it('Should return ERMF', () => {
+
+    it('Should return Unknown/NOT_CALIBRATED when neither spacing is present', () => {
+      const result = calculateRadiographicPixelSpacing({});
+      expect(result.type).toBe(CalibrationTypes.UNKNOWN);
+      expect(result.PixelSpacing).toBeUndefined();
+      expect(result.Message).toBe(Messages.NOT_CALIBRATED);
+    });
+
+    it('Should treat invalid ImagerPixelSpacing (zero values) as not usable', () => {
+      // hasImagerPixelSpacing true, but isValidSpacing false → branch falls through
       const instance = {
-        ImagerPixelSpacing,
+        PixelSpacing,
+        ImagerPixelSpacing: [0, 0],
+      };
+      const result = calculateRadiographicPixelSpacing(instance);
+      expect(result.type).toBe(CalibrationTypes.UNKNOWN);
+      expect(result.PixelSpacing).toBe(PixelSpacing);
+      expect(result.Message).toBe(Messages.UNCERTAIN);
+    });
+
+    it('Should treat non-array ImagerPixelSpacing as absent', () => {
+      const instance = {
+        PixelSpacing,
+        ImagerPixelSpacing: 'not-an-array',
+      };
+      const result = calculateRadiographicPixelSpacing(instance);
+      expect(result.type).toBe(CalibrationTypes.UNKNOWN);
+      expect(result.PixelSpacing).toBe(PixelSpacing);
+      expect(result.Message).toBe(Messages.UNCERTAIN);
+    });
+
+    it('Should treat wrong-length PixelSpacing as absent', () => {
+      const instance = {
+        PixelSpacing: [1],
+        PixelSpacingCalibrationType: 'FIDUCIAL',
+      };
+      const result = calculateRadiographicPixelSpacing(instance);
+      // FIDUCIAL branch requires hasSpacing, so this falls through to NOT_CALIBRATED
+      expect(result.type).toBe(CalibrationTypes.UNKNOWN);
+      expect(result.Message).toBe(Messages.NOT_CALIBRATED);
+    });
+  });
+
+  describe('getPixelSpacingInformation', () => {
+    it('Should delegate to calculateRadiographicPixelSpacing for a projection SOPClassUID', () => {
+      const instance = {
+        SOPClassUID: CR_SOP_CLASS_UID,
+        PixelSpacing,
+        PixelSpacingCalibrationType: 'FIDUCIAL',
+      };
+      const result = getPixelSpacingInformation(instance);
+      expect(result.type).toBe(CalibrationTypes.CALIBRATED);
+      expect(result.isProjection).toBe(true);
+      expect(result.Message).toBe(Messages.USER_CALIBRATED);
+    });
+
+    it('Should return NOT_APPLICABLE for non-projection SOPClassUID', () => {
+      const instance = {
+        SOPClassUID: CT_SOP_CLASS_UID,
         PixelSpacing,
       };
-      const { type } = calculateRadiographicPixelSpacing(instance);
-      expect(type).toBe('ERMF');
+      const result = getPixelSpacingInformation(instance);
+      expect(result.type).toBe(CalibrationTypes.NOT_APPLICABLE);
+      expect(result.isProjection).toBe(false);
+      expect(result.PixelSpacing).toBe(PixelSpacing);
+      expect(result.Message).toBeUndefined();
+    });
+
+    it('Should return NOT_APPLICABLE when SOPClassUID is missing', () => {
+      const result = getPixelSpacingInformation({ PixelSpacing });
+      expect(result.type).toBe(CalibrationTypes.NOT_APPLICABLE);
+      expect(result.isProjection).toBe(false);
     });
   });
 });


### PR DESCRIPTION
This pull request enhances the logic and robustness of pixel spacing calibration in radiographic imaging utilities, adding clearer handling for various calibration scenarios and significantly expanding the unit tests to cover edge cases. The main functional improvements include the introduction of standardized measurement messages, more precise branching for calibration types, and improved validation for pixel spacing values.

Key improvements and additions:

**Calibration Logic & Messaging Enhancements:**

* Introduced a `MeasurementMessages` object to standardize user-facing messages for different calibration outcomes, improving clarity and maintainability.
* Refactored the `calculateRadiographicPixelSpacing` function to:
  - Use new helper functions (`hasSpacing`, `isValidSpacing`) for safer pixel spacing validation.
  - Add more granular calibration type handling, including explicit messages for each scenario (e.g., user-calibrated, corrected at modality, corrected using ERMF, not calibrated, uncertain).
  - Ensure correct prioritization when both `FIDUCIAL` and `GEOMETRY` calibration types are present, and handle invalid or missing spacing data gracefully. [[1]](diffhunk://#diff-a1d75b850580a99c69238cc6723ebc50d2f56f238c0255814340a926985a48d1R93-R129) [[2]](diffhunk://#diff-a1d75b850580a99c69238cc6723ebc50d2f56f238c0255814340a926985a48d1R138-R190)

**Testing Improvements:**

* Greatly expanded the test suite for pixel spacing utilities:
  - Added comprehensive tests for all calibration scenarios, including edge cases such as missing or invalid spacing, illegal ERMF values, and both projection and non-projection SOPClassUIDs.
  - Used spies to verify warning/error logging behavior.
  - Ensured all new message and calibration branches are covered by assertions. [[1]](diffhunk://#diff-eaedaa905bf55807dd71203260c79f69ccde4033b6ed86f3575901fb99617c57R4-R32) [[2]](diffhunk://#diff-eaedaa905bf55807dd71203260c79f69ccde4033b6ed86f3575901fb99617c57L39-R62) [[3]](diffhunk://#diff-eaedaa905bf55807dd71203260c79f69ccde4033b6ed86f3575901fb99617c57R71-R289)

**Validation & Error Handling:**

* Improved validation for `PixelSpacing` and `ImagerPixelSpacing` to ensure only valid arrays of positive numbers are accepted, preventing subtle bugs and incorrect calibration results. [[1]](diffhunk://#diff-a1d75b850580a99c69238cc6723ebc50d2f56f238c0255814340a926985a48d1R48-R70) [[2]](diffhunk://#diff-a1d75b850580a99c69238cc6723ebc50d2f56f238c0255814340a926985a48d1R93-R129)
* Added explicit error logging for illegal ERMF values and ensured fallback logic is robust in these cases. [[1]](diffhunk://#diff-a1d75b850580a99c69238cc6723ebc50d2f56f238c0255814340a926985a48d1R138-R190) [[2]](diffhunk://#diff-eaedaa905bf55807dd71203260c79f69ccde4033b6ed86f3575901fb99617c57R71-R289)

These changes make the calibration logic more robust, user-friendly, and easier to maintain, while the improved test coverage helps ensure correctness and easier future refactoring.

**References:** [[1]](diffhunk://#diff-a1d75b850580a99c69238cc6723ebc50d2f56f238c0255814340a926985a48d1R48-R70) [[2]](diffhunk://#diff-a1d75b850580a99c69238cc6723ebc50d2f56f238c0255814340a926985a48d1R93-R129) [[3]](diffhunk://#diff-a1d75b850580a99c69238cc6723ebc50d2f56f238c0255814340a926985a48d1R138-R190) [[4]](diffhunk://#diff-eaedaa905bf55807dd71203260c79f69ccde4033b6ed86f3575901fb99617c57R4-R32) [[5]](diffhunk://#diff-eaedaa905bf55807dd71203260c79f69ccde4033b6ed86f3575901fb99617c57L39-R62) [[6]](diffhunk://#diff-eaedaa905bf55807dd71203260c79f69ccde4033b6ed86f3575901fb99617c57R71-R289)