### PR TITLE
[codex] Fix image target id parsing

### DIFF
--- a/packages/tools/src/tools/MagnifyTool.ts
+++ b/packages/tools/src/tools/MagnifyTool.ts
@@ -49,7 +49,7 @@ class MagnifyTool extends BaseTool {
     let referencedImageId;
 
     if (viewport instanceof StackViewport) {
-      referencedImageId = targetId.split('imageId:')[1];
+      referencedImageId = this.getImageIdFromTargetId(targetId);
     }
 
     return referencedImageId;

--- a/packages/tools/src/tools/annotation/ProbeTool.ts
+++ b/packages/tools/src/tools/annotation/ProbeTool.ts
@@ -618,7 +618,7 @@ class ProbeTool extends AnnotationTool {
         // Index[2] for stackViewport is always 0, but for visualization
         // we reset it to be imageId index
         if (targetId.startsWith('imageId:')) {
-          const imageId = targetId.split('imageId:')[1];
+          const imageId = this.getImageIdFromTargetId(targetId);
           const imageURI = csUtils.imageIdToURI(imageId);
           const viewports = csUtils.getViewportsWithImageURI(imageURI);
 

--- a/packages/tools/src/tools/base/BaseTool.spec.ts
+++ b/packages/tools/src/tools/base/BaseTool.spec.ts
@@ -1,0 +1,17 @@
+import BaseTool from './BaseTool';
+
+class TestTool extends BaseTool {
+  public getImageId(targetId: string): string {
+    return this.getImageIdFromTargetId(targetId);
+  }
+}
+
+describe('BaseTool', () => {
+  it('keeps image IDs intact when they contain the target-id delimiter', () => {
+    const tool = new TestTool({}, { supportedInteractionTypes: [] });
+    const imageId =
+      'wadouri:https://example.com/dicom?redirect=imageId:series-1';
+
+    expect(tool.getImageId(`imageId:${imageId}`)).toBe(imageId);
+  });
+});

--- a/packages/tools/src/tools/base/BaseTool.ts
+++ b/packages/tools/src/tools/base/BaseTool.ts
@@ -10,6 +10,7 @@ import type {
 } from '../../types';
 
 const { DefaultHistoryMemo } = csUtils.HistoryMemo;
+const IMAGE_ID_TARGET_PREFIX = 'imageId:';
 
 /**
  * Abstract base class from which all tools derive.
@@ -237,8 +238,8 @@ abstract class BaseTool {
   protected getTargetImageData(
     targetId: string
   ): Types.IImageData | Types.CPUIImageData {
-    if (targetId.startsWith('imageId:')) {
-      const imageId = targetId.split('imageId:')[1];
+    if (targetId.startsWith(IMAGE_ID_TARGET_PREFIX)) {
+      const imageId = this.getImageIdFromTargetId(targetId);
       const imageURI = csUtils.imageIdToURI(imageId);
       let viewports = csUtils.getViewportsWithImageURI(imageURI);
 
@@ -279,6 +280,10 @@ abstract class BaseTool {
         'getTargetIdImage: targetId must start with "imageId:" or "volumeId:"'
       );
     }
+  }
+
+  protected getImageIdFromTargetId(targetId: string): string {
+    return targetId.slice(IMAGE_ID_TARGET_PREFIX.length);
   }
 
   /**

--- a/packages/tools/src/tools/segmentation/RectangleROIThresholdTool.ts
+++ b/packages/tools/src/tools/segmentation/RectangleROIThresholdTool.ts
@@ -86,7 +86,7 @@ class RectangleROIThresholdTool extends RectangleROITool {
     let referencedImageId, volumeId;
 
     if (viewport instanceof StackViewport) {
-      referencedImageId = targetId.split('imageId:')[1];
+      referencedImageId = this.getImageIdFromTargetId(targetId);
     } else {
       volumeId = csUtils.getVolumeId(targetId);
       const imageVolume = cache.getVolume(volumeId);


### PR DESCRIPTION
## Summary

Fix delimiter-unsafe parsing of stack image target IDs. Target IDs use the `imageId:<imageId>` format, but several call sites used `split('imageId:')[1]`, which truncates valid image IDs when the underlying URL or query string also contains `imageId:`.

This change adds a shared `BaseTool` helper that removes only the fixed prefix with `slice`, updates the runtime call sites that parsed image target IDs, and adds regression coverage for an image ID containing the delimiter.

## Impact

Valid stack image IDs containing the literal `imageId:` are preserved for cached stats, probe index calculation, magnification, and rectangle ROI threshold annotations. This avoids incorrect viewport/image lookup and stale or missing measurement recalculation for otherwise valid images.

## Validation

- Confirmed no remaining `split('imageId:')` call sites under `packages/tools/src` or `packages/core/src`.
- Could not run the Jest test suite in this local environment because the repo has no root `node_modules`, `yarn`/`npm`/`npx` are not on `PATH`, and the pre-commit hook also depends on `yarn`.
- Attempted Prettier through a temporary npm bootstrap; repo-configured Prettier could not load `@prettier/plugin-oxc` without the repo dependency tree installed.