### PR TITLE
fix(annotations): incorrect area calculation for livewire, spline, rectangle, and planar freehand ROI tools

### DIFF
--- a/packages/tools/src/tools/annotation/LivewireContourTool.ts
+++ b/packages/tools/src/tools/annotation/LivewireContourTool.ts
@@ -1031,43 +1031,36 @@ class LivewireContourTool extends ContourSegmentationBaseTool {
       const deltaInY = vec3.distance(originalWorldPoint, deltaYPoint);
 
       const { imageData } = image;
-      const { scale, areaUnit } = getCalibratedLengthUnitsAndScale(
-        image,
-        () => {
-          const {
-            maxX: canvasMaxX,
-            maxY: canvasMaxY,
-            minX: canvasMinX,
-            minY: canvasMinY,
-          } = math.polyline.getAABB(canvasCoordinates);
+      const { areaUnit } = getCalibratedLengthUnitsAndScale(image, () => {
+        const {
+          maxX: canvasMaxX,
+          maxY: canvasMaxY,
+          minX: canvasMinX,
+          minY: canvasMinY,
+        } = math.polyline.getAABB(canvasCoordinates);
 
-          const topLeftBBWorld = viewport.canvasToWorld([
-            canvasMinX,
-            canvasMinY,
-          ]);
+        const topLeftBBWorld = viewport.canvasToWorld([canvasMinX, canvasMinY]);
 
-          const topLeftBBIndex = utilities.transformWorldToIndex(
-            imageData,
-            topLeftBBWorld
-          );
+        const topLeftBBIndex = utilities.transformWorldToIndex(
+          imageData,
+          topLeftBBWorld
+        );
 
-          const bottomRightBBWorld = viewport.canvasToWorld([
-            canvasMaxX,
-            canvasMaxY,
-          ]);
+        const bottomRightBBWorld = viewport.canvasToWorld([
+          canvasMaxX,
+          canvasMaxY,
+        ]);
 
-          const bottomRightBBIndex = utilities.transformWorldToIndex(
-            imageData,
-            bottomRightBBWorld
-          );
+        const bottomRightBBIndex = utilities.transformWorldToIndex(
+          imageData,
+          bottomRightBBWorld
+        );
 
-          return [topLeftBBIndex, bottomRightBBIndex];
-        }
-      );
-      let area = math.polyline.getArea(canvasCoordinates) / scale / scale;
-
+        return [topLeftBBIndex, bottomRightBBIndex];
+      });
       // Convert from canvas_pixels ^2 to mm^2
-      area *= deltaInX * deltaInY;
+      const area =
+        math.polyline.getArea(canvasCoordinates) * deltaInX * deltaInY;
 
       cachedStats[targetId] = {
         Modality: metadata.Modality,

--- a/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
+++ b/packages/tools/src/tools/annotation/PlanarFreehandROITool.ts
@@ -901,7 +901,7 @@ class PlanarFreehandROITool extends ContourSegmentationBaseTool {
     deltaInX,
     deltaInY,
   }) {
-    const { scale, areaUnit, unit } = calibratedScale;
+    const { areaUnit, unit } = calibratedScale;
 
     const { voxelManager } = viewport.getImageData();
 
@@ -926,9 +926,8 @@ class PlanarFreehandROITool extends ContourSegmentationBaseTool {
       kMax = Math.max(kMax, worldPosIndex[2]);
     }
 
-    let area = polyline.getArea(canvasCoordinates) / scale / scale;
     // Convert from canvas_pixels ^2 to mm^2
-    area *= deltaInX * deltaInY;
+    const area = polyline.getArea(canvasCoordinates) * deltaInX * deltaInY;
 
     const perimeter = PlanarFreehandROITool.calculateLengthInIndex(
       calibratedScale,

--- a/packages/tools/src/tools/annotation/RectangleROITool.ts
+++ b/packages/tools/src/tools/annotation/RectangleROITool.ts
@@ -867,14 +867,14 @@ class RectangleROITool extends AnnotationTool {
         const handles = [pos1Index, pos2Index];
         const calibrate = getCalibratedLengthUnitsAndScale(image, handles);
 
-        const width = RectangleROITool.calculateLengthInIndex(
-          calibrate,
-          indexHandles.slice(0, 2)
-        );
-        const height = RectangleROITool.calculateLengthInIndex(
-          calibrate,
-          indexHandles.slice(2, 4)
-        );
+        const width = RectangleROITool.calculateLengthInIndex(calibrate, [
+          indexHandles[0],
+          indexHandles[1],
+        ]);
+        const height = RectangleROITool.calculateLengthInIndex(calibrate, [
+          indexHandles[0],
+          indexHandles[2],
+        ]);
         const area = Math.abs(width * height);
         const { areaUnit } = calibrate;
 

--- a/packages/tools/src/tools/annotation/SplineROITool.ts
+++ b/packages/tools/src/tools/annotation/SplineROITool.ts
@@ -1297,43 +1297,36 @@ class SplineROITool extends ContourSegmentationBaseTool {
       const deltaInY = vec3.distance(originalWorldPoint, deltaYPoint);
 
       const { imageData } = image;
-      const { scale, areaUnit } = getCalibratedLengthUnitsAndScale(
-        image,
-        () => {
-          const {
-            maxX: canvasMaxX,
-            maxY: canvasMaxY,
-            minX: canvasMinX,
-            minY: canvasMinY,
-          } = math.polyline.getAABB(canvasCoordinates);
+      const { areaUnit } = getCalibratedLengthUnitsAndScale(image, () => {
+        const {
+          maxX: canvasMaxX,
+          maxY: canvasMaxY,
+          minX: canvasMinX,
+          minY: canvasMinY,
+        } = math.polyline.getAABB(canvasCoordinates);
 
-          const topLeftBBWorld = viewport.canvasToWorld([
-            canvasMinX,
-            canvasMinY,
-          ]);
+        const topLeftBBWorld = viewport.canvasToWorld([canvasMinX, canvasMinY]);
 
-          const topLeftBBIndex = utilities.transformWorldToIndex(
-            imageData,
-            topLeftBBWorld
-          );
+        const topLeftBBIndex = utilities.transformWorldToIndex(
+          imageData,
+          topLeftBBWorld
+        );
 
-          const bottomRightBBWorld = viewport.canvasToWorld([
-            canvasMaxX,
-            canvasMaxY,
-          ]);
+        const bottomRightBBWorld = viewport.canvasToWorld([
+          canvasMaxX,
+          canvasMaxY,
+        ]);
 
-          const bottomRightBBIndex = utilities.transformWorldToIndex(
-            imageData,
-            bottomRightBBWorld
-          );
+        const bottomRightBBIndex = utilities.transformWorldToIndex(
+          imageData,
+          bottomRightBBWorld
+        );
 
-          return [topLeftBBIndex, bottomRightBBIndex];
-        }
-      );
-      let area = math.polyline.getArea(canvasCoordinates) / scale / scale;
-
+        return [topLeftBBIndex, bottomRightBBIndex];
+      });
       // Convert from canvas_pixels ^2 to mm^2
-      area *= deltaInX * deltaInY;
+      const area =
+        math.polyline.getArea(canvasCoordinates) * deltaInX * deltaInY;
 
       cachedStats[targetId] = {
         Modality: metadata.Modality,


### PR DESCRIPTION
OHIF_REF: test/update-screenshots

<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

See associated tests in OHIF PR: https://github.com/OHIF/Viewers/pull/6022

### Context
Fixes #2732 

Suspected PRs that broke the area calculations...
- https://github.com/cornerstonejs/cornerstone3D/pull/2415
- https://github.com/cornerstonejs/cornerstone3D/pull/2591

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

#### Root cause

- Contour-based tools (Livewire, Spline, PlanarFreehand): Area was being divided by scale * scale and then multiplied by deltaInX * deltaInY. The delta factors already convert from canvas pixels² to mm², so the extra / scale / scale was a duplicate calibration adjustment that compounded onto the polyline's canvas-space area and produced incorrect values for calibrated images.

- RectangleROITool: The handle pairs used for width/height were both horizontal edges of the rectangle. indexHandles.slice(0, 2) correctly gave one edge, but indexHandles.slice(2, 4) picked the opposite parallel edge rather than a perpendicular one — so width * height was effectively width * width.

#### Changes

  - LivewireContourTool.ts — drop scale from the destructure and remove the / scale / scale division; area is now polyline.getArea(canvasCoordinates) * deltaInX * deltaInY.
  - SplineROITool.ts — same fix as Livewire.
  - PlanarFreehandROITool.ts — same fix; scale no longer pulled off calibratedScale.
  - RectangleROITool.ts — width uses [indexHandles[0], indexHandles[1]] and height uses [indexHandles[0], indexHandles[2]], giving two perpendicular edges instead of two parallel ones.
  
<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
See the associated #2732 .

Run the OHIF automated tests in test/update-screenshots
<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

System:
- OS: Windows 11 10.0.26200
- CPU: (20) x64 12th Gen Intel(R) Core(TM) i7-12700H
- Memory: 5.01 GB / 31.68 GB

Binaries:
- Node: 20.9.0 - C:\Users\joebo\AppData\Local\fnm_multishells\49860_1778779646720\node.EXE
- Yarn: 1.22.22 - C:\Program Files (x86)\Yarn\bin\yarn.CMD
- npm: 10.1.0 - C:\Users\joebo\AppData\Local\fnm_multishells\49860_1778779646720\npm.CMD
- pnpm: 11.1.1 - C:\Users\joebo\AppData\Local\pnpm\bin\pnpm.CMD
- bun: 1.2.23 - C:\Users\joebo\.bun\bin\bun.EXE

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
