### PR TITLE
fix(dicomImageLoader): keep PT/RTDOSE scaling for identity modality LUT

### DIFF
--- a/packages/dicomImageLoader/src/imageLoader/getScalingParameters.ts
+++ b/packages/dicomImageLoader/src/imageLoader/getScalingParameters.ts
@@ -18,21 +18,38 @@ export default function getScalingParameters(metaData, imageId: string) {
   const rescaleSlope = modalityLutModule.rescaleSlope;
   const rescaleIntercept = modalityLutModule.rescaleIntercept;
 
-  // Identity transform (slope 1, intercept 0) is implicitly non-prescaled; do not set preScale.
+  const scalingModules = metaData.get('scalingModule', imageId) || {};
+
+  // Modality-specific scaling (PT SUV body weight, RTDOSE dose grid scaling)
+  // must be applied even when the modality LUT is an identity transform. PET
+  // stored in counts (e.g. Philips CNTS) commonly has rescaleSlope 1 /
+  // intercept 0 while still requiring suvbw to convert to SUV, so this is
+  // checked before the identity-transform short-circuit below.
+  const hasPTScaling =
+    modality === 'PT' &&
+    typeof scalingModules.suvbw === 'number' &&
+    !isNaN(scalingModules.suvbw);
+  const hasDoseScaling =
+    modality === 'RTDOSE' &&
+    typeof scalingModules.DoseGridScaling === 'number' &&
+    !isNaN(scalingModules.DoseGridScaling);
+
+  // Identity transform (slope 1, intercept 0) with no modality-specific scaling
+  // is implicitly non-prescaled; do not set preScale.
   if (
     rescaleSlope === 1 &&
-    (rescaleIntercept === 0 || rescaleIntercept == null)
+    (rescaleIntercept === 0 || rescaleIntercept == null) &&
+    !hasPTScaling &&
+    !hasDoseScaling
   ) {
     return undefined;
   }
 
   const scalingParameters = {
-    rescaleSlope,
-    rescaleIntercept,
+    rescaleSlope: rescaleSlope ?? 1,
+    rescaleIntercept: rescaleIntercept ?? 0,
     modality,
   };
-
-  const scalingModules = metaData.get('scalingModule', imageId) || {};
 
   return {
     ...scalingParameters,


### PR DESCRIPTION
## Problem

`getScalingParameters` returns `undefined` whenever the modality LUT is an identity transform (`rescaleSlope === 1 && rescaleIntercept === 0`). When it returns `undefined`, `createImage` sets `preScale.enabled = false`, so **no scaling is applied at all** — including PT SUV body-weight (`suvbw`) and RTDOSE dose grid scaling.

PET stored in counts (e.g. Philips `CNTS`) commonly has an identity modality LUT while still requiring `suvbw` to convert to SUV. As a result those images render without SUV scaling.

Real-world example (Philips whole-body PET, 255 slices): only the 21 slices that happened to have `rescaleSlope !== 1` were SUV-scaled; the other 234 (identity LUT) rendered raw, even though `suvbw` was present in the `scalingModule` metadata for all of them.

## Fix

Check for PT `suvbw` / RTDOSE `doseGridScaling` **before** the identity-transform short-circuit, so modality-specific scaling is preserved even when the modality LUT is identity. `rescaleSlope`/`rescaleIntercept` now default to `1`/`0` to keep `scaleArray` arithmetic well-defined.

## Verification

Simulated old vs new logic against all 255 instances of a Philips CNTS study: old logic returned `suvbw` for 21/255, new logic returns it for 255/255. With the fix, all slices prescale correctly (e.g. a slice with raw max 7198 → SUV max 2.735 with `suvbw 0.00038`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image scaling accuracy for PT (PET) and RTDOSE modalities to ensure correct dose and uptake value representation.
  * Fixed scaling behavior when scaling is missing by applying sensible defaults for slope and intercept.
  * Adjusted identity-transform handling so PT/RTDOSE prescaling requirements are preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->