### PR TITLE
fix(wsi): render WSIViewport via setDisplaySets by resolving the registered generic dataset

### DIFF
--- a/packages/core/src/RenderingEngine/WSIViewport.ts
+++ b/packages/core/src/RenderingEngine/WSIViewport.ts
@@ -651,7 +651,7 @@ class WSIViewport extends Viewport {
       );
     }
 
-    await this.setWSI(dataSet.imageIds, dataSet.options.webClient);
+    return this.setDataIds(dataSet.imageIds, dataSet.options);
   }
 
   public postrender = () => {

--- a/packages/core/src/RenderingEngine/WSIViewport.ts
+++ b/packages/core/src/RenderingEngine/WSIViewport.ts
@@ -30,6 +30,7 @@ import {
   type WSITransformUtilitiesLike,
   type WSIViewerLike,
 } from '../utilities/WSIUtilities';
+import { getGenericViewportWSIDataSet } from './GenericViewport/genericViewportDataSetAccess';
 
 let WSIUtilFunctions: WSITransformUtilitiesLike | null = null;
 const EVENT_POSTRENDER = 'postrender';
@@ -624,6 +625,33 @@ class WSIViewport extends Viewport {
       '--ol-subtle-background-color': 'rgba(78, 78, 78, 0.5)',
       background: 'none',
     });
+  }
+
+  /**
+   * Renders a registered whole-slide display set. The dataset (imageIds +
+   * webClient) must first be registered with
+   * `utilities.genericViewportDataSetMetadataProvider` keyed by `displaySetId`.
+   * This reads from the same registry as the GenericViewport WSI data provider,
+   * so the same caller code drives both the legacy and generic render paths.
+   */
+  public async setDisplaySets(
+    ...entries: Array<{ displaySetId: string; options?: unknown }>
+  ): Promise<void> {
+    const [entry] = entries;
+    if (!entry?.displaySetId) {
+      throw new Error(
+        '[WSIViewport] setDisplaySets requires a displaySetId to render whole slide imaging'
+      );
+    }
+
+    const dataSet = getGenericViewportWSIDataSet(entry.displaySetId);
+    if (!dataSet?.imageIds?.length || !dataSet.options?.webClient) {
+      throw new Error(
+        `[WSIViewport] No registered WSI dataset (imageIds + webClient) for display set ${entry.displaySetId}`
+      );
+    }
+
+    await this.setWSI(dataSet.imageIds, dataSet.options.webClient);
   }
 
   public postrender = () => {


### PR DESCRIPTION


<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
See https://github.com/OHIF/Viewers/pull/6107

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results
#### Summary

  Adds a setDisplaySets method to the legacy WSIViewport so whole-slide imaging can be mounted through the display-set API (the direction CS3D is moving
  with #2738), instead of requiring callers to use the legacy setDataIds.

#### What it does

  setDisplaySets({ displaySetId }) resolves the WSI dataset (imageIds + webClient) via getGenericViewportWSIDataSet(displaySetId) and renders it through
  setWSI. The dataset must first be registered with utilities.genericViewportDataSetMetadataProvider, keyed by displaySetId.

#### Why

  This reads from the same registry the GenericViewport WSI data provider uses, so one caller code path drives both the legacy and generic
  (useGenericViewport) render paths. It throws clear errors when called without a displaySetId or with an unregistered dataset.

#### Scope

  - One file: packages/core/src/RenderingEngine/WSIViewport.ts (+28 lines).
  - Adds a method; no behavior change to existing setDataIds/setWSI.
<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing
Load and display a WSI study in OHIF

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

System:
OS: Windows 11 10.0.26200
CPU: (20) x64 12th Gen Intel(R) Core(TM) i7-12700H
Memory: 8.83 GB / 31.68 GB
Binaries:
Node: 24.15.0 - C:\Users\joebo\AppData\Local\fnm_multishells\50148_1782198425052\node.EXE
Yarn: 1.22.22 - C:\Program Files (x86)\Yarn\bin\yarn.CMD
npm: 11.12.1 - C:\Users\joebo\AppData\Local\fnm_multishells\50148_1782198425052\npm.CMD
pnpm: 11.5.2 - C:\Users\joebo\AppData\Local\pnpm\bin\pnpm.CMD
bun: 1.2.23 - C:\Users\joebo.bun\bin\bun.EXE
Browsers:
Chrome: 149.0.7827.115
Edge: Chromium (149.0.4022.80)
Internet Explorer: 11.0.26100.8115
<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for loading WSI views by providing display set IDs to the viewport via a new public method.
  * When a display set is selected, the viewport automatically loads the associated WSI content.

* **Bug Fixes**
  * Improved validation and error handling for missing display set IDs and incomplete or unavailable WSI data referenced by a display set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->