### PR TITLE
fix(segmentation): fully remove segmentations from viewport on delete after reload 

### DIFF
--- a/packages/tools/src/stateManagement/segmentation/SegmentationStateManager.ts
+++ b/packages/tools/src/stateManagement/segmentation/SegmentationStateManager.ts
@@ -64,6 +64,12 @@ export default class SegmentationStateManager {
   private _labelmapImageIdReferenceMap = new Map<string, string[]>();
 
   /**
+   * An index mapping each segmentationId to the set of keys it owns in
+   * _labelmapImageIdReferenceMap
+   */
+  private _labelmapKeysBySegmentationId = new Map<string, Set<string>>();
+
+  /**
    * Creates an instance of SegmentationStateManager.
    * @param {string} [uid] - Optional unique identifier for the manager.
    */
@@ -112,6 +118,7 @@ export default class SegmentationStateManager {
   resetState(): void {
     this._stackLabelmapImageIdReferenceMap.clear();
     this._labelmapImageIdReferenceMap.clear();
+    this._labelmapKeysBySegmentationId.clear();
     this.state = Object.freeze(
       csUtils.deepClone(initialDefaultState) as SegmentationState
     );
@@ -206,10 +213,13 @@ export default class SegmentationStateManager {
   removeSegmentation(segmentationId: string): void {
     // Clean up image ID reference maps to prevent stale entries accumulating on reload
     this._stackLabelmapImageIdReferenceMap.delete(segmentationId);
-    for (const key of this._labelmapImageIdReferenceMap.keys()) {
-      if (key.startsWith(`${segmentationId}-`)) {
+
+    const keys = this._labelmapKeysBySegmentationId.get(segmentationId);
+    if (keys) {
+      for (const key of keys) {
         this._labelmapImageIdReferenceMap.delete(key);
       }
+      this._labelmapKeysBySegmentationId.delete(segmentationId);
     }
 
     this.updateState((state) => {
@@ -888,12 +898,20 @@ export default class SegmentationStateManager {
 
     if (!this._labelmapImageIdReferenceMap.has(key)) {
       this._labelmapImageIdReferenceMap.set(key, [labelmapImageId]);
-      return;
+    } else {
+      const currentValues = this._labelmapImageIdReferenceMap.get(key);
+      const newValues = Array.from(
+        new Set([...currentValues, labelmapImageId])
+      );
+      this._labelmapImageIdReferenceMap.set(key, newValues);
     }
 
-    const currentValues = this._labelmapImageIdReferenceMap.get(key);
-    const newValues = Array.from(new Set([...currentValues, labelmapImageId]));
-    this._labelmapImageIdReferenceMap.set(key, newValues);
+    let keys = this._labelmapKeysBySegmentationId.get(segmentationId);
+    if (!keys) {
+      keys = new Set();
+      this._labelmapKeysBySegmentationId.set(segmentationId, keys);
+    }
+    keys.add(key);
   }
 
   _setActiveSegmentation(

--- a/packages/tools/src/stateManagement/segmentation/SegmentationStateManager.ts
+++ b/packages/tools/src/stateManagement/segmentation/SegmentationStateManager.ts
@@ -204,6 +204,14 @@ export default class SegmentationStateManager {
    * @param {string} segmentationId - The ID of the segmentation to remove.
    */
   removeSegmentation(segmentationId: string): void {
+    // Clean up image ID reference maps to prevent stale entries accumulating on reload
+    this._stackLabelmapImageIdReferenceMap.delete(segmentationId);
+    for (const key of this._labelmapImageIdReferenceMap.keys()) {
+      if (key.startsWith(`${segmentationId}-`)) {
+        this._labelmapImageIdReferenceMap.delete(key);
+      }
+    }
+
     this.updateState((state) => {
       // Use Array.prototype.filter to create a new array instead of reassigning
       const filteredSegmentations = state.segmentations.filter(

--- a/packages/tools/src/tools/displayTools/Contour/contourDisplay.ts
+++ b/packages/tools/src/tools/displayTools/Contour/contourDisplay.ts
@@ -38,6 +38,13 @@ function removeRepresentation(
     return;
   }
 
+  const viewportProcessed = processedViewportSegmentations.get(viewportId);
+  if (viewportProcessed) {
+    viewportProcessed.delete(segmentationId);
+  }
+
+  removeContourFromElement(viewportId, segmentationId);
+
   const { viewport } = enabledElement;
 
   if (!renderImmediate) {

--- a/packages/tools/src/tools/displayTools/Contour/contourDisplay.ts
+++ b/packages/tools/src/tools/displayTools/Contour/contourDisplay.ts
@@ -38,13 +38,6 @@ function removeRepresentation(
     return;
   }
 
-  const viewportProcessed = processedViewportSegmentations.get(viewportId);
-  if (viewportProcessed) {
-    viewportProcessed.delete(segmentationId);
-  }
-
-  removeContourFromElement(viewportId, segmentationId);
-
   const { viewport } = enabledElement;
 
   if (!renderImmediate) {

--- a/packages/tools/src/tools/displayTools/Labelmap/removeLabelmapFromElement.ts
+++ b/packages/tools/src/tools/displayTools/Labelmap/removeLabelmapFromElement.ts
@@ -1,5 +1,5 @@
 import { getEnabledElement } from '@cornerstonejs/core';
-import { getLabelmapActorUID } from '../../../stateManagement/segmentation/helpers/getSegmentationActor';
+import { getLabelmapActorEntries } from '../../../stateManagement/segmentation/helpers/getSegmentationActor';
 
 /**
  * Remove the labelmap segmentation representation from the viewport's HTML Element.
@@ -17,7 +17,10 @@ function removeLabelmapFromElement(
   const enabledElement = getEnabledElement(element);
   const { viewport } = enabledElement;
 
-  viewport.removeActors([getLabelmapActorUID(viewport.id, segmentationId)]);
+  const actorEntries = getLabelmapActorEntries(viewport.id, segmentationId);
+  if (actorEntries?.length) {
+    viewport.removeActors(actorEntries.map((entry) => entry.uid));
+  }
 }
 
 export default removeLabelmapFromElement;


### PR DESCRIPTION


<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

Fixes an issue on OHIF https://github.com/OHIF/Viewers/issues/5706 

When a user loads a SEG series, deletes the segmentations, then loads SEG series again and tries to delete it a second time, the segmentation is not fully removed from the viewport. The segments stay visible on the currently displayed slice. 

Reloading SEG series more times makes the segments colors darker as stale actors pile up.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Root Cause
Two bugs working together:

1. `removeSegmentation` never cleaned up `_stackLabelmapImageIdReferenceMap` or `_labelmapImageIdReferenceMap`. On reload, `_labelmapImageIdReferenceMap` accumulated both old and new labelmap frame IDs, causing `addLabelmapToElement` to register multiple actors for the same slice.
2. `removeLabelmapFromElement` only removed the **first** matching actor (`getLabelmapActorUID` → `filteredActors[0]`), leaving the rest on screen.

### Changes 

- **`removeSegmentation`**: clear both reference maps for the segmentation before removing it from state, so a reload always starts clean
- **`removeLabelmapFromElement`**: switch from `getLabelmapActorUID` (singular) to `getLabelmapActorEntries` (plural) and remove all matching actors

### Result
All segments are fully removed from the viewport when user clicks on delete on the second load. 

https://github.com/user-attachments/assets/37e5465c-9c63-42a6-8f0f-153afb2da1d7


<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

- Open a study in a segmentation mode (e.g., StudyInstanceUIDs=1.3.6.1.4.1.14519.5.2.1.256467663913010332776401703474716742458)
- Load SEG series, clicks yes to hydrate segmentations
- From left panel, clicks on `...`, then clicks Delete 
- Verify All segments removed
- Load the SEG series again, hydrate, and delete them again 
- Verify the colors of segments on the first slice stay same (not darker)
- Verify All segments removed from the viewport 

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: macOS 10.15.4
- [x] Node version: v22.13.0
- [x] Browser: Chrome 83.0.4103.116

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
