### PR TITLE
fix(dicom-image-loader): use Float32Array for non-integer rescale slopes to prevent pixel data corruption

### DIFF
--- a/packages/core/src/types/ScalingParameters.ts
+++ b/packages/core/src/types/ScalingParameters.ts
@@ -11,6 +11,8 @@ interface ScalingParameters {
   suvlbm?: number;
   /** SUV body surface area */
   suvbsa?: number;
+  /** dose grid scaling factor applied for RTDOSE modality */
+  doseGridScaling?: number;
 }
 
 interface PTScaling {

--- a/packages/core/src/utilities/generateVolumePropsFromImageIds.ts
+++ b/packages/core/src/utilities/generateVolumePropsFromImageIds.ts
@@ -129,6 +129,10 @@ function _determineDataType(
 
   switch (BitsAllocated) {
     case 8:
+      // Fall back to Float32 for non-integer scaling, like the 16-bit case. See #2706.
+      if (canRenderFloat && floatAfterScale) {
+        return 'Float32Array';
+      }
       return 'Uint8Array';
 
     case 16:

--- a/packages/core/src/utilities/getScalingMode.ts
+++ b/packages/core/src/utilities/getScalingMode.ts
@@ -1,0 +1,30 @@
+import type { ScalingParameters } from '../types';
+
+export type ScalingMode = 'PT_SUV' | 'RTDOSE' | 'RESCALE' | 'NONE';
+
+/**
+ * Which modality-specific scaling transform is applied to the pixel data.
+ * Mirrored in dicom-image-loader (its worker can't import core runtime); keep
+ * both in sync.
+ */
+export function getScalingMode(
+  scalingParameters: ScalingParameters
+): ScalingMode {
+  const { rescaleSlope, rescaleIntercept, modality, doseGridScaling, suvbw } =
+    scalingParameters;
+
+  if (modality === 'PT' && typeof suvbw === 'number' && !isNaN(suvbw)) {
+    return 'PT_SUV';
+  }
+  if (
+    modality === 'RTDOSE' &&
+    typeof doseGridScaling === 'number' &&
+    !isNaN(doseGridScaling)
+  ) {
+    return 'RTDOSE';
+  }
+  if (typeof rescaleSlope === 'number' && typeof rescaleIntercept === 'number') {
+    return 'RESCALE';
+  }
+  return 'NONE';
+}

--- a/packages/core/src/utilities/hasFloatScalingParameters.ts
+++ b/packages/core/src/utilities/hasFloatScalingParameters.ts
@@ -1,15 +1,28 @@
 import type { ScalingParameters } from '../types';
+import { getScalingMode } from './getScalingMode';
 
 /**
- * Checks if the scaling parameters contain a float rescale value.
- * @param scalingParameters - The scaling parameters to check.
- * @returns True if the scaling parameters contain a float rescale value, false otherwise.
+ * True if the applied scaling can produce non-integer output (needs Float32).
+ * Only inspects parameters used by the current modality. See #2706.
  */
 export const hasFloatScalingParameters = (
   scalingParameters: ScalingParameters
 ): boolean => {
-  const hasFloatRescale = Object.values(scalingParameters).some(
-    (value) => typeof value === 'number' && !Number.isInteger(value)
-  );
-  return hasFloatRescale;
+  const { rescaleSlope, rescaleIntercept, doseGridScaling, suvbw } =
+    scalingParameters;
+  const isFloat = (value: unknown): boolean =>
+    typeof value === 'number' && !Number.isInteger(value);
+
+  switch (getScalingMode(scalingParameters)) {
+    case 'PT_SUV':
+      return (
+        isFloat(suvbw) || isFloat(rescaleSlope) || isFloat(rescaleIntercept)
+      );
+    case 'RTDOSE':
+      return isFloat(doseGridScaling);
+    case 'RESCALE':
+      return isFloat(rescaleSlope) || isFloat(rescaleIntercept);
+    default:
+      return false;
+  }
 };

--- a/packages/core/src/utilities/index.ts
+++ b/packages/core/src/utilities/index.ts
@@ -70,6 +70,7 @@ import getViewportImageIds from './getViewportImageIds';
 import { getRandomSampleFromArray } from './getRandomSampleFromArray';
 import { getVolumeId } from './getVolumeId';
 import { hasFloatScalingParameters } from './hasFloatScalingParameters';
+import { getScalingMode } from './getScalingMode';
 import { pointInShapeCallback } from './pointInShapeCallback';
 // name spaces
 export * as planar from './planar';
@@ -194,6 +195,7 @@ export {
   getVolumeId,
   color,
   hasFloatScalingParameters,
+  getScalingMode,
   getDynamicVolumeInfo,
   autoLoad,
   scaleArray,

--- a/packages/core/src/utilities/windowLevel.ts
+++ b/packages/core/src/utilities/windowLevel.ts
@@ -58,11 +58,8 @@ function toLowHighRange(
   lower: number;
   upper: number;
 } {
-  // When WindowWidth <= 1, the LINEAR formula produces lower === upper
-  // (degenerate range) because (WW-1) becomes 0 or negative. This causes
-  // division by zero in the VOI LUT shader. Fall back to LINEAR_EXACT
-  // which handles all positive WW values correctly.
-  // See: https://github.com/cornerstonejs/cornerstone3D/issues/2706
+  // LINEAR formula produces lower === upper when WW <= 1 because (WW-1)
+  // becomes 0. Fall back to LINEAR_EXACT to avoid division by zero. See #2706.
   if (windowWidth <= 1 && voiLUTFunction === VOILUTFunctionType.LINEAR) {
     voiLUTFunction = VOILUTFunctionType.LINEAR_EXACT;
   }

--- a/packages/core/src/utilities/windowLevel.ts
+++ b/packages/core/src/utilities/windowLevel.ts
@@ -58,6 +58,15 @@ function toLowHighRange(
   lower: number;
   upper: number;
 } {
+  // When WindowWidth <= 1, the LINEAR formula produces lower === upper
+  // (degenerate range) because (WW-1) becomes 0 or negative. This causes
+  // division by zero in the VOI LUT shader. Fall back to LINEAR_EXACT
+  // which handles all positive WW values correctly.
+  // See: https://github.com/cornerstonejs/cornerstone3D/issues/2706
+  if (windowWidth <= 1 && voiLUTFunction === VOILUTFunctionType.LINEAR) {
+    voiLUTFunction = VOILUTFunctionType.LINEAR_EXACT;
+  }
+
   // Note: The SIGMOID function is currently treated the same as LINEAR
   // because we don't have a good way to define "bounds" for it.
   // Remove or statement when fixed

--- a/packages/core/src/utilities/windowLevel.ts
+++ b/packages/core/src/utilities/windowLevel.ts
@@ -58,9 +58,13 @@ function toLowHighRange(
   lower: number;
   upper: number;
 } {
-  // LINEAR formula produces lower === upper when WW <= 1 because (WW-1)
-  // becomes 0. Fall back to LINEAR_EXACT to avoid division by zero. See #2706.
-  if (windowWidth <= 1 && voiLUTFunction === VOILUTFunctionType.LINEAR) {
+  // WW <= 1 makes (WW-1) = 0, so LINEAR/SAMPLED_SIGMOID produce lower === upper
+  // (division by zero). Fall back to LINEAR_EXACT. See #2706.
+  if (
+    windowWidth <= 1 &&
+    (voiLUTFunction === VOILUTFunctionType.LINEAR ||
+      voiLUTFunction === VOILUTFunctionType.SAMPLED_SIGMOID)
+  ) {
     voiLUTFunction = VOILUTFunctionType.LINEAR_EXACT;
   }
 

--- a/packages/dicomImageLoader/src/decodeImageFrameWorker.js
+++ b/packages/dicomImageLoader/src/decodeImageFrameWorker.js
@@ -244,13 +244,10 @@ function _handlePreScaleSetup(
   const scalingParameters = options.preScale.scalingParameters;
   _validateScalingParameters(scalingParameters);
 
-  // When scaling parameters contain non-integer values (e.g. rescaleSlope=0.001
-  // for DTI FA maps), the scaled pixel values will be fractional (e.g. 0.013,
-  // 0.5, 0.999). Force Float32Array to prevent truncation that would occur if
-  // getPixelDataTypeFromMinMax selects an integer array type — which happens
-  // when scaled min/max are "integer-like" (e.g. 0.0 and 1.0) because
-  // Number.isInteger(1.0) === true in JavaScript.
-  // See: https://github.com/cornerstonejs/cornerstone3D/issues/2706
+  // Force Float32Array when scaling parameters are non-integer to avoid
+  // getPixelDataTypeFromMinMax selecting Uint8Array (Number.isInteger(1.0)
+  // is true in JS, so scaled min/max can appear integer even when values
+  // between them are fractional). See #2706.
   const hasFloatRescale = Object.values(scalingParameters).some(
     (v) => typeof v === 'number' && !Number.isInteger(v)
   );

--- a/packages/dicomImageLoader/src/decodeImageFrameWorker.js
+++ b/packages/dicomImageLoader/src/decodeImageFrameWorker.js
@@ -244,6 +244,23 @@ function _handlePreScaleSetup(
   const scalingParameters = options.preScale.scalingParameters;
   _validateScalingParameters(scalingParameters);
 
+  // When scaling parameters contain non-integer values (e.g. rescaleSlope=0.001
+  // for DTI FA maps), the scaled pixel values will be fractional (e.g. 0.013,
+  // 0.5, 0.999). Force Float32Array to prevent truncation that would occur if
+  // getPixelDataTypeFromMinMax selects an integer array type — which happens
+  // when scaled min/max are "integer-like" (e.g. 0.0 and 1.0) because
+  // Number.isInteger(1.0) === true in JavaScript.
+  // See: https://github.com/cornerstonejs/cornerstone3D/issues/2706
+  const hasFloatRescale = Object.values(scalingParameters).some(
+    (v) => typeof v === 'number' && !Number.isInteger(v)
+  );
+
+  if (hasFloatRescale) {
+    const typedArray = new Float32Array(imageFrame.pixelData.length);
+    typedArray.set(imageFrame.pixelData, 0);
+    return typedArray;
+  }
+
   const scaledValues = _calculateScaledMinMax(
     minBeforeScale,
     maxBeforeScale,

--- a/packages/dicomImageLoader/src/decodeImageFrameWorker.js
+++ b/packages/dicomImageLoader/src/decodeImageFrameWorker.js
@@ -19,6 +19,10 @@ import getMinMax from './shared/getMinMax';
 import getPixelDataTypeFromMinMax, {
   validatePixelDataType,
 } from './shared/getPixelDataTypeFromMinMax';
+import {
+  getScalingMode,
+  hasNonIntegerScaling,
+} from './shared/scaling/getScalingMode';
 import isColorImage from './shared/isColorImage';
 
 const imageUtils = {
@@ -77,10 +81,7 @@ export function postProcessDecodedPixels(
   const willScale = options.preScale?.enabled;
 
   const hasFloatRescale =
-    willScale &&
-    Object.values(options.preScale.scalingParameters).some(
-      (v) => typeof v === 'number' && !Number.isInteger(v)
-    );
+    willScale && hasNonIntegerScaling(options.preScale.scalingParameters);
 
   const disableScale =
     !options.preScale.enabled || (!canRenderFloat && hasFloatRescale);
@@ -97,11 +98,17 @@ export function postProcessDecodedPixels(
       maxBeforeScale,
       scalingParameters
     );
-    invalidType = !validatePixelDataType(
-      scaledValues.min,
-      scaledValues.max,
-      typedArrayConstructors[type]
-    );
+    // Non-integer scaling into an integer target truncates. Scaled min/max can
+    // look integer (e.g. [0, 1]) so validatePixelDataType alone isn't enough.
+    // See #2706.
+    const isFloatTarget = typedArrayConstructors[type] === Float32Array;
+    invalidType =
+      (hasFloatRescale && !isFloatTarget) ||
+      !validatePixelDataType(
+        scaledValues.min,
+        scaledValues.max,
+        typedArrayConstructors[type]
+      );
   }
 
   if (type && !invalidType) {
@@ -116,7 +123,8 @@ export function postProcessDecodedPixels(
       options,
       minBeforeScale,
       maxBeforeScale,
-      imageFrame
+      imageFrame,
+      hasFloatRescale
     );
   } else {
     pixelDataArray = _getDefaultPixelDataArray(
@@ -239,19 +247,14 @@ function _handlePreScaleSetup(
   options,
   minBeforeScale,
   maxBeforeScale,
-  imageFrame
+  imageFrame,
+  hasFloatRescale
 ) {
   const scalingParameters = options.preScale.scalingParameters;
   _validateScalingParameters(scalingParameters);
 
-  // Force Float32Array when scaling parameters are non-integer to avoid
-  // getPixelDataTypeFromMinMax selecting Uint8Array (Number.isInteger(1.0)
-  // is true in JS, so scaled min/max can appear integer even when values
-  // between them are fractional). See #2706.
-  const hasFloatRescale = Object.values(scalingParameters).some(
-    (v) => typeof v === 'number' && !Number.isInteger(v)
-  );
-
+  // Force Float32Array for non-integer scaling; scaled min/max can look integer
+  // (e.g. [0, 1]) and mislead getPixelDataTypeFromMinMax. See #2706.
   if (hasFloatRescale) {
     const typedArray = new Float32Array(imageFrame.pixelData.length);
     typedArray.set(imageFrame.pixelData, 0);
@@ -281,36 +284,30 @@ function _getDefaultPixelDataArray(min, max, imageFrame) {
 }
 
 function _calculateScaledMinMax(minValue, maxValue, scalingParameters) {
-  const { rescaleSlope, rescaleIntercept, modality, doseGridScaling, suvbw } =
+  const { rescaleSlope, rescaleIntercept, doseGridScaling, suvbw } =
     scalingParameters;
 
-  if (modality === 'PT' && typeof suvbw === 'number' && !isNaN(suvbw)) {
-    return {
-      min: suvbw * (minValue * rescaleSlope + rescaleIntercept),
-      max: suvbw * (maxValue * rescaleSlope + rescaleIntercept),
-    };
-  } else if (
-    modality === 'RTDOSE' &&
-    typeof doseGridScaling === 'number' &&
-    !isNaN(doseGridScaling)
-  ) {
-    return {
-      min: minValue * doseGridScaling,
-      max: maxValue * doseGridScaling,
-    };
-  } else if (
-    typeof rescaleSlope === 'number' &&
-    typeof rescaleIntercept === 'number'
-  ) {
-    return {
-      min: rescaleSlope * minValue + rescaleIntercept,
-      max: rescaleSlope * maxValue + rescaleIntercept,
-    };
-  } else {
-    return {
-      min: minValue,
-      max: maxValue,
-    };
+  switch (getScalingMode(scalingParameters)) {
+    case 'PT_SUV':
+      return {
+        min: suvbw * (minValue * rescaleSlope + rescaleIntercept),
+        max: suvbw * (maxValue * rescaleSlope + rescaleIntercept),
+      };
+    case 'RTDOSE':
+      return {
+        min: minValue * doseGridScaling,
+        max: maxValue * doseGridScaling,
+      };
+    case 'RESCALE':
+      return {
+        min: rescaleSlope * minValue + rescaleIntercept,
+        max: rescaleSlope * maxValue + rescaleIntercept,
+      };
+    default:
+      return {
+        min: minValue,
+        max: maxValue,
+      };
   }
 }
 

--- a/packages/dicomImageLoader/src/imageLoader/setPixelDataType.ts
+++ b/packages/dicomImageLoader/src/imageLoader/setPixelDataType.ts
@@ -8,10 +8,8 @@ import getPixelDataTypeFromMinMax from '../shared/getPixelDataTypeFromMinMax';
  * min and max values
  */
 function setPixelDataType(imageFrame) {
-  // If the pixel data is already Float32Array (e.g. from _handlePreScaleSetup
-  // forcing Float32 for non-integer rescale slopes), skip re-typing to prevent
-  // getPixelDataTypeFromMinMax from downgrading it to Uint8Array.
-  // See: https://github.com/cornerstonejs/cornerstone3D/issues/2706
+  // Skip re-typing if already Float32Array to prevent downgrading to
+  // Uint8Array via getPixelDataTypeFromMinMax. See #2706.
   if (imageFrame.pixelData instanceof Float32Array) {
     return;
   }

--- a/packages/dicomImageLoader/src/imageLoader/setPixelDataType.ts
+++ b/packages/dicomImageLoader/src/imageLoader/setPixelDataType.ts
@@ -8,6 +8,14 @@ import getPixelDataTypeFromMinMax from '../shared/getPixelDataTypeFromMinMax';
  * min and max values
  */
 function setPixelDataType(imageFrame) {
+  // If the pixel data is already Float32Array (e.g. from _handlePreScaleSetup
+  // forcing Float32 for non-integer rescale slopes), skip re-typing to prevent
+  // getPixelDataTypeFromMinMax from downgrading it to Uint8Array.
+  // See: https://github.com/cornerstonejs/cornerstone3D/issues/2706
+  if (imageFrame.pixelData instanceof Float32Array) {
+    return;
+  }
+
   const minValue = imageFrame.smallestPixelValue;
   const maxValue = imageFrame.largestPixelValue;
 

--- a/packages/dicomImageLoader/src/shared/scaling/getScalingMode.ts
+++ b/packages/dicomImageLoader/src/shared/scaling/getScalingMode.ts
@@ -1,0 +1,55 @@
+import type { Types } from '@cornerstonejs/core';
+
+export type ScalingMode = 'PT_SUV' | 'RTDOSE' | 'RESCALE' | 'NONE';
+
+/**
+ * Which modality-specific scaling transform is applied to the pixel data.
+ * Single source of truth for scaleArray and _calculateScaledMinMax.
+ */
+export function getScalingMode(
+  scalingParameters: Types.ScalingParameters
+): ScalingMode {
+  const { rescaleSlope, rescaleIntercept, modality, doseGridScaling, suvbw } =
+    scalingParameters;
+
+  if (modality === 'PT' && typeof suvbw === 'number' && !isNaN(suvbw)) {
+    return 'PT_SUV';
+  }
+  if (
+    modality === 'RTDOSE' &&
+    typeof doseGridScaling === 'number' &&
+    !isNaN(doseGridScaling)
+  ) {
+    return 'RTDOSE';
+  }
+  if (typeof rescaleSlope === 'number' && typeof rescaleIntercept === 'number') {
+    return 'RESCALE';
+  }
+  return 'NONE';
+}
+
+/**
+ * True if the applied scaling can produce non-integer output (needs Float32).
+ * Only inspects parameters used by the current modality. See #2706.
+ */
+export function hasNonIntegerScaling(
+  scalingParameters: Types.ScalingParameters
+): boolean {
+  const { rescaleSlope, rescaleIntercept, doseGridScaling, suvbw } =
+    scalingParameters;
+  const isFloat = (v: unknown): boolean =>
+    typeof v === 'number' && !Number.isInteger(v);
+
+  switch (getScalingMode(scalingParameters)) {
+    case 'PT_SUV':
+      return (
+        isFloat(suvbw) || isFloat(rescaleSlope) || isFloat(rescaleIntercept)
+      );
+    case 'RTDOSE':
+      return isFloat(doseGridScaling);
+    case 'RESCALE':
+      return isFloat(rescaleSlope) || isFloat(rescaleIntercept);
+    default:
+      return false;
+  }
+}

--- a/packages/dicomImageLoader/src/shared/scaling/scaleArray.ts
+++ b/packages/dicomImageLoader/src/shared/scaling/scaleArray.ts
@@ -1,4 +1,5 @@
 import type { Types } from '@cornerstonejs/core';
+import { getScalingMode } from './getScalingMode';
 
 export default function scaleArray(
   array: Types.PixelDataTypedArray,
@@ -8,26 +9,22 @@ export default function scaleArray(
   const { rescaleSlope, rescaleIntercept, suvbw, doseGridScaling } =
     scalingParameters;
 
-  if (
-    scalingParameters.modality === 'PT' &&
-    typeof suvbw === 'number' &&
-    !isNaN(suvbw)
-  ) {
-    for (let i = 0; i < arrayLength; i++) {
-      array[i] = suvbw * (array[i] * rescaleSlope + rescaleIntercept);
-    }
-  } else if (
-    scalingParameters.modality === 'RTDOSE' &&
-    typeof doseGridScaling === 'number' &&
-    !isNaN(doseGridScaling)
-  ) {
-    for (let i = 0; i < arrayLength; i++) {
-      array[i] = array[i] * doseGridScaling;
-    }
-  } else {
-    for (let i = 0; i < arrayLength; i++) {
-      array[i] = array[i] * rescaleSlope + rescaleIntercept;
-    }
+  switch (getScalingMode(scalingParameters)) {
+    case 'PT_SUV':
+      for (let i = 0; i < arrayLength; i++) {
+        array[i] = suvbw * (array[i] * rescaleSlope + rescaleIntercept);
+      }
+      break;
+    case 'RTDOSE':
+      for (let i = 0; i < arrayLength; i++) {
+        array[i] = array[i] * doseGridScaling;
+      }
+      break;
+    default:
+      // RESCALE and NONE: linear rescale (matches prior else branch).
+      for (let i = 0; i < arrayLength; i++) {
+        array[i] = array[i] * rescaleSlope + rescaleIntercept;
+      }
   }
 
   return true;


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->

### Context

Fixes #2706

DICOM images with non-integer `RescaleSlope` (e.g. DTI FA maps with `RescaleSlope=0.001`) render as completely black in StackViewport. These images display correctly in other viewers such as RadiAnt and OsiriX.

The legacy Cornerstone had a similar issue ([cornerstonejs/cornerstone#302](https://github.com/cornerstonejs/cornerstone/issues/302), fixed in [PR #303](https://github.com/cornerstonejs/cornerstone/pull/303)).

Two independent bugs are involved:

1. **`getPixelDataTypeFromMinMax(0.0, 1.0)` selects `Uint8Array`** because `Number.isInteger(1.0) === true` in JavaScript. All fractional scaled values (0.013, 0.5, 0.999) are truncated to 0. This function is called twice (web worker + main thread `setPixelDataType`), destroying the data at both stages.

2. **`toLowHighRange` with `WindowWidth=1`** produces `lower === upper === 0` via the LINEAR formula `(WW-1) = 0`, causing division by zero in the VOI shader and a binary black/white image.

### Changes & Results

1. **`_handlePreScaleSetup` in `decodeImageFrameWorker.js`**: Detect non-integer scaling parameters and force `Float32Array` before `getPixelDataTypeFromMinMax` is called.

2. **`setPixelDataType` in `setPixelDataType.ts`**: Skip re-typing if `pixelData` is already `Float32Array`, preventing the main thread from downgrading it to `Uint8Array`.

3. **`toLowHighRange` in `windowLevel.ts`**: When `WindowWidth <= 1` with LINEAR function, fall back to LINEAR_EXACT (`lower = WC - WW/2`, `upper = WC + WW/2`) to produce a valid range.

All three fixes are needed — removing any one results in either a black screen or a binary black/white image.

### Testing

- Load a DTI FA DICOM with `RescaleSlope=0.001` in StackViewport — should display grayscale instead of black
- Load a standard CT DICOM (integer `RescaleSlope=1`) — should be unaffected
- Load a DICOM with `WindowWidth > 1` — `toLowHighRange` should use existing LINEAR formula unchanged

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: macOS
- [x] Node version: 20
- [x] Browser: Chrome

I may be wrong about some of the details — please correct me if I've misunderstood anything. Any feedback would be greatly appreciated. Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an additional dose-based scaling option for RTDOSE images.
  * Improved scaling detection so image data is handled more accurately across PET, RTDOSE, and standard rescale cases.

* **Bug Fixes**
  * Fixed pixel type handling for cases where scaling produces non-integer values, reducing unexpected truncation.
  * Improved rendering of very small window widths for certain display settings.
  * Prevented already floating-point pixel data from being downgraded during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->