### PR TITLE
fix middle slice circle 3d

### DIFF
--- a/packages/tools/src/tools/segmentation/CircleROIStartEndThresholdTool.ts
+++ b/packages/tools/src/tools/segmentation/CircleROIStartEndThresholdTool.ts
@@ -426,9 +426,14 @@ class CircleROIStartEndThresholdTool extends CircleROITool {
       // if it is inside the start/end slice, but not exactly the first or
       // last slice, we render the line in dash, but not the handles
 
-      let isMiddleSlice = false;
-      if (roundedCameraCoordinate === middleCoordinate) {
-        isMiddleSlice = true;
+      let isNearMiddleSlice = false;
+      const targetId = this.getTargetId(viewport);
+      const imageVolume = cache.getVolume(targetId.split(/volumeId:|\?/)[1]);
+      if (
+        Math.abs(roundedCameraCoordinate - middleCoordinate) <
+        csUtils.getSpacingInNormalDirection(imageVolume, viewplaneNormal)
+      ) {
+        isNearMiddleSlice = true;
       }
 
       data.handles.points[0][
@@ -467,7 +472,7 @@ class CircleROIStartEndThresholdTool extends CircleROITool {
         !isAnnotationLocked(annotationUID) &&
         !this.editData &&
         activeHandleIndex !== null &&
-        isMiddleSlice
+        isNearMiddleSlice
       ) {
         if (this.configuration.simplified) {
           activeHandleCanvasCoords = [canvasCoordinates[activeHandleIndex]];
@@ -493,7 +498,7 @@ class CircleROIStartEndThresholdTool extends CircleROITool {
       let lineWidthToUse = lineWidth;
       let lineDashToUse = lineDash;
 
-      if (isMiddleSlice) {
+      if (isNearMiddleSlice) {
         lineWidthToUse = lineWidth;
         lineDashToUse = []; // Use solid line for real line
       } else {


### PR DESCRIPTION
### Context

We had an issue for circleStartEnd, as the central slice is the only one interactable, if we had an even number of slice the camera position was never able to match the center of the ROI.

This PR changes behaviour to activate handles for closest slices of the center (determined by slice position is lower than thickness, can select two slices for even number of slice in ROI)


### Changes & Results

Handles are not lost if even number of slices in the ROI

### Testing

Manually through test

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

Linux and chrome latest


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved slice detection for circle ROI rendering so it works with near-center positions instead of requiring an exact match.
  * Updated line and handle display behavior to stay consistent when the view is close to the middle slice, reducing unexpected solid/dashed rendering changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->