### PR TITLE
fix: publish GitHub

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v6.0.3
       - uses: pnpm/action-setup@v6.0.8
         with:
-          version: 11.4.0
+          version: 11.5.2
       - uses: actions/setup-node@v6.4.0
         with:
           node-version: '24'

--- a/.github/workflows/docusaurus-build.yml
+++ b/.github/workflows/docusaurus-build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 11.4.0
+          version: 11.5.2
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 11.4.0
+          version: 11.5.2
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ohif-downstream.yml
+++ b/.github/workflows/ohif-downstream.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 120
     env:
-      PNPM_VERSION: 11.4.0
+      PNPM_VERSION: 11.5.2
       BUN_VERSION: 1.2.23
       NODE_VERSION: 24
       OHIF_REF: master

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 11.4.0
+          version: 11.5.2
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 11.4.0
+          version: 11.5.2
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/validate-codemod-registry.yml
+++ b/.github/workflows/validate-codemod-registry.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 11.4.0
+          version: 11.5.2
 
       - uses: actions/setup-node@v4
         with:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Cornerstone is a set of JavaScript libraries that can be used to build web-based
 
 ## Local Setup
 
-This repository is pinned to pnpm 11.4.0 via `packageManager`. Use Corepack to
+This repository is pinned to pnpm 11.5.2 via `packageManager`. Use Corepack to
 run the pinned version:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -180,5 +180,5 @@
     "not ie < 11",
     "not op_mini all"
   ],
-  "packageManager": "pnpm@11.4.0"
+  "packageManager": "pnpm@11.5.2"
 }

--- a/publish-version.mjs
+++ b/publish-version.mjs
@@ -204,26 +204,68 @@ async function createGithubRelease(tagName, version) {
     return;
   }
 
-  // gh reads GH_TOKEN/GITHUB_TOKEN from the environment and infers the repo from
-  // the origin remote. --verify-tag ensures the tag we just pushed exists before
-  // creating the release.
+  // Resolve owner/repo from the origin remote (what the gh CLI used to infer).
+  let repoSlug;
   try {
-    await execa('gh', [
-      'release',
-      'create',
-      tagName,
-      '--title',
-      tagName,
-      '--generate-notes',
-      '--verify-tag',
-      ...(version.includes('-') ? ['--prerelease'] : []),
+    const { stdout: remoteUrl } = await execa('git', [
+      'config',
+      '--get',
+      'remote.origin.url',
     ]);
+    // Match both SSH (git@github.com:owner/repo.git) and HTTPS
+    // (https://github.com/owner/repo[.git]) forms.
+    const match = remoteUrl
+      .trim()
+      .match(/github\.com[:/]([^/]+\/[^/]+?)(?:\.git)?$/);
+    if (!match) {
+      throw new Error(`could not parse owner/repo from "${remoteUrl.trim()}"`);
+    }
+    repoSlug = match[1];
+  } catch (err) {
+    console.warn(
+      `GitHub release creation for ${tagName} skipped (non-fatal) - could not ` +
+        `determine repo from origin remote: ${err.shortMessage || err.message}`
+    );
+    return;
+  }
+
+  // Create the release via the GitHub REST API using fetch (built into Node 24).
+  // We deliberately do NOT shell out to the gh CLI: gh is not installed in the
+  // CircleCI cimg/node image (FROM cimg/base, neither bundles it), which is why
+  // releases silently stopped after lerna switched to --no-push. curl would work
+  // too but means shell-escaping a JSON body, so fetch is cleaner. The tag was
+  // already pushed above, so the API attaches the release to the existing tag,
+  // and generate_release_notes mirrors the old `gh ... --generate-notes`.
+  try {
+    const response = await fetch(
+      `https://api.github.com/repos/${repoSlug}/releases`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${ghToken}`,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+          'Content-Type': 'application/json',
+          'User-Agent': 'cornerstone3D-release-script',
+        },
+        body: JSON.stringify({
+          tag_name: tagName,
+          name: tagName,
+          generate_release_notes: true,
+          prerelease: version.includes('-'),
+        }),
+      }
+    );
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`GitHub API responded ${response.status}: ${body}`);
+    }
+
     console.log(`Created GitHub release ${tagName}`);
   } catch (err) {
     console.warn(
-      `GitHub release creation for ${tagName} failed (non-fatal): ${
-        err.shortMessage || err.message
-      }`
+      `GitHub release creation for ${tagName} failed (non-fatal): ${err.message}`
     );
   }
 }


### PR DESCRIPTION
Switched to direct API usage for gh publish because gh isn't installed in the image
Also update to pnpm 11.5.2.

OHIF_REF: feat/ohifpnpm2

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pnpm package manager to version 11.5.2 across all build workflows and project configuration.
  * Enhanced GitHub release creation process with improved implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->