### PR TITLE
fix: Guard Crosshairs mouse move without annotations

### DIFF
--- a/packages/tools/src/tools/CrosshairsTool.ts
+++ b/packages/tools/src/tools/CrosshairsTool.ts
@@ -741,6 +741,10 @@ class CrosshairsTool extends AnnotationTool {
     evt: EventTypes.MouseMoveEventType,
     filteredToolAnnotations: Annotations
   ): boolean => {
+    if (!filteredToolAnnotations) {
+      return false;
+    }
+
     const { element, currentPoints } = evt.detail;
     const canvasCoords = currentPoints.canvas;
     let imageNeedsUpdate = false;


### PR DESCRIPTION
## Summary
- return early from `CrosshairsTool.mouseMoveCallback` when no filtered annotations are provided
- avoid a follow-up `Cannot read properties of undefined (reading 'length')` crash during viewport/tool-state transitions

## Context
We hit this when switching out of 2D MPR in an OHIF integration: the mouse move callback could be invoked while no filtered Crosshairs annotations were available yet.

## Test
- `npx oxlint packages/tools/src/tools/CrosshairsTool.ts --quiet`

The lint command completed with 0 errors; it reported 3 existing warnings in the file.