### PR TITLE
fix(core): fix RT contour displacement after viewport maximize/restore (one-up and back)

### DIFF
--- a/packages/core/src/RenderingEngine/ContextPoolRenderingEngine.ts
+++ b/packages/core/src/RenderingEngine/ContextPoolRenderingEngine.ts
@@ -235,10 +235,6 @@ class ContextPoolRenderingEngine extends BaseRenderingEngine {
       return;
     }
 
-    if (this._animationFrameSet) {
-      return;
-    }
-
     for (const vp of viewportsNeedingResize) {
       const canvas = getOrCreateCanvas(vp.element);
       const displayedWidth = Math.round(canvas.clientWidth * devicePixelRatio);
@@ -250,6 +246,10 @@ class ContextPoolRenderingEngine extends BaseRenderingEngine {
 
       vp.sWidth = targetWidth;
       vp.sHeight = targetHeight;
+    }
+
+    if (this._animationFrameSet) {
+      return;
     }
 
     if (vtkDrivenViewports.length) {


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

OHIF_REF: fix/6025-contour-offset-double-click

This fixes an issue on ohif: https://github.com/OHIF/Viewers/issues/6025

When a user opens an RT study, hydrates an RTSTRUCT series into a viewport, then double-clicks to maximize that viewport (one-up) and double-clicks again, the RT contours appear displaced from their correct position.

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Root cause
Contour positions are calculated by `worldToCanvas()`, which reads `canvas.width/height`. These are set inside `_copyToOnscreenCanvas()` using `viewport.sWidth/sHeight`.
The bug: `_resizeVTKViewports()` had an early return that fired **before** `sWidth/sHeight` were updated. So when a render frame was already scheduled (common during maximize/restore), the pending render used stale dimensions — causing `worldToCanvas()` to compute wrong pixel positions and displace the contours.

### Changes & Results
`ContextPoolRenderingEngine.ts`: Move the early return to **after** `sWidth/sHeight` are written, so the pending render always has the correct dimensions.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
- Open RT study in segmentation mode (e.g., StudyInstanceUIDs=1.2.840.113619.2.290.3.3767434740.226.1600859119.501)
- Hydrate RTSTRUCT into a viewport 
- Double-click the viewport to maximize (one-up)
- Double-click again 
- Verify contours remain correctly positioned 


<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: macOS 10.15.4
- [x] Node version: v22.13.0
- [x] Browser: Chrome 83.0.4103.116

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
