### PR TITLE
fix: codemod publish and docs 5x

### DIFF
--- a/.github/workflows/publish-codemod-registry.yml
+++ b/.github/workflows/publish-codemod-registry.yml
@@ -57,7 +57,7 @@ jobs:
         if: steps.resolve.outputs.registry_entry == 'cornerstone3d/5'
         run: |
           TARGET="$(mktemp -d)"
-          npx codemod run cornerstone3d/5/generic-viewport --dry-run -t "$TARGET" --allow-dirty --no-interactive
+          npx codemod run @cornerstonejs/cornerstone3d-5-generic-viewport --dry-run -t "$TARGET" --allow-dirty --no-interactive
 
       - name: Publish registry entry
         uses: codemod/publish-action@v1

--- a/packages/codemods/README.md
+++ b/packages/codemods/README.md
@@ -8,23 +8,23 @@ the Codemod registry so users run them with `npx codemod`.
 Run the full Cornerstone3D v5 migration:
 
 ```sh
-npx codemod cornerstone3d/5
+npx codemod @cornerstonejs/cornerstone3d-5
 ```
 
 Run only the Generic Viewport migration:
 
 ```sh
-npx codemod cornerstone3d/5/generic-viewport
+npx codemod @cornerstonejs/cornerstone3d-5-generic-viewport
 ```
 
 ## Registry Packages
 
 This workspace currently includes:
 
-- `cornerstone3d/5`: runs all available Cornerstone3D v5 migration packages in
-  the recommended order.
-- `cornerstone3d/5/generic-viewport`: migrates removed RenderingEngine viewport
-  accessor APIs.
+- `@cornerstonejs/cornerstone3d-5`: runs all available Cornerstone3D v5
+  migration packages in the recommended order.
+- `@cornerstonejs/cornerstone3d-5-generic-viewport`: migrates removed
+  RenderingEngine viewport accessor APIs.
 
 The Generic Viewport migration changes:
 

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -2,12 +2,14 @@
   "name": "@cornerstonejs/codemods",
   "version": "5.0.1",
   "description": "Codemod registry packages for Cornerstone3D migrations",
-  "private": true,
   "keywords": [
     "cornerstone3d",
     "codemod",
     "migration"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/cornerstonejs/cornerstone3D",
   "sideEffects": false,
   "scripts": {

--- a/packages/codemods/registry/cornerstone3d/5/README.md
+++ b/packages/codemods/registry/cornerstone3d/5/README.md
@@ -6,22 +6,23 @@ order.
 ## Usage
 
 ```sh
-npx codemod cornerstone3d/5
+npx codemod @cornerstonejs/cornerstone3d-5
 ```
 
 To preview changes before writing files:
 
 ```sh
-npx codemod cornerstone3d/5 --dry-run
+npx codemod @cornerstonejs/cornerstone3d-5 --dry-run
 ```
 
 ## Included Migrations
 
-- `cornerstone3d/5/generic-viewport`: replaces removed RenderingEngine viewport
-  accessor APIs with Cornerstone3D v5 compatible viewport APIs.
+- `@cornerstonejs/cornerstone3d-5-generic-viewport`: replaces removed
+  RenderingEngine viewport accessor APIs with Cornerstone3D v5 compatible
+  viewport APIs.
 
 ## Publishing
 
 Publish child migration packages before publishing this aggregate package. The
-workflow resolves `cornerstone3d/5/generic-viewport` from the Codemod registry at
-runtime.
+workflow resolves `@cornerstonejs/cornerstone3d-5-generic-viewport` from the
+Codemod registry at runtime.

--- a/packages/codemods/registry/cornerstone3d/5/codemod.yaml
+++ b/packages/codemods/registry/cornerstone3d/5/codemod.yaml
@@ -1,5 +1,5 @@
 schema_version: '1.0'
-name: 'cornerstone3d/5'
+name: '@cornerstonejs/cornerstone3d-5'
 version: '0.1.0'
 description: 'Apply all available Cornerstone3D v5 migration transforms in the recommended order.'
 author: 'Cornerstone.js Contributors'

--- a/packages/codemods/registry/cornerstone3d/5/generic-viewport/README.md
+++ b/packages/codemods/registry/cornerstone3d/5/generic-viewport/README.md
@@ -6,13 +6,13 @@ compatible viewport APIs.
 ## Usage
 
 ```sh
-npx codemod cornerstone3d/5/generic-viewport
+npx codemod @cornerstonejs/cornerstone3d-5-generic-viewport
 ```
 
 To preview changes before writing files:
 
 ```sh
-npx codemod cornerstone3d/5/generic-viewport --dry-run
+npx codemod @cornerstonejs/cornerstone3d-5-generic-viewport --dry-run
 ```
 
 ## Changes

--- a/packages/codemods/registry/cornerstone3d/5/generic-viewport/codemod.yaml
+++ b/packages/codemods/registry/cornerstone3d/5/generic-viewport/codemod.yaml
@@ -1,5 +1,5 @@
 schema_version: '1.0'
-name: 'cornerstone3d/5/generic-viewport'
+name: '@cornerstonejs/cornerstone3d-5-generic-viewport'
 version: '0.1.0'
 description: 'Replace removed RenderingEngine viewport accessors with Cornerstone3D v5 compatible viewport APIs.'
 author: 'Cornerstone.js Contributors'

--- a/packages/codemods/registry/cornerstone3d/5/workflow.yaml
+++ b/packages/codemods/registry/cornerstone3d/5/workflow.yaml
@@ -5,4 +5,4 @@ nodes:
     steps:
       - name: Apply RenderingEngine viewport accessor transform
         codemod:
-          source: cornerstone3d/5/generic-viewport
+          source: '@cornerstonejs/cornerstone3d-5-generic-viewport'

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,6 +67,9 @@
       "types": "./dist/esm/version.d.ts"
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "prebuild": "node ../../scripts/generate-version.js ./",
     "build:esm": "pnpm run prebuild && tsc --project ./tsconfig.json",

--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -73,8 +73,8 @@ module.exports = {
           ],
         },
         {
-          to: '/docs/migration-guides/4x',
-          label: '4.0 Migration Guides',
+          to: '/docs/migration-guides/5x',
+          label: '5.0 Migration Guides',
           position: 'left',
           className: 'new-badge',
         },
@@ -223,7 +223,7 @@ module.exports = {
           onlyIncludeVersions: ['current'],
           versions: {
             current: {
-              label: `4.0 (Latest)`,
+              label: `5.0 (Latest)`,
             },
           },
         },

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -84,6 +84,9 @@
       "types": "./dist/esm/version.d.ts"
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "prebuild": "node ../../scripts/generate-version.js ./",
     "build:esm": "pnpm run prebuild && tsc --project ./tsconfig.json",

--- a/publish-version.mjs
+++ b/publish-version.mjs
@@ -182,9 +182,10 @@ async function run() {
   // creating releases, because lerna only creates a release when it pushes the
   // tag itself. As a result npm kept publishing while GitHub Releases froze.
   //
-  // We now create the release explicitly, after pushing the tag, reusing the
-  // same GH_TOKEN. This is best-effort: a missing token or an API error logs a
-  // warning but never fails the build/release (the npm publish step is separate).
+  // We now create the release explicitly via the gh CLI, after pushing the tag,
+  // reusing the same GH_TOKEN. This is best-effort: a missing token or a CLI
+  // error logs a warning but never fails the build/release (the npm publish step
+  // is separate).
   await createGithubRelease(tagName, nextVersion.trim());
 
   console.log('Version set using lerna');
@@ -203,62 +204,26 @@ async function createGithubRelease(tagName, version) {
     return;
   }
 
-  let owner;
-  let repo;
+  // gh reads GH_TOKEN/GITHUB_TOKEN from the environment and infers the repo from
+  // the origin remote. --verify-tag ensures the tag we just pushed exists before
+  // creating the release.
   try {
-    const { stdout: remoteUrl } = await execa('git', [
-      'config',
-      '--get',
-      'remote.origin.url',
+    await execa('gh', [
+      'release',
+      'create',
+      tagName,
+      '--title',
+      tagName,
+      '--generate-notes',
+      '--verify-tag',
+      ...(version.includes('-') ? ['--prerelease'] : []),
     ]);
-    const match = remoteUrl
-      .trim()
-      .match(/github\.com[:/]+([^/]+)\/(.+?)(?:\.git)?\/?$/);
-    if (!match) {
-      console.warn(
-        `Could not parse owner/repo from "${remoteUrl}" - skipping GitHub release for ${tagName}`
-      );
-      return;
-    }
-    [, owner, repo] = match;
+    console.log(`Created GitHub release ${tagName}`);
   } catch (err) {
     console.warn(
-      `Could not resolve remote origin URL (non-fatal): ${err.message}`
-    );
-    return;
-  }
-
-  try {
-    const response = await fetch(
-      `https://api.github.com/repos/${owner}/${repo}/releases`,
-      {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${ghToken}`,
-          Accept: 'application/vnd.github+json',
-          'X-GitHub-Api-Version': '2022-11-28',
-          'User-Agent': `${repo}-release`,
-        },
-        body: JSON.stringify({
-          tag_name: tagName,
-          name: tagName,
-          generate_release_notes: true,
-          prerelease: version.includes('-'),
-        }),
-      }
-    );
-
-    if (response.ok) {
-      console.log(`Created GitHub release ${tagName}`);
-    } else {
-      const detail = await response.text();
-      console.warn(
-        `GitHub release creation for ${tagName} failed (${response.status}, non-fatal): ${detail}`
-      );
-    }
-  } catch (err) {
-    console.warn(
-      `GitHub release creation for ${tagName} errored (non-fatal): ${err.message}`
+      `GitHub release creation for ${tagName} failed (non-fatal): ${
+        err.shortMessage || err.message
+      }`
     );
   }
 }

--- a/publish-version.mjs
+++ b/publish-version.mjs
@@ -119,6 +119,12 @@ async function run() {
 
   // Run lerna version without pushing
   // lerna will update package.json files and create a commit
+  //
+  // NOTE: --create-release github is intentionally NOT passed here. lerna only
+  // creates the GitHub release when it pushes the tag itself, and we run with
+  // --no-push (so the version bump + generated files land as a single amended
+  // commit). The GitHub release is created explicitly after the tag is pushed,
+  // below.
   await execa('npx', [
     'lerna',
     'version',
@@ -129,8 +135,6 @@ async function run() {
     '--message',
     `chore(version): Update package versions to ${nextVersion} [skip ci]`,
     '--conventional-commits',
-    '--create-release',
-    'github',
     '--no-push',
     // The repo enforces frozenLockfile via pnpm-workspace.yaml, but lerna must
     // update the lockfile after bumping versions. Relax it for this one install.
@@ -170,7 +174,93 @@ async function run() {
   console.log('Pushing tag...');
   await execa('git', ['push', 'origin', tagName]);
 
+  // Create the GitHub release for the tag we just pushed.
+  //
+  // Historically `lerna version --create-release github` created this release,
+  // authenticating with the GH_TOKEN environment variable. When lerna switched
+  // to --no-push (to land the version bump as a single amended commit) it stopped
+  // creating releases, because lerna only creates a release when it pushes the
+  // tag itself. As a result npm kept publishing while GitHub Releases froze.
+  //
+  // We now create the release explicitly, after pushing the tag, reusing the
+  // same GH_TOKEN. This is best-effort: a missing token or an API error logs a
+  // warning but never fails the build/release (the npm publish step is separate).
+  await createGithubRelease(tagName, nextVersion.trim());
+
   console.log('Version set using lerna');
+}
+
+// Best-effort GitHub release creation for an already-pushed tag. Never throws;
+// any failure is logged as a warning so it cannot fail the release.
+async function createGithubRelease(tagName, version) {
+  const ghToken = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+
+  if (!ghToken) {
+    console.warn(
+      `GH_TOKEN/GITHUB_TOKEN not set - skipping GitHub release creation for ${tagName}. ` +
+        'Set GH_TOKEN in the CircleCI project/context environment to enable releases.'
+    );
+    return;
+  }
+
+  let owner;
+  let repo;
+  try {
+    const { stdout: remoteUrl } = await execa('git', [
+      'config',
+      '--get',
+      'remote.origin.url',
+    ]);
+    const match = remoteUrl
+      .trim()
+      .match(/github\.com[:/]+([^/]+)\/(.+?)(?:\.git)?\/?$/);
+    if (!match) {
+      console.warn(
+        `Could not parse owner/repo from "${remoteUrl}" - skipping GitHub release for ${tagName}`
+      );
+      return;
+    }
+    [, owner, repo] = match;
+  } catch (err) {
+    console.warn(
+      `Could not resolve remote origin URL (non-fatal): ${err.message}`
+    );
+    return;
+  }
+
+  try {
+    const response = await fetch(
+      `https://api.github.com/repos/${owner}/${repo}/releases`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${ghToken}`,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+          'User-Agent': `${repo}-release`,
+        },
+        body: JSON.stringify({
+          tag_name: tagName,
+          name: tagName,
+          generate_release_notes: true,
+          prerelease: version.includes('-'),
+        }),
+      }
+    );
+
+    if (response.ok) {
+      console.log(`Created GitHub release ${tagName}`);
+    } else {
+      const detail = await response.text();
+      console.warn(
+        `GitHub release creation for ${tagName} failed (${response.status}, non-fatal): ${detail}`
+      );
+    }
+  } catch (err) {
+    console.warn(
+      `GitHub release creation for ${tagName} errored (non-fatal): ${err.message}`
+    );
+  }
 }
 
 async function unlinkFile(filePath) {

--- a/scripts/generate-version.js
+++ b/scripts/generate-version.js
@@ -12,10 +12,34 @@ if (!packagePath) {
   process.exit(1);
 }
 
-// Get the root directory (two levels up from scripts/)
-const rootDir = path.resolve(__dirname, '..');
+// Only stamp version.ts for packages that are actually published. Published
+// packages set publishConfig.access to 'public'; anything else (e.g. the private
+// docs site) is skipped rather than failing the release.
+const packageJsonPath = path.join(packagePath, 'package.json');
+let packageJson;
+try {
+  packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+} catch (error) {
+  console.log(`Skipping ${packagePath}: could not read package.json`);
+  process.exit(0);
+}
 
-// Read the version.json file from the root directory
+if (packageJson.publishConfig?.access !== 'public') {
+  console.log(`Skipping ${packagePath}: publishConfig.access is not 'public'`);
+  process.exit(0);
+}
+
+// A published package may still have no src directory (e.g. the codemods
+// registry package). There is nowhere to stamp version.ts, so skip rather than
+// fail the release.
+const srcDir = path.join(packagePath, 'src');
+if (!fs.existsSync(srcDir)) {
+  console.log(`Skipping ${packagePath}: no src directory`);
+  process.exit(0);
+}
+
+// Read the version.json file from the root directory (two levels up from scripts/)
+const rootDir = path.resolve(__dirname, '..');
 const versionJsonPath = path.join(rootDir, 'version.json');
 let versionData;
 
@@ -32,15 +56,6 @@ const versionContent = `/**
  * Do not modify this file directly
  */
 export const version = '${versionData.version}';\n`;
-
-// Determine the src directory
-const srcDir = path.join(packagePath, 'src');
-if (!fs.existsSync(srcDir)) {
-  // Packages without a src directory (e.g. private codemods, the docs site)
-  // have nowhere to stamp version.ts. Skip rather than fail the release.
-  console.log(`Skipping ${packagePath}: no src directory`);
-  process.exit(0);
-}
 
 // Write the version.ts file
 const versionFilePath = path.join(srcDir, 'version.ts');


### PR DESCRIPTION
No functitonal change, just publish codemod and versions to github. 
Update the docs to 5.x

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated codemod usage and registry references to use scoped package names across guides and CLI examples
  * Refreshed migration guides, navigation and version labeling to emphasize 5.x migration resources

* **Chores**
  * Improved publish process with best-effort GitHub release creation after tagging; safer token handling and non-blocking failures
  * Made several packages publishable (public) and updated workflows/verifications to use scoped codemod package identifiers
  * Tightened version file generation to only write releases for public packages with source present
<!-- end of auto-generated comment: release notes by coderabbit.ai -->