### PR TITLE
fix(examples): use correct genericViewportDisplaySetMetadataProvider name

### DIFF
--- a/packages/tools/examples/genericViewportShowcase/index.ts
+++ b/packages/tools/examples/genericViewportShowcase/index.ts
@@ -435,18 +435,18 @@ async function run() {
   // --------------------------------------------------------------------------
   // Register display-set metadata
   // --------------------------------------------------------------------------
-  utilities.genericViewportDataSetMetadataProvider.add(acqDataId, {
+  utilities.genericViewportDisplaySetMetadataProvider.add(acqDataId, {
     imageIds,
     kind: 'planar',
     initialImageIdIndex: middleImageIndex,
   });
-  utilities.genericViewportDataSetMetadataProvider.add(mprDataId, {
+  utilities.genericViewportDisplaySetMetadataProvider.add(mprDataId, {
     imageIds,
     kind: 'planar',
     volumeId,
     initialImageIdIndex: middleImageIndex,
   });
-  utilities.genericViewportDataSetMetadataProvider.add(volume3dDataId, {
+  utilities.genericViewportDisplaySetMetadataProvider.add(volume3dDataId, {
     imageIds,
     volumeId,
   });


### PR DESCRIPTION
## Summary
- `genericViewportShowcase` called `utilities.genericViewportDataSetMetadataProvider`, which doesn't exist on the core `utilities` export (the real export is `genericViewportDisplaySetMetadataProvider`), causing a runtime error/no-op when the example registers display-set metadata.

## Test plan
- [x] Rebuilt examples (`build-all-examples-cli.js --build --fromRoot --packages core,tools`) — compiles with no warnings (previously emitted `ESModulesLinkingWarning` for this export).
- [x] Served `.static-examples` locally and loaded `genericViewportShowcase.html`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the generic viewport showcase example to use the newer display-set metadata approach.
  * Improved how acquisition, MPR, and 3D volume items are registered so the example renders more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->