### PR TITLE
test(core): add unit tests for GenericViewport base class and planar/modality camera math

### DIFF
--- a/packages/core/test/genericViewportBase.jest.js
+++ b/packages/core/test/genericViewportBase.jest.js
@@ -1,0 +1,977 @@
+import GenericViewport from '../src/RenderingEngine/GenericViewport/GenericViewport';
+import ViewportType from '../src/enums/ViewportType';
+import ViewportStatus from '../src/enums/ViewportStatus';
+import Events from '../src/enums/Events';
+import {
+  getGenericViewportRegisteredDisplaySet,
+  getGenericViewportImageDisplaySet,
+  getGenericViewportPlanarDisplaySet,
+  getGenericViewportWSIDisplaySet,
+  getGenericViewportSourceDataId,
+  isGenericViewportImageDisplaySet,
+  isGenericViewportWSIDisplaySet,
+  isGenericViewportSourceAliasDisplaySet,
+} from '../src/RenderingEngine/GenericViewport/genericViewportDisplaySetAccess';
+import genericViewportDisplaySetMetadataProvider from '../src/utilities/genericViewportDisplaySetMetadataProvider';
+
+// ── Test fixture: a minimal concrete GenericViewport subclass ────────────
+//
+// GenericViewport is abstract and generic over view-state/presentation/
+// render-context types. The base class only orchestrates bindings, view
+// state, and lifecycle; it delegates rendering, resolved-view computation,
+// view-state normalization, and presentation notifications to subclasses.
+// This fixture implements just enough of those hooks to exercise the base
+// class behavior, with spies exposed so tests can assert on hook calls.
+class TestViewport extends GenericViewport {
+  constructor({
+    id,
+    element,
+    renderingEngineId = 'test-engine',
+    dataProvider,
+    renderPathResolver,
+    renderContext,
+    viewState = {},
+    resolvedView,
+  }) {
+    super({ id, element });
+
+    this.type = ViewportType.STACK;
+    this.renderingEngineId = renderingEngineId;
+    this.dataProvider = dataProvider;
+    this.renderPathResolver = renderPathResolver;
+    this.renderContext = renderContext ?? { viewportId: id, type: 'planar' };
+    this.viewState = viewState;
+
+    this.renderCount = 0;
+    this._resolvedView = resolvedView;
+    this._normalizeViewState = undefined;
+
+    this.normalizeViewStateSpy = jest.fn();
+    this.notifyDataPresentationModifiedSpy = jest.fn();
+    this.onDestroySpy = jest.fn();
+  }
+
+  render() {
+    this.renderCount += 1;
+  }
+
+  getResolvedView() {
+    return this._resolvedView;
+  }
+
+  normalizeViewState(viewState) {
+    this.normalizeViewStateSpy(viewState);
+    return this._normalizeViewState
+      ? this._normalizeViewState(viewState)
+      : viewState;
+  }
+
+  notifyDataPresentationModified(displaySetId, props) {
+    this.notifyDataPresentationModifiedSpy(displaySetId, props);
+  }
+
+  onDestroy() {
+    this.onDestroySpy();
+  }
+}
+
+// ── Fakes ──────────────────────────────────────────────────────────────
+
+function createAttachment(overrides = {}) {
+  return {
+    rendering: { renderMode: 'fake' },
+    removeData: jest.fn(),
+    applyViewState: jest.fn(),
+    updateDataPresentation: jest.fn(),
+    getFrameOfReferenceUID: () => '1.2.3',
+    render: jest.fn(),
+    resize: jest.fn(),
+    ...overrides,
+  };
+}
+
+function createResolver(addData) {
+  const impl = addData ?? jest.fn(async () => createAttachment());
+
+  return {
+    resolve: jest.fn(() => ({
+      createRenderPath: () => ({ addData: impl }),
+      selectContext: undefined,
+    })),
+  };
+}
+
+function createDataProvider() {
+  return {
+    load: jest.fn(async (displaySetId) => ({
+      id: displaySetId,
+      type: 'image',
+    })),
+  };
+}
+
+function createHarness({
+  id = 'vp-1',
+  renderingEngineId = 'engine-1',
+  viewState = {},
+  resolvedView,
+  addData,
+  dataProvider,
+} = {}) {
+  const element = document.createElement('div');
+  element.setAttribute('data-viewport-uid', id);
+  element.setAttribute('data-rendering-engine-uid', renderingEngineId);
+
+  const provider = dataProvider ?? createDataProvider();
+  const resolver = createResolver(addData);
+
+  const viewport = new TestViewport({
+    id,
+    element,
+    renderingEngineId,
+    dataProvider: provider,
+    renderPathResolver: resolver,
+    viewState,
+    resolvedView,
+  });
+
+  return { element, viewport, dataProvider: provider, resolver };
+}
+
+// Mounts a display set with a fresh attachment (unless one is supplied),
+// swapping the resolver just for this call so each mounted display set gets
+// its own distinguishable attachment/spies.
+async function mountDisplaySet(
+  viewport,
+  displaySetId,
+  options = {},
+  attachment
+) {
+  const resolvedAttachment = attachment ?? createAttachment();
+  viewport.renderPathResolver = createResolver(
+    jest.fn(async () => resolvedAttachment)
+  );
+  await viewport.addDisplaySet(displaySetId, {
+    renderMode: 'fake',
+    ...options,
+  });
+  return resolvedAttachment;
+}
+
+describe('GenericViewport', () => {
+  describe('setDisplaySets', () => {
+    it('throws when an entry is missing options', async () => {
+      const { viewport } = createHarness();
+
+      await expect(
+        viewport.setDisplaySets({ displaySetId: 'ds-1' })
+      ).rejects.toThrow(/requires per-entry options/);
+    });
+
+    it('defaults the first entry to source and later entries to overlay', async () => {
+      const { viewport } = createHarness();
+
+      await viewport.setDisplaySets(
+        { displaySetId: 'ds-1', options: { renderMode: 'fake' } },
+        { displaySetId: 'ds-2', options: { renderMode: 'fake' } }
+      );
+
+      expect(viewport.getDisplaySets()).toEqual([
+        { displaySetId: 'ds-1', options: { role: 'source' } },
+        { displaySetId: 'ds-2', options: { role: 'overlay' } },
+      ]);
+    });
+
+    it('respects an explicit role over the positional default', async () => {
+      const { viewport } = createHarness();
+
+      await viewport.setDisplaySets({
+        displaySetId: 'ds-1',
+        options: { renderMode: 'fake', role: 'overlay' },
+      });
+
+      expect(viewport.getDisplaySets()).toEqual([
+        { displaySetId: 'ds-1', options: { role: 'overlay' } },
+      ]);
+    });
+
+    it('replaces all previously mounted display sets', async () => {
+      const { viewport } = createHarness();
+      const firstAttachment = createAttachment();
+      const secondAttachment = createAttachment();
+      const thirdAttachment = createAttachment();
+      const attachments = [firstAttachment, secondAttachment, thirdAttachment];
+      let callIndex = 0;
+
+      viewport.renderPathResolver = createResolver(
+        jest.fn(async () => attachments[callIndex++])
+      );
+
+      await viewport.setDisplaySets(
+        { displaySetId: 'ds-1', options: { renderMode: 'fake' } },
+        { displaySetId: 'ds-2', options: { renderMode: 'fake' } }
+      );
+
+      await viewport.setDisplaySets({
+        displaySetId: 'ds-3',
+        options: { renderMode: 'fake' },
+      });
+
+      expect(firstAttachment.removeData).toHaveBeenCalledTimes(1);
+      expect(secondAttachment.removeData).toHaveBeenCalledTimes(1);
+      expect(viewport.getDisplaySets()).toEqual([
+        { displaySetId: 'ds-3', options: { role: 'source' } },
+      ]);
+    });
+  });
+
+  describe('addLoadedData lifecycle', () => {
+    it('mounts loaded data, re-applies stored presentation before mounting, applies view state, and schedules a render', async () => {
+      const { viewport } = createHarness({ viewState: { zoom: 1 } });
+      const attachment = createAttachment();
+
+      viewport.renderPathResolver = createResolver(
+        jest.fn(async () => attachment)
+      );
+
+      // Presentation stored before the display set is ever mounted.
+      viewport.setDisplaySetPresentation('ds-1', { opacity: 0.5 });
+
+      await viewport.addDisplaySet('ds-1', { renderMode: 'fake' });
+
+      expect(attachment.updateDataPresentation).toHaveBeenCalledWith({
+        opacity: 0.5,
+      });
+      expect(attachment.applyViewState).toHaveBeenCalledWith({ zoom: 1 });
+      expect(viewport.viewportStatus).toBe(ViewportStatus.PRE_RENDER);
+      expect(viewport.renderCount).toBeGreaterThan(0);
+      expect(viewport._debug.renderModes['ds-1']).toBe('fake');
+      expect(viewport.getDisplaySets()).toEqual([
+        { displaySetId: 'ds-1', options: { role: 'overlay' } },
+      ]);
+    });
+
+    it('returns false and mounts nothing when shouldIgnore is already true before addData is called', async () => {
+      const { viewport } = createHarness();
+      const addData = jest.fn();
+
+      viewport.renderPathResolver = createResolver(addData);
+
+      const result = await viewport.addLoadedData(
+        'ds-1',
+        { id: 'ds-1', type: 'image' },
+        { renderMode: 'fake' },
+        () => true
+      );
+
+      expect(result).toBe(false);
+      expect(addData).not.toHaveBeenCalled();
+      expect(viewport.getDisplaySets()).toEqual([]);
+    });
+
+    it('discards the staged attachment and leaves the previous binding untouched when shouldIgnore flips true mid-await', async () => {
+      const { viewport } = createHarness();
+      const previousAttachment = createAttachment();
+
+      viewport.renderPathResolver = createResolver(
+        jest.fn(async () => previousAttachment)
+      );
+
+      await viewport.addLoadedData(
+        'ds-1',
+        { id: 'ds-1', type: 'image' },
+        { renderMode: 'fake' }
+      );
+
+      let resolveAddData;
+      const stagedAttachment = createAttachment();
+
+      viewport.renderPathResolver = createResolver(
+        jest.fn(
+          () =>
+            new Promise((resolve) => {
+              resolveAddData = resolve;
+            })
+        )
+      );
+
+      let ignore = false;
+      const pending = viewport.addLoadedData(
+        'ds-1',
+        { id: 'ds-1', type: 'image' },
+        { renderMode: 'fake' },
+        () => ignore
+      );
+
+      ignore = true;
+      resolveAddData(stagedAttachment);
+      const result = await pending;
+
+      expect(result).toBe(false);
+      expect(stagedAttachment.removeData).toHaveBeenCalledTimes(1);
+      expect(previousAttachment.removeData).not.toHaveBeenCalled();
+      expect(viewport.bindings.get('ds-1').removeData).toBe(
+        previousAttachment.removeData
+      );
+    });
+
+    it('removes the staged attachment and throws when the viewport is destroyed mid-await', async () => {
+      const { viewport } = createHarness();
+      let resolveAddData;
+      const attachment = createAttachment();
+
+      viewport.renderPathResolver = createResolver(
+        jest.fn(
+          () =>
+            new Promise((resolve) => {
+              resolveAddData = resolve;
+            })
+        )
+      );
+
+      const pending = viewport.addLoadedData(
+        'ds-1',
+        { id: 'ds-1', type: 'image' },
+        { renderMode: 'fake' }
+      );
+
+      viewport.destroy();
+      resolveAddData(attachment);
+
+      await expect(pending).rejects.toThrow('Viewport has been destroyed');
+      expect(attachment.removeData).toHaveBeenCalledTimes(1);
+    });
+
+    it('replaces the previous attachment when the same display set is remounted', async () => {
+      const { viewport } = createHarness();
+
+      const first = await mountDisplaySet(viewport, 'ds-1');
+      const second = await mountDisplaySet(viewport, 'ds-1');
+
+      expect(first.removeData).toHaveBeenCalledTimes(1);
+      expect(viewport.bindings.get('ds-1').removeData).toBe(second.removeData);
+    });
+
+    it('demotes existing bindings to overlay when a new source binding mounts', async () => {
+      const { viewport } = createHarness();
+
+      await mountDisplaySet(viewport, 'ds-1', { role: 'source' });
+      await mountDisplaySet(viewport, 'ds-2', { role: 'overlay' });
+      await mountDisplaySet(viewport, 'ds-3', { role: 'source' });
+
+      const sets = viewport.getDisplaySets();
+      const roleOf = (id) =>
+        sets.find((s) => s.displaySetId === id).options.role;
+
+      expect(roleOf('ds-1')).toBe('overlay');
+      expect(roleOf('ds-2')).toBe('overlay');
+      expect(roleOf('ds-3')).toBe('source');
+    });
+
+    it('rejects addDisplaySet calls after the viewport has been destroyed', async () => {
+      const { viewport } = createHarness();
+
+      viewport.destroy();
+
+      await expect(
+        viewport.addDisplaySet('ds-1', { renderMode: 'fake' })
+      ).rejects.toThrow('Viewport has been destroyed');
+    });
+  });
+
+  describe('removeData', () => {
+    it('removes the binding, stored presentation, and debug entry, then renders', async () => {
+      const { viewport } = createHarness();
+
+      await mountDisplaySet(viewport, 'ds-1');
+      viewport.setDisplaySetPresentation('ds-1', { opacity: 0.4 });
+      const attachment = viewport.bindings.get('ds-1');
+      const renderCountBefore = viewport.renderCount;
+
+      viewport.removeData('ds-1');
+
+      expect(attachment.removeData).toHaveBeenCalledTimes(1);
+      expect(viewport.getDisplaySets()).toEqual([]);
+      expect(viewport.getDisplaySetPresentation('ds-1')).toBeUndefined();
+      expect(viewport._debug.renderModes['ds-1']).toBeUndefined();
+      expect(viewport.renderCount).toBeGreaterThan(renderCountBefore);
+    });
+
+    it('is a no-op for an unknown display set id', () => {
+      const { viewport } = createHarness();
+      const renderCountBefore = viewport.renderCount;
+
+      expect(() => viewport.removeData('does-not-exist')).not.toThrow();
+      expect(viewport.renderCount).toBe(renderCountBefore);
+    });
+
+    it('does not trigger a render when the viewport has already been marked destroyed', async () => {
+      const { viewport } = createHarness();
+
+      await mountDisplaySet(viewport, 'ds-1');
+      const attachment = viewport.bindings.get('ds-1');
+
+      viewport.isDestroyed = true;
+      const renderCountBefore = viewport.renderCount;
+
+      viewport.removeData('ds-1');
+
+      expect(attachment.removeData).toHaveBeenCalledTimes(1);
+      expect(viewport.renderCount).toBe(renderCountBefore);
+    });
+  });
+
+  describe('setDisplaySetPresentation / getDisplaySetPresentation', () => {
+    it('targets the first mounted binding when called with props only', async () => {
+      const { viewport } = createHarness();
+
+      await mountDisplaySet(viewport, 'ds-1', { role: 'source' });
+      await mountDisplaySet(viewport, 'ds-2', { role: 'overlay' });
+
+      viewport.setDisplaySetPresentation({ opacity: 0.3 });
+
+      expect(viewport.getDisplaySetPresentation('ds-1')).toEqual({
+        opacity: 0.3,
+      });
+      expect(viewport.getDisplaySetPresentation('ds-2')).toBeUndefined();
+    });
+
+    it('targets an explicit display set id when provided', async () => {
+      const { viewport } = createHarness();
+
+      await mountDisplaySet(viewport, 'ds-1', { role: 'source' });
+      await mountDisplaySet(viewport, 'ds-2', { role: 'overlay' });
+
+      viewport.setDisplaySetPresentation('ds-2', { opacity: 0.7 });
+
+      expect(viewport.getDisplaySetPresentation('ds-1')).toBeUndefined();
+      expect(viewport.getDisplaySetPresentation('ds-2')).toEqual({
+        opacity: 0.7,
+      });
+    });
+
+    it('merges new keys with previously stored keys', () => {
+      const { viewport } = createHarness();
+
+      viewport.setDisplaySetPresentation('ds-1', {
+        opacity: 0.5,
+        visible: true,
+      });
+      viewport.setDisplaySetPresentation('ds-1', { opacity: 0.8 });
+
+      expect(viewport.getDisplaySetPresentation('ds-1')).toEqual({
+        opacity: 0.8,
+        visible: true,
+      });
+    });
+
+    it('is a no-op when called with props only and nothing is mounted', () => {
+      const { viewport } = createHarness();
+      const renderCountBefore = viewport.renderCount;
+
+      expect(() =>
+        viewport.setDisplaySetPresentation({ opacity: 0.5 })
+      ).not.toThrow();
+      expect(viewport.renderCount).toBe(renderCountBefore);
+    });
+
+    it('returns stored presentation for a display set that was never mounted', () => {
+      const { viewport } = createHarness();
+
+      viewport.setDisplaySetPresentation('never-mounted', { opacity: 0.1 });
+
+      expect(viewport.getDisplaySetPresentation('never-mounted')).toEqual({
+        opacity: 0.1,
+      });
+    });
+  });
+
+  describe('notifyDataPresentationModified hook', () => {
+    it('is only invoked when the target display set is mounted', async () => {
+      const { viewport } = createHarness();
+
+      viewport.setDisplaySetPresentation('unmounted-ds', { opacity: 0.2 });
+      expect(viewport.notifyDataPresentationModifiedSpy).not.toHaveBeenCalled();
+
+      await mountDisplaySet(viewport, 'ds-1');
+      viewport.setDisplaySetPresentation('ds-1', { opacity: 0.9 });
+
+      expect(viewport.notifyDataPresentationModifiedSpy).toHaveBeenCalledWith(
+        'ds-1',
+        { opacity: 0.9 }
+      );
+    });
+  });
+
+  describe('setViewState / updateViewState', () => {
+    it('merges the patch into the current view state', () => {
+      const { viewport } = createHarness({
+        viewState: { zoom: 1, pan: [0, 0] },
+      });
+
+      viewport.setViewState({ zoom: 2 });
+
+      expect(viewport.getViewState()).toEqual({ zoom: 2, pan: [0, 0] });
+    });
+
+    it('runs the patch through the normalizeViewState hook', () => {
+      const { viewport } = createHarness({ viewState: { zoom: 1 } });
+      viewport._normalizeViewState = (vs) => ({
+        ...vs,
+        zoom: Math.min(vs.zoom, 5),
+      });
+
+      viewport.setViewState({ zoom: 10 });
+
+      expect(viewport.normalizeViewStateSpy).toHaveBeenCalledWith({ zoom: 10 });
+      expect(viewport.getViewState().zoom).toBe(5);
+    });
+
+    it('propagates the new view state to every binding and schedules a render', async () => {
+      const { viewport } = createHarness({ viewState: { zoom: 1 } });
+
+      await mountDisplaySet(viewport, 'ds-1');
+      await mountDisplaySet(viewport, 'ds-2');
+      const first = viewport.bindings.get('ds-1');
+      const second = viewport.bindings.get('ds-2');
+      first.applyViewState.mockClear();
+      second.applyViewState.mockClear();
+      const renderCountBefore = viewport.renderCount;
+
+      viewport.setViewState({ zoom: 3 });
+
+      expect(first.applyViewState).toHaveBeenCalledWith({ zoom: 3 });
+      expect(second.applyViewState).toHaveBeenCalledWith({ zoom: 3 });
+      expect(viewport.renderCount).toBeGreaterThan(renderCountBefore);
+    });
+
+    it('fires CAMERA_MODIFIED using the resolved-view camera when one is available', () => {
+      const { element, viewport } = createHarness({ viewState: { zoom: 1 } });
+      viewport._resolvedView = {
+        toICamera: () => ({ zoom: viewport.getViewState().zoom }),
+        getFrameOfReferenceUID: () => '1.2.3',
+        canvasToWorld: jest.fn(),
+        worldToCanvas: jest.fn(),
+      };
+
+      const events = [];
+      element.addEventListener(Events.CAMERA_MODIFIED, (evt) => {
+        events.push(evt.detail);
+      });
+
+      viewport.setViewState({ zoom: 3 });
+
+      expect(events).toHaveLength(1);
+      expect(events[0].previousCamera).toEqual({ zoom: 1 });
+      expect(events[0].camera).toEqual({ zoom: 3 });
+      expect(events[0].viewportId).toBe(viewport.id);
+    });
+
+    it('falls back to the raw view state for CAMERA_MODIFIED payloads when there is no resolved view', () => {
+      const { element, viewport } = createHarness({ viewState: { zoom: 1 } });
+
+      const events = [];
+      element.addEventListener(Events.CAMERA_MODIFIED, (evt) => {
+        events.push(evt.detail);
+      });
+
+      viewport.setViewState({ zoom: 4 });
+
+      expect(events).toHaveLength(1);
+      expect(events[0].previousCamera).toEqual({ zoom: 1 });
+      expect(events[0].camera).toEqual({ zoom: 4 });
+    });
+
+    it('updateViewState accepts a function updater', () => {
+      const { viewport } = createHarness({ viewState: { zoom: 1 } });
+
+      viewport.updateViewState((vs) => ({ zoom: (vs.zoom ?? 0) + 1 }));
+
+      expect(viewport.getViewState().zoom).toBe(2);
+    });
+
+    it('updateViewState is a no-op when the updater returns undefined or null', () => {
+      const { viewport } = createHarness({ viewState: { zoom: 1 } });
+      const renderCountBefore = viewport.renderCount;
+
+      viewport.updateViewState(() => undefined);
+      viewport.updateViewState(() => null);
+
+      expect(viewport.getViewState()).toEqual({ zoom: 1 });
+      expect(viewport.renderCount).toBe(renderCountBefore);
+    });
+
+    it('setViewState is a no-op after the viewport has been destroyed', () => {
+      const { element, viewport } = createHarness({ viewState: { zoom: 1 } });
+
+      viewport.destroy();
+      const renderCountBefore = viewport.renderCount;
+      const events = [];
+      element.addEventListener(Events.CAMERA_MODIFIED, (evt) => {
+        events.push(evt.detail);
+      });
+
+      viewport.setViewState({ zoom: 99 });
+
+      expect(viewport.getViewState()).toEqual({ zoom: 1 });
+      expect(viewport.renderCount).toBe(renderCountBefore);
+      expect(events).toHaveLength(0);
+    });
+  });
+
+  describe('destroy / dispose', () => {
+    it('tears down all bindings, clears presentation state, removes element attributes, and calls onDestroy once', async () => {
+      const { element, viewport } = createHarness();
+
+      await mountDisplaySet(viewport, 'ds-1');
+      await mountDisplaySet(viewport, 'ds-2');
+      viewport.setDisplaySetPresentation('ds-1', { opacity: 0.4 });
+
+      const first = viewport.bindings.get('ds-1');
+      const second = viewport.bindings.get('ds-2');
+
+      viewport.destroy();
+
+      expect(first.removeData).toHaveBeenCalledTimes(1);
+      expect(second.removeData).toHaveBeenCalledTimes(1);
+      expect(viewport.getDisplaySets()).toEqual([]);
+      expect(viewport.getDisplaySetPresentation('ds-1')).toBeUndefined();
+      expect(Object.keys(viewport._debug.renderModes)).toHaveLength(0);
+      expect(element.hasAttribute('data-viewport-uid')).toBe(false);
+      expect(element.hasAttribute('data-rendering-engine-uid')).toBe(false);
+      expect(viewport.onDestroySpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('is idempotent on a second call', async () => {
+      const { viewport } = createHarness();
+
+      await mountDisplaySet(viewport, 'ds-1');
+      const attachment = viewport.bindings.get('ds-1');
+
+      viewport.destroy();
+      viewport.destroy();
+
+      expect(attachment.removeData).toHaveBeenCalledTimes(1);
+      expect(viewport.onDestroySpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('dispose aliases destroy', () => {
+      const { viewport } = createHarness();
+
+      viewport.dispose();
+
+      expect(viewport.isDestroyed).toBe(true);
+      expect(viewport.onDestroySpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getDisplaySets / getCurrentMode', () => {
+    it('reports empty content mode with no bindings and unknown once a source binding mounts', async () => {
+      const { viewport } = createHarness();
+
+      expect(viewport.getCurrentMode()).toBe('empty');
+
+      await mountDisplaySet(viewport, 'ds-1', { role: 'source' });
+
+      expect(viewport.getCurrentMode()).toBe('unknown');
+    });
+
+    it('reflects mounted bindings in mount order with role metadata', async () => {
+      const { viewport } = createHarness();
+
+      await mountDisplaySet(viewport, 'ds-1', { role: 'source' });
+      await mountDisplaySet(viewport, 'ds-2', { role: 'overlay' });
+
+      expect(viewport.getDisplaySets()).toEqual([
+        { displaySetId: 'ds-1', options: { role: 'source' } },
+        { displaySetId: 'ds-2', options: { role: 'overlay' } },
+      ]);
+    });
+  });
+
+  describe('view reference helpers', () => {
+    it('falls back to a viewport-local frame of reference id when there is no resolved view', () => {
+      const { viewport } = createHarness();
+
+      expect(viewport.getFrameOfReferenceUID()).toBe(
+        `${viewport.type}-viewport-${viewport.id}`
+      );
+      expect(viewport.getViewReferenceId()).toBe(
+        `frameOfReference:${viewport.type}-viewport-${viewport.id}`
+      );
+    });
+
+    it('uses the resolved view frame of reference when one is available', () => {
+      const { viewport } = createHarness();
+      viewport._resolvedView = {
+        getFrameOfReferenceUID: () => 'resolved-for',
+        toICamera: () => ({}),
+        canvasToWorld: jest.fn(),
+        worldToCanvas: jest.fn(),
+      };
+
+      expect(viewport.getFrameOfReferenceUID()).toBe('resolved-for');
+    });
+
+    it('includes the current binding data id in getViewReference', async () => {
+      const { viewport } = createHarness();
+
+      await mountDisplaySet(viewport, 'ds-1');
+
+      expect(viewport.getViewReference().dataId).toBe('ds-1');
+    });
+
+    it('isReferenceViewable matches on frame of reference and data id from a mounted binding', async () => {
+      const { viewport } = createHarness();
+      const attachment = createAttachment({
+        getFrameOfReferenceUID: () => 'for-match',
+      });
+
+      await mountDisplaySet(viewport, 'ds-1', {}, attachment);
+
+      expect(
+        viewport.isReferenceViewable({
+          FrameOfReferenceUID: 'for-match',
+          dataId: 'ds-1',
+        })
+      ).toBe(true);
+      expect(
+        viewport.isReferenceViewable({
+          FrameOfReferenceUID: 'no-match',
+          dataId: 'ds-1',
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe('coordinate transforms', () => {
+    it('throws when converting canvas/world coordinates without a resolved view', () => {
+      const { viewport } = createHarness();
+
+      expect(() => viewport.canvasToWorld([0, 0])).toThrow(
+        /no data is mounted/
+      );
+      expect(() => viewport.worldToCanvas([0, 0, 0])).toThrow(
+        /no data is mounted/
+      );
+    });
+
+    it('delegates canvas/world coordinate conversion to the resolved view', () => {
+      const { viewport } = createHarness();
+      viewport._resolvedView = {
+        canvasToWorld: jest.fn(() => [1, 2, 3]),
+        worldToCanvas: jest.fn(() => [4, 5]),
+        getFrameOfReferenceUID: () => '1.2.3',
+        toICamera: () => ({}),
+      };
+
+      expect(viewport.canvasToWorld([0, 0])).toEqual([1, 2, 3]);
+      expect(viewport.worldToCanvas([1, 2, 3])).toEqual([4, 5]);
+    });
+
+    it('defaults getAspectRatio to [1, 1]', () => {
+      const { viewport } = createHarness();
+
+      expect(viewport.getAspectRatio()).toEqual([1, 1]);
+    });
+  });
+
+  describe('render-status transitions', () => {
+    it('setRendered does not mark the viewport rendered while NO_DATA or LOADING', () => {
+      const { viewport } = createHarness();
+
+      viewport.setRendered();
+      expect(viewport.viewportStatus).toBe(ViewportStatus.NO_DATA);
+
+      viewport.viewportStatus = ViewportStatus.LOADING;
+      viewport.setRendered();
+      expect(viewport.viewportStatus).toBe(ViewportStatus.LOADING);
+    });
+
+    it('setRendered marks the viewport rendered from other statuses', () => {
+      const { viewport } = createHarness();
+
+      viewport.viewportStatus = ViewportStatus.PRE_RENDER;
+      viewport.setRendered();
+
+      expect(viewport.viewportStatus).toBe(ViewportStatus.RENDERED);
+    });
+
+    it('setNeedsRender marks the viewport pending regardless of previous status', () => {
+      const { viewport } = createHarness();
+
+      viewport.viewportStatus = ViewportStatus.RENDERED;
+      viewport.setNeedsRender();
+
+      expect(viewport.viewportStatus).toBe(ViewportStatus.NEEDS_RENDER);
+    });
+  });
+
+  describe('resize', () => {
+    it('resizes each binding and re-applies the current view state', async () => {
+      const { viewport } = createHarness({ viewState: { zoom: 2 } });
+
+      await mountDisplaySet(viewport, 'ds-1');
+      const attachment = viewport.bindings.get('ds-1');
+      attachment.applyViewState.mockClear();
+
+      viewport.resize();
+
+      expect(attachment.resize).toHaveBeenCalledTimes(1);
+      expect(attachment.applyViewState).toHaveBeenCalledWith({ zoom: 2 });
+    });
+
+    it('does not resize bindings once the viewport has been destroyed', async () => {
+      const { viewport } = createHarness();
+
+      await mountDisplaySet(viewport, 'ds-1');
+      const attachment = viewport.bindings.get('ds-1');
+
+      viewport.destroy();
+      attachment.resize.mockClear();
+
+      viewport.resize();
+
+      expect(attachment.resize).not.toHaveBeenCalled();
+    });
+
+    it('resizeForRenderingEngine resets view state only when keepCamera is false', () => {
+      const { viewport } = createHarness();
+      const resetSpy = jest.spyOn(viewport, 'resetViewState');
+
+      viewport.resizeForRenderingEngine();
+      expect(resetSpy).not.toHaveBeenCalled();
+
+      viewport.resizeForRenderingEngine({ keepCamera: false });
+      expect(resetSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('resizeForRenderingEngine is a no-op after destroy', () => {
+      const { viewport } = createHarness();
+
+      viewport.destroy();
+      const resetSpy = jest.spyOn(viewport, 'resetViewState');
+
+      viewport.resizeForRenderingEngine({ keepCamera: false });
+
+      expect(resetSpy).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('genericViewportDisplaySetAccess', () => {
+  afterEach(() => {
+    genericViewportDisplaySetMetadataProvider.clear();
+  });
+
+  it('returns undefined for every accessor when nothing is registered', () => {
+    expect(getGenericViewportRegisteredDisplaySet('missing')).toBeUndefined();
+    expect(getGenericViewportImageDisplaySet('missing')).toBeUndefined();
+    expect(getGenericViewportPlanarDisplaySet('missing')).toBeUndefined();
+    expect(getGenericViewportWSIDisplaySet('missing')).toBeUndefined();
+  });
+
+  it('normalizes a bare imageId array into an image/planar display set', () => {
+    genericViewportDisplaySetMetadataProvider.add('ds-array', [
+      'image:1',
+      'image:2',
+    ]);
+
+    expect(getGenericViewportImageDisplaySet('ds-array')).toEqual({
+      imageIds: ['image:1', 'image:2'],
+    });
+    expect(getGenericViewportPlanarDisplaySet('ds-array')).toEqual({
+      imageIds: ['image:1', 'image:2'],
+    });
+  });
+
+  it('passes through a registered planar display set object unchanged', () => {
+    const registered = {
+      imageIds: ['image:1'],
+      kind: 'planar',
+      volumeId: 'vol-1',
+    };
+    genericViewportDisplaySetMetadataProvider.add('ds-planar', registered);
+
+    expect(getGenericViewportImageDisplaySet('ds-planar')).toBe(registered);
+    expect(getGenericViewportPlanarDisplaySet('ds-planar')).toBe(registered);
+  });
+
+  it('excludes non-planar kinds from getGenericViewportPlanarDisplaySet', () => {
+    const registered = {
+      imageIds: ['image:1'],
+      kind: 'wsi',
+      options: { webClient: { getDICOMwebMetadata: () => {} } },
+    };
+    genericViewportDisplaySetMetadataProvider.add('ds-non-planar', registered);
+
+    expect(getGenericViewportImageDisplaySet('ds-non-planar')).toBe(registered);
+    expect(getGenericViewportPlanarDisplaySet('ds-non-planar')).toBeUndefined();
+  });
+
+  it('recognizes a canonically-shaped WSI display set', () => {
+    const webClient = { getDICOMwebMetadata: () => {} };
+    const registered = {
+      kind: 'wsi',
+      imageIds: ['wsi:1'],
+      options: { webClient, miniNavigationOverlay: true },
+    };
+    genericViewportDisplaySetMetadataProvider.add('ds-wsi', registered);
+
+    expect(getGenericViewportWSIDisplaySet('ds-wsi')).toEqual(registered);
+  });
+
+  it('normalizes a loosely-shaped WSI-like record into the canonical WSI shape', () => {
+    const webClient = { getDICOMwebMetadata: () => {} };
+    genericViewportDisplaySetMetadataProvider.add('ds-wsi-loose', {
+      imageIds: ['wsi:1'],
+      options: { webClient },
+    });
+
+    expect(getGenericViewportWSIDisplaySet('ds-wsi-loose')).toEqual({
+      imageIds: ['wsi:1'],
+      kind: 'wsi',
+      options: { miniNavigationOverlay: undefined, webClient },
+    });
+  });
+
+  it('resolves the source data id for strings, arrays, and alias display sets', () => {
+    genericViewportDisplaySetMetadataProvider.add('ds-string', 'source-id-1');
+    genericViewportDisplaySetMetadataProvider.add('ds-array-alias', [
+      'first-id',
+      'second-id',
+    ]);
+    genericViewportDisplaySetMetadataProvider.add('ds-video', {
+      kind: 'video',
+      sourceDataId: 'video-source-id',
+    });
+
+    expect(getGenericViewportSourceDataId('ds-string')).toBe('source-id-1');
+    expect(getGenericViewportSourceDataId('ds-array-alias')).toBe('first-id');
+    expect(getGenericViewportSourceDataId('ds-video')).toBe('video-source-id');
+    expect(getGenericViewportSourceDataId('ds-unregistered')).toBe(
+      'ds-unregistered'
+    );
+  });
+
+  it('type guards classify shapes correctly', () => {
+    expect(isGenericViewportImageDisplaySet({ imageIds: ['a'] })).toBe(true);
+    expect(isGenericViewportImageDisplaySet({ imageIds: 'a' })).toBe(false);
+    expect(
+      isGenericViewportWSIDisplaySet({
+        kind: 'wsi',
+        imageIds: ['a'],
+        options: { webClient: { getDICOMwebMetadata: () => {} } },
+      })
+    ).toBe(true);
+    expect(
+      isGenericViewportWSIDisplaySet({ kind: 'video', imageIds: ['a'] })
+    ).toBe(false);
+    expect(
+      isGenericViewportSourceAliasDisplaySet({ kind: 'ecg', sourceDataId: 'x' })
+    ).toBe(true);
+    expect(
+      isGenericViewportSourceAliasDisplaySet({ kind: 'wsi', sourceDataId: 'x' })
+    ).toBe(false);
+  });
+});

--- a/packages/core/test/modalityViewportCameras.jest.js
+++ b/packages/core/test/modalityViewportCameras.jest.js
@@ -1,0 +1,852 @@
+import {
+  createDefaultVideoViewState,
+  normalizeVideoViewState,
+  resolveVideoCanvasMapping,
+  getPanForVideoCanvasMapping,
+  getAnchorWorldForPan as getAnchorWorldForVideoPan,
+} from '../src/RenderingEngine/GenericViewport/Video/videoViewportCamera';
+import {
+  createDefaultECGViewState,
+  normalizeECGViewState,
+  resolveECGCanvasMapping,
+  getPanForECGCanvasMapping,
+  getAnchorWorldForPan as getAnchorWorldForECGPan,
+  getAnchorWorldForCanvasPoint,
+} from '../src/RenderingEngine/GenericViewport/ECG/ecgViewportCamera';
+import {
+  cloneVolume3DCamera,
+  getVolume3DProjectionScale,
+  getVolume3DProjectionPosition,
+} from '../src/RenderingEngine/GenericViewport/Volume3D/volume3DProjectionCamera';
+
+describe('videoViewportCamera', () => {
+  describe('createDefaultVideoViewState', () => {
+    it('returns the canonical default state', () => {
+      expect(createDefaultVideoViewState()).toEqual({
+        currentTimeSeconds: 0,
+        anchorCanvas: [0.5, 0.5],
+        scale: 1,
+        scaleMode: 'fit',
+        rotation: 0,
+      });
+    });
+  });
+
+  describe('normalizeVideoViewState', () => {
+    it('clamps negative currentTimeSeconds to zero', () => {
+      const result = normalizeVideoViewState({
+        currentTimeSeconds: -5,
+        anchorCanvas: [0.5, 0.5],
+        scale: 1,
+        scaleMode: 'fit',
+        rotation: 0,
+      });
+
+      expect(result.currentTimeSeconds).toBe(0);
+    });
+
+    it('leaves currentTimeSeconds untouched when omitted', () => {
+      const result = normalizeVideoViewState({
+        anchorCanvas: [0.5, 0.5],
+        scale: 1,
+        scaleMode: 'fit',
+        rotation: 0,
+      });
+
+      expect(result.currentTimeSeconds).toBeUndefined();
+    });
+
+    it('clamps scale to the 0.001 floor', () => {
+      const result = normalizeVideoViewState({
+        currentTimeSeconds: 1,
+        anchorCanvas: [0.5, 0.5],
+        scale: 0,
+        scaleMode: 'fit',
+        rotation: 0,
+      });
+
+      expect(result.scale).toBe(0.001);
+    });
+
+    it('defaults scale to 1 when scale is undefined', () => {
+      const result = normalizeVideoViewState({
+        currentTimeSeconds: 1,
+        anchorCanvas: [0.5, 0.5],
+        scaleMode: 'fit',
+        rotation: 0,
+      });
+
+      expect(result.scale).toBe(1);
+    });
+
+    it('defaults anchorCanvas and rotation when missing, and forces scaleMode to fit', () => {
+      const result = normalizeVideoViewState({
+        currentTimeSeconds: 1,
+        scale: 2,
+        scaleMode: 'absolute',
+        rotation: undefined,
+      });
+
+      expect(result.anchorCanvas).toEqual([0.5, 0.5]);
+      expect(result.rotation).toBe(0);
+      expect(result.scaleMode).toBe('fit');
+    });
+
+    it('clones anchorCanvas rather than aliasing the input array', () => {
+      const anchorCanvas = [0.25, 0.75];
+      const result = normalizeVideoViewState({
+        currentTimeSeconds: 0,
+        anchorCanvas,
+        scale: 1,
+        scaleMode: 'fit',
+        rotation: 0,
+      });
+
+      expect(result.anchorCanvas).toEqual(anchorCanvas);
+      expect(result.anchorCanvas).not.toBe(anchorCanvas);
+    });
+
+    it('omits anchorWorld when not provided on the input camera', () => {
+      const result = normalizeVideoViewState({
+        currentTimeSeconds: 0,
+        anchorCanvas: [0.5, 0.5],
+        scale: 1,
+        scaleMode: 'fit',
+        rotation: 0,
+      });
+
+      expect(result.anchorWorld).toBeUndefined();
+    });
+
+    it('clones anchorWorld when provided, rather than aliasing it', () => {
+      const anchorWorld = [12, 34];
+      const result = normalizeVideoViewState({
+        currentTimeSeconds: 0,
+        anchorCanvas: [0.5, 0.5],
+        scale: 1,
+        scaleMode: 'fit',
+        rotation: 0,
+        anchorWorld,
+      });
+
+      expect(result.anchorWorld).toEqual(anchorWorld);
+      expect(result.anchorWorld).not.toBe(anchorWorld);
+    });
+  });
+
+  describe('resolveVideoCanvasMapping', () => {
+    it('returns undefined when any dimension is zero or missing', () => {
+      expect(
+        resolveVideoCanvasMapping({
+          containerWidth: 0,
+          containerHeight: 100,
+          intrinsicWidth: 100,
+          intrinsicHeight: 100,
+        })
+      ).toBeUndefined();
+      expect(
+        resolveVideoCanvasMapping({
+          containerWidth: 100,
+          containerHeight: 100,
+          intrinsicWidth: 100,
+          intrinsicHeight: 0,
+        })
+      ).toBeUndefined();
+    });
+
+    it('letterboxes a wide 1920x1080 video into a 512x512 square canvas (contain/fit)', () => {
+      // containScale = min(512/1920, 512/1080) = min(0.26667, 0.474) = 0.26667
+      // width = 1920 * 0.26667 = 512, height = 1080 * 0.26667 = 288
+      const mapping = resolveVideoCanvasMapping({
+        containerWidth: 512,
+        containerHeight: 512,
+        intrinsicWidth: 1920,
+        intrinsicHeight: 1080,
+        objectFit: 'contain',
+      });
+
+      expect(mapping.width).toBeCloseTo(512, 5);
+      expect(mapping.height).toBeCloseTo(288, 5);
+      // default anchorCanvas [0.5,0.5] with default anchorWorld = intrinsic center
+      // worldToCanvasRatio = 512 / 1920 = 0.26667
+      expect(mapping.worldToCanvasRatio).toBeCloseTo(512 / 1920, 5);
+      // left = 512*0.5 - (1920/2)*ratio = 256 - 256 = 0
+      expect(mapping.left).toBeCloseTo(0, 5);
+      // top = 512*0.5 - (1080/2)*ratio = 256 - 144 = 112 (letterbox band)
+      expect(mapping.top).toBeCloseTo(112, 5);
+    });
+
+    it('crops (cover) the same video to fill the square canvas with no letterboxing', () => {
+      // coverScale = max(512/1920, 512/1080) = 512/1080 = 0.474
+      // width = 1920 * 0.474 = 910.2, height = 1080*0.474 = 512
+      const mapping = resolveVideoCanvasMapping({
+        containerWidth: 512,
+        containerHeight: 512,
+        intrinsicWidth: 1920,
+        intrinsicHeight: 1080,
+        objectFit: 'cover',
+      });
+
+      expect(mapping.height).toBeCloseTo(512, 5);
+      expect(mapping.width).toBeCloseTo((512 / 1080) * 1920, 5);
+      // top offset should be 0 (height matches container exactly)
+      expect(mapping.top).toBeCloseTo(0, 5);
+      // left should be negative (cropped left/right)
+      expect(mapping.left).toBeLessThan(0);
+    });
+
+    it('fills the canvas exactly regardless of aspect ratio for objectFit "fill"', () => {
+      const mapping = resolveVideoCanvasMapping({
+        containerWidth: 512,
+        containerHeight: 512,
+        intrinsicWidth: 1920,
+        intrinsicHeight: 1080,
+        objectFit: 'fill',
+      });
+
+      expect(mapping.width).toBeCloseTo(512, 5);
+      expect(mapping.height).toBeCloseTo(512, 5);
+    });
+
+    it('uses intrinsic size unscaled for objectFit "none"', () => {
+      const mapping = resolveVideoCanvasMapping({
+        containerWidth: 512,
+        containerHeight: 512,
+        intrinsicWidth: 1920,
+        intrinsicHeight: 1080,
+        objectFit: 'none',
+      });
+
+      expect(mapping.width).toBeCloseTo(1920, 5);
+      expect(mapping.height).toBeCloseTo(1080, 5);
+    });
+
+    it('scale-down behaves like contain when intrinsic is larger than container', () => {
+      const scaleDown = resolveVideoCanvasMapping({
+        containerWidth: 512,
+        containerHeight: 512,
+        intrinsicWidth: 1920,
+        intrinsicHeight: 1080,
+        objectFit: 'scale-down',
+      });
+      const contain = resolveVideoCanvasMapping({
+        containerWidth: 512,
+        containerHeight: 512,
+        intrinsicWidth: 1920,
+        intrinsicHeight: 1080,
+        objectFit: 'contain',
+      });
+
+      expect(scaleDown.width).toBeCloseTo(contain.width, 5);
+      expect(scaleDown.height).toBeCloseTo(contain.height, 5);
+    });
+
+    it('scale-down behaves like "none" when intrinsic is smaller than container', () => {
+      // containScale = min(512/100, 512/50) = 5.12 > 1, so scaleDown clamps to 1
+      const mapping = resolveVideoCanvasMapping({
+        containerWidth: 512,
+        containerHeight: 512,
+        intrinsicWidth: 100,
+        intrinsicHeight: 50,
+        objectFit: 'scale-down',
+      });
+
+      expect(mapping.width).toBeCloseTo(100, 5);
+      expect(mapping.height).toBeCloseTo(50, 5);
+    });
+
+    it('applies camera.scale as an additional zoom multiplier on top of objectFit', () => {
+      const unzoomed = resolveVideoCanvasMapping({
+        containerWidth: 512,
+        containerHeight: 512,
+        intrinsicWidth: 1920,
+        intrinsicHeight: 1080,
+        objectFit: 'contain',
+      });
+      const zoomed = resolveVideoCanvasMapping({
+        containerWidth: 512,
+        containerHeight: 512,
+        intrinsicWidth: 1920,
+        intrinsicHeight: 1080,
+        objectFit: 'contain',
+        camera: {
+          anchorCanvas: [0.5, 0.5],
+          scale: 2,
+          scaleMode: 'fit',
+          rotation: 0,
+        },
+      });
+
+      expect(zoomed.width).toBeCloseTo(unzoomed.width * 2, 5);
+      expect(zoomed.height).toBeCloseTo(unzoomed.height * 2, 5);
+    });
+
+    it('floors camera.scale at 0.001 to avoid a zero-size mapping', () => {
+      const mapping = resolveVideoCanvasMapping({
+        containerWidth: 512,
+        containerHeight: 512,
+        intrinsicWidth: 1920,
+        intrinsicHeight: 1080,
+        camera: {
+          anchorCanvas: [0.5, 0.5],
+          scale: -10,
+          scaleMode: 'fit',
+          rotation: 0,
+        },
+      });
+
+      expect(mapping.width).toBeGreaterThan(0);
+      expect(mapping.height).toBeGreaterThan(0);
+    });
+
+    it('uses camera.anchorWorld when provided instead of the intrinsic center', () => {
+      const mapping = resolveVideoCanvasMapping({
+        containerWidth: 512,
+        containerHeight: 512,
+        intrinsicWidth: 1920,
+        intrinsicHeight: 1080,
+        objectFit: 'contain',
+        camera: {
+          anchorCanvas: [0.5, 0.5],
+          anchorWorld: [0, 0],
+          scale: 1,
+          scaleMode: 'fit',
+          rotation: 0,
+        },
+      });
+
+      expect(mapping.anchorWorld).toEqual([0, 0]);
+      // left = 512*0.5 - 0*ratio = 256
+      expect(mapping.left).toBeCloseTo(256, 5);
+      expect(mapping.top).toBeCloseTo(256, 5);
+    });
+  });
+
+  describe('getPanForVideoCanvasMapping / getAnchorWorldForPan round trip', () => {
+    it('round-trips pan -> anchorWorld -> mapping -> pan for an off-center anchor', () => {
+      const mapping = resolveVideoCanvasMapping({
+        containerWidth: 512,
+        containerHeight: 512,
+        intrinsicWidth: 1920,
+        intrinsicHeight: 1080,
+        objectFit: 'contain',
+        camera: {
+          anchorCanvas: [0.5, 0.5],
+          anchorWorld: [960, 540],
+          scale: 1,
+          scaleMode: 'fit',
+          rotation: 0,
+        },
+      });
+
+      const pan = getPanForVideoCanvasMapping(mapping);
+      const recoveredAnchorWorld = getAnchorWorldForVideoPan(pan, mapping);
+
+      expect(recoveredAnchorWorld[0]).toBeCloseTo(mapping.anchorWorld[0], 5);
+      expect(recoveredAnchorWorld[1]).toBeCloseTo(mapping.anchorWorld[1], 5);
+    });
+
+    it('keeps the anchor canvas point stationary when zooming about that anchor', () => {
+      // Simulate a zoom-about-anchor: set anchorWorld to the world point under a
+      // fixed canvas point, then re-resolve mapping at a different scale; the
+      // canvas position of that world point should not move.
+      const containerWidth = 512;
+      const containerHeight = 512;
+      const intrinsicWidth = 1920;
+      const intrinsicHeight = 1080;
+      const anchorCanvasPoint = [300, 200];
+
+      const initialMapping = resolveVideoCanvasMapping({
+        containerWidth,
+        containerHeight,
+        intrinsicWidth,
+        intrinsicHeight,
+        objectFit: 'contain',
+        camera: {
+          anchorCanvas: [0.5, 0.5],
+          scale: 1,
+          scaleMode: 'fit',
+          rotation: 0,
+        },
+      });
+      const anchorWorld = [
+        (anchorCanvasPoint[0] - initialMapping.left) /
+          initialMapping.worldToCanvasRatio,
+        (anchorCanvasPoint[1] - initialMapping.top) /
+          initialMapping.worldToCanvasRatio,
+      ];
+
+      const zoomedMapping = resolveVideoCanvasMapping({
+        containerWidth,
+        containerHeight,
+        intrinsicWidth,
+        intrinsicHeight,
+        objectFit: 'contain',
+        camera: {
+          anchorCanvas: [
+            anchorCanvasPoint[0] / containerWidth,
+            anchorCanvasPoint[1] / containerHeight,
+          ],
+          anchorWorld,
+          scale: 3,
+          scaleMode: 'fit',
+          rotation: 0,
+        },
+      });
+
+      const canvasX =
+        zoomedMapping.left + anchorWorld[0] * zoomedMapping.worldToCanvasRatio;
+      const canvasY =
+        zoomedMapping.top + anchorWorld[1] * zoomedMapping.worldToCanvasRatio;
+
+      expect(canvasX).toBeCloseTo(anchorCanvasPoint[0], 5);
+      expect(canvasY).toBeCloseTo(anchorCanvasPoint[1], 5);
+    });
+  });
+});
+
+describe('ecgViewportCamera', () => {
+  const timeRange = [0, 2000];
+  const valueRange = [-1, 1];
+
+  describe('createDefaultECGViewState', () => {
+    it('builds the default state from the supplied ranges, cloning the input arrays', () => {
+      const result = createDefaultECGViewState({ timeRange, valueRange });
+
+      expect(result).toEqual({
+        timeRange: [0, 2000],
+        valueRange: [-1, 1],
+        scrollOffset: 0,
+        anchorCanvas: [0.5, 0.5],
+        scale: 1,
+        scaleMode: 'fit',
+        rotation: 0,
+      });
+      expect(result.timeRange).not.toBe(timeRange);
+      expect(result.valueRange).not.toBe(valueRange);
+    });
+  });
+
+  describe('normalizeECGViewState', () => {
+    function baseCamera(overrides = {}) {
+      return {
+        timeRange: [0, 2000],
+        valueRange: [-1, 1],
+        scrollOffset: 0,
+        anchorCanvas: [0.5, 0.5],
+        scale: 1,
+        scaleMode: 'fit',
+        rotation: 0,
+        ...overrides,
+      };
+    }
+
+    it('clones timeRange and valueRange rather than aliasing them', () => {
+      const camera = baseCamera();
+      const result = normalizeECGViewState(camera);
+
+      expect(result.timeRange).toEqual(camera.timeRange);
+      expect(result.timeRange).not.toBe(camera.timeRange);
+      expect(result.valueRange).toEqual(camera.valueRange);
+      expect(result.valueRange).not.toBe(camera.valueRange);
+    });
+
+    it('preserves scrollOffset when defined, including zero', () => {
+      const result = normalizeECGViewState(baseCamera({ scrollOffset: 0 }));
+      expect(result.scrollOffset).toBe(0);
+
+      const result2 = normalizeECGViewState(baseCamera({ scrollOffset: 42 }));
+      expect(result2.scrollOffset).toBe(42);
+    });
+
+    it('omits scrollOffset when undefined on the input', () => {
+      const camera = baseCamera();
+      delete camera.scrollOffset;
+
+      const result = normalizeECGViewState(camera);
+
+      expect(result.scrollOffset).toBeUndefined();
+    });
+
+    it('clamps scale to the 0.001 floor and forces scaleMode to fit / rotation to 0', () => {
+      const result = normalizeECGViewState(
+        baseCamera({ scale: 0, scaleMode: 'absolute', rotation: 45 })
+      );
+
+      expect(result.scale).toBe(0.001);
+      expect(result.scaleMode).toBe('fit');
+      expect(result.rotation).toBe(0);
+    });
+
+    it('defaults anchorCanvas when missing', () => {
+      const camera = baseCamera();
+      delete camera.anchorCanvas;
+
+      const result = normalizeECGViewState(camera);
+
+      expect(result.anchorCanvas).toEqual([0.5, 0.5]);
+    });
+
+    it('omits anchorWorld when absent, and clones it when present', () => {
+      const withoutAnchor = normalizeECGViewState(baseCamera());
+      expect(withoutAnchor.anchorWorld).toBeUndefined();
+
+      const anchorWorld = [10, 20];
+      const withAnchor = normalizeECGViewState(baseCamera({ anchorWorld }));
+      expect(withAnchor.anchorWorld).toEqual(anchorWorld);
+      expect(withAnchor.anchorWorld).not.toBe(anchorWorld);
+    });
+  });
+
+  describe('resolveECGCanvasMapping', () => {
+    function makeCanvas(clientWidth, clientHeight) {
+      const canvas = document.createElement('canvas');
+      Object.defineProperty(canvas, 'clientWidth', {
+        configurable: true,
+        value: clientWidth,
+      });
+      Object.defineProperty(canvas, 'clientHeight', {
+        configurable: true,
+        value: clientHeight,
+      });
+      return canvas;
+    }
+
+    const metrics = {
+      ecgWidth: 2000,
+      ecgHeight: 400,
+      channelScale: 10,
+      worldToCanvasRatio: 0.1,
+      xOffsetCanvas: 0,
+      yOffsetCanvas: 0,
+    };
+
+    it('centers the signal in the canvas when no camera pan/zoom is supplied', () => {
+      // drawWidth = 2000*0.1 = 200, drawHeight = 400*0.1 = 40
+      // canvas is 300x100 -> centeredXOffset = (300-200)/2 = 50
+      // centeredYOffset = (100-40)/2 = 30
+      const canvas = makeCanvas(300, 100);
+      const mapping = resolveECGCanvasMapping({ metrics, canvas });
+
+      expect(mapping.centeredXOffset).toBeCloseTo(50, 5);
+      expect(mapping.centeredYOffset).toBeCloseTo(30, 5);
+      expect(mapping.effectiveRatio).toBeCloseTo(0.1, 5);
+      // default anchorWorld = ecg center [1000, 200]; anchorCanvas [0.5,0.5]
+      // xOffset = 300*0.5 - 1000*0.1 = 150 - 100 = 50 (matches centeredXOffset)
+      expect(mapping.xOffset).toBeCloseTo(50, 5);
+      expect(mapping.yOffset).toBeCloseTo(30, 5);
+    });
+
+    it('scales effectiveRatio by camera.scale and floors it at 0.001', () => {
+      const canvas = makeCanvas(300, 100);
+      const zoomed = resolveECGCanvasMapping({
+        metrics,
+        canvas,
+        camera: {
+          timeRange,
+          valueRange,
+          anchorCanvas: [0.5, 0.5],
+          scale: 2,
+          scaleMode: 'fit',
+          rotation: 0,
+        },
+      });
+
+      expect(zoomed.effectiveRatio).toBeCloseTo(0.2, 5);
+
+      const negativeScale = resolveECGCanvasMapping({
+        metrics,
+        canvas,
+        camera: {
+          timeRange,
+          valueRange,
+          anchorCanvas: [0.5, 0.5],
+          scale: -5,
+          scaleMode: 'fit',
+          rotation: 0,
+        },
+      });
+
+      expect(negativeScale.effectiveRatio).toBeCloseTo(0.1 * 0.001, 8);
+    });
+
+    it('uses camera.anchorWorld to offset the mapping away from center', () => {
+      const canvas = makeCanvas(300, 100);
+      const mapping = resolveECGCanvasMapping({
+        metrics,
+        canvas,
+        camera: {
+          timeRange,
+          valueRange,
+          anchorCanvas: [0.5, 0.5],
+          anchorWorld: [0, 0],
+          scale: 1,
+          scaleMode: 'fit',
+          rotation: 0,
+        },
+      });
+
+      expect(mapping.anchorWorld).toEqual([0, 0]);
+      // xOffset = 300*0.5 - 0*0.1 = 150
+      expect(mapping.xOffset).toBeCloseTo(150, 5);
+      expect(mapping.yOffset).toBeCloseTo(50, 5);
+    });
+  });
+
+  describe('getPanForECGCanvasMapping / getAnchorWorldForPan round trip', () => {
+    it('reports zero pan for the centered default mapping', () => {
+      const canvas = document.createElement('canvas');
+      Object.defineProperty(canvas, 'clientWidth', {
+        value: 300,
+        configurable: true,
+      });
+      Object.defineProperty(canvas, 'clientHeight', {
+        value: 100,
+        configurable: true,
+      });
+      const metrics = {
+        ecgWidth: 2000,
+        ecgHeight: 400,
+        channelScale: 10,
+        worldToCanvasRatio: 0.1,
+        xOffsetCanvas: 0,
+        yOffsetCanvas: 0,
+      };
+      const mapping = resolveECGCanvasMapping({ metrics, canvas });
+      const pan = getPanForECGCanvasMapping(mapping);
+
+      expect(pan[0]).toBeCloseTo(0, 5);
+      expect(pan[1]).toBeCloseTo(0, 5);
+    });
+
+    it('round-trips pan -> anchorWorld -> mapping -> pan for a non-trivial anchor', () => {
+      const canvas = document.createElement('canvas');
+      Object.defineProperty(canvas, 'clientWidth', {
+        value: 300,
+        configurable: true,
+      });
+      Object.defineProperty(canvas, 'clientHeight', {
+        value: 100,
+        configurable: true,
+      });
+      const metrics = {
+        ecgWidth: 2000,
+        ecgHeight: 400,
+        channelScale: 10,
+        worldToCanvasRatio: 0.1,
+        xOffsetCanvas: 0,
+        yOffsetCanvas: 0,
+      };
+      const mapping = resolveECGCanvasMapping({
+        metrics,
+        canvas,
+        camera: {
+          timeRange,
+          valueRange,
+          anchorCanvas: [0.5, 0.5],
+          anchorWorld: [500, -0.3],
+          scale: 1.5,
+          scaleMode: 'fit',
+          rotation: 0,
+        },
+      });
+
+      const pan = getPanForECGCanvasMapping(mapping);
+      const recoveredAnchorWorld = getAnchorWorldForECGPan(pan, mapping);
+
+      expect(recoveredAnchorWorld[0]).toBeCloseTo(mapping.anchorWorld[0], 5);
+      expect(recoveredAnchorWorld[1]).toBeCloseTo(mapping.anchorWorld[1], 5);
+    });
+  });
+
+  describe('getAnchorWorldForCanvasPoint', () => {
+    it('inverts the canvas-space offset back into signal-space (sample index, amplitude)', () => {
+      const canvas = document.createElement('canvas');
+      Object.defineProperty(canvas, 'clientWidth', {
+        value: 300,
+        configurable: true,
+      });
+      Object.defineProperty(canvas, 'clientHeight', {
+        value: 100,
+        configurable: true,
+      });
+      const metrics = {
+        ecgWidth: 2000,
+        ecgHeight: 400,
+        channelScale: 10,
+        worldToCanvasRatio: 0.1,
+        xOffsetCanvas: 0,
+        yOffsetCanvas: 0,
+      };
+      const mapping = resolveECGCanvasMapping({ metrics, canvas });
+
+      // canvas point at (xOffset + 100*ratio, yOffset + 20*ratio) should map back
+      // to signal coordinate [100, 20]
+      const canvasPoint = [
+        mapping.xOffset + 100 * mapping.effectiveRatio,
+        mapping.yOffset + 20 * mapping.effectiveRatio,
+      ];
+      const anchorWorld = getAnchorWorldForCanvasPoint(canvasPoint, mapping);
+
+      expect(anchorWorld[0]).toBeCloseTo(100, 5);
+      expect(anchorWorld[1]).toBeCloseTo(20, 5);
+    });
+
+    it('is the inverse of the forward canvas transform used by ECGResolvedView.worldToCanvas', () => {
+      const canvas = document.createElement('canvas');
+      Object.defineProperty(canvas, 'clientWidth', {
+        value: 300,
+        configurable: true,
+      });
+      Object.defineProperty(canvas, 'clientHeight', {
+        value: 100,
+        configurable: true,
+      });
+      const metrics = {
+        ecgWidth: 2000,
+        ecgHeight: 400,
+        channelScale: 10,
+        worldToCanvasRatio: 0.1,
+        xOffsetCanvas: 0,
+        yOffsetCanvas: 0,
+      };
+      const mapping = resolveECGCanvasMapping({
+        metrics,
+        canvas,
+        camera: {
+          timeRange,
+          valueRange,
+          anchorCanvas: [0.5, 0.5],
+          scale: 2,
+          scaleMode: 'fit',
+          rotation: 0,
+        },
+      });
+
+      const originalCanvasPoint = [123, 45];
+      const anchorWorld = getAnchorWorldForCanvasPoint(
+        originalCanvasPoint,
+        mapping
+      );
+      // Forward transform (mirrors resolveECGCanvasMapping's own xOffset/yOffset
+      // derivation): canvas = world*effectiveRatio + offset, but offset here is
+      // computed from mapping.xOffset/yOffset directly since anchorWorld
+      // corresponds to this exact mapping's xOffset/yOffset origin.
+      const reprojectedX =
+        anchorWorld[0] * mapping.effectiveRatio + mapping.xOffset;
+      const reprojectedY =
+        anchorWorld[1] * mapping.effectiveRatio + mapping.yOffset;
+
+      expect(reprojectedX).toBeCloseTo(originalCanvasPoint[0], 5);
+      expect(reprojectedY).toBeCloseTo(originalCanvasPoint[1], 5);
+    });
+  });
+});
+
+describe('volume3DProjectionCamera', () => {
+  function makeCamera(overrides = {}) {
+    return {
+      clippingRange: [0.1, 1000],
+      focalPoint: [1, 2, 3],
+      position: [1, 2, 103],
+      viewPlaneNormal: [0, 0, 1],
+      viewUp: [0, -1, 0],
+      parallelProjection: true,
+      parallelScale: 50,
+      ...overrides,
+    };
+  }
+
+  describe('cloneVolume3DCamera', () => {
+    it('deep-clones point arrays so mutating the clone does not affect the source', () => {
+      const camera = makeCamera();
+      const clone = cloneVolume3DCamera(camera);
+
+      expect(clone).toEqual(camera);
+      expect(clone.focalPoint).not.toBe(camera.focalPoint);
+      expect(clone.position).not.toBe(camera.position);
+      expect(clone.viewPlaneNormal).not.toBe(camera.viewPlaneNormal);
+      expect(clone.viewUp).not.toBe(camera.viewUp);
+      expect(clone.clippingRange).not.toBe(camera.clippingRange);
+
+      clone.focalPoint[0] = 999;
+      expect(camera.focalPoint[0]).toBe(1);
+    });
+
+    it('passes through undefined point fields as undefined rather than throwing', () => {
+      const camera = makeCamera({
+        clippingRange: undefined,
+        focalPoint: undefined,
+        position: undefined,
+        viewPlaneNormal: undefined,
+        viewUp: undefined,
+      });
+      const clone = cloneVolume3DCamera(camera);
+
+      expect(clone.clippingRange).toBeUndefined();
+      expect(clone.focalPoint).toBeUndefined();
+      expect(clone.position).toBeUndefined();
+      expect(clone.viewPlaneNormal).toBeUndefined();
+      expect(clone.viewUp).toBeUndefined();
+    });
+
+    it('preserves non-point scalar fields via spread (e.g. parallelScale, parallelProjection)', () => {
+      const camera = makeCamera({
+        parallelScale: 77,
+        parallelProjection: false,
+      });
+      const clone = cloneVolume3DCamera(camera);
+
+      expect(clone.parallelScale).toBe(77);
+      expect(clone.parallelProjection).toBe(false);
+    });
+  });
+
+  describe('getVolume3DProjectionScale', () => {
+    it('reports physical mm-per-canvas-pixel from parallelScale and canvasHeight', () => {
+      // mmPerCanvasPixel = (parallelScale*2) / canvasHeight = (50*2)/200 = 0.5
+      const result = getVolume3DProjectionScale({
+        camera: makeCamera({ parallelScale: 50 }),
+        canvasHeight: 200,
+      });
+
+      expect(result).toEqual({ kind: 'physical', mmPerCanvasPixel: 0.5 });
+    });
+
+    it('returns undefined when parallelScale is not a number', () => {
+      const result = getVolume3DProjectionScale({
+        camera: makeCamera({ parallelScale: undefined }),
+        canvasHeight: 200,
+      });
+
+      expect(result).toBeUndefined();
+    });
+
+    it('clamps the divisor at 1 canvas pixel to avoid divide-by-zero for a zero/negative canvasHeight', () => {
+      const result = getVolume3DProjectionScale({
+        camera: makeCamera({ parallelScale: 10 }),
+        canvasHeight: 0,
+      });
+
+      // mmPerCanvasPixel = (10*2)/max(0,1) = 20
+      expect(result).toEqual({ kind: 'physical', mmPerCanvasPixel: 20 });
+    });
+  });
+
+  describe('getVolume3DProjectionPosition', () => {
+    it('reports a focalPoint position, cloning the point array', () => {
+      const camera = makeCamera({ focalPoint: [4, 5, 6] });
+      const result = getVolume3DProjectionPosition(camera);
+
+      expect(result).toEqual({ kind: 'focalPoint', worldPoint: [4, 5, 6] });
+      expect(result.worldPoint).not.toBe(camera.focalPoint);
+    });
+
+    it('returns undefined when the camera has no focalPoint', () => {
+      const camera = makeCamera({ focalPoint: undefined });
+      const result = getVolume3DProjectionPosition(camera);
+
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/packages/core/test/planarRenderCamera.jest.js
+++ b/packages/core/test/planarRenderCamera.jest.js
@@ -1,0 +1,987 @@
+jest.mock('../src/metaData', () => ({
+  addProvider: jest.fn(),
+  get: jest.fn(),
+}));
+
+import { OrientationAxis } from '../src/enums';
+import { RENDERING_DEFAULTS } from '../src/constants';
+import { PlanarVolumeResolvedView } from '../src/RenderingEngine/GenericViewport/Planar';
+import {
+  applyPlanarICameraToActor,
+  applyPlanarICameraToRenderer,
+  createPlanarPresentationScaleMatrix,
+  derivePlanarPresentation,
+  projectAnchorWorldToCurrentPlane,
+  resolvePlanarICamera,
+  setPlanarVolumeCameraClippingRange,
+  updatePlanarVolumeClippingPlanes,
+} from '../src/RenderingEngine/GenericViewport/Planar/planarRenderCamera';
+import setVtkCameraClippingRange from '../src/RenderingEngine/GenericViewport/setVtkCameraClippingRange';
+
+function expectPoint2Close(actual, expected, precision = 5) {
+  expect(actual[0]).toBeCloseTo(expected[0], precision);
+  expect(actual[1]).toBeCloseTo(expected[1], precision);
+}
+
+function expectPoint3Close(actual, expected, precision = 5) {
+  expect(actual[0]).toBeCloseTo(expected[0], precision);
+  expect(actual[1]).toBeCloseTo(expected[1], precision);
+  expect(actual[2]).toBeCloseTo(expected[2], precision);
+}
+
+// Independent re-derivation of Rodrigues' rotation formula for a vector `v`
+// that is perpendicular to a unit `axis`. Used to compute an expected
+// rotated viewUp without reusing the source's own rotatePlanarViewUp/mat4
+// helpers, so the test is not just re-running the implementation.
+function rotatePerpendicular(v, axis, angleDeg) {
+  const rad = (angleDeg * Math.PI) / 180;
+  const cos = Math.cos(rad);
+  const sin = Math.sin(rad);
+  const cross = [
+    axis[1] * v[2] - axis[2] * v[1],
+    axis[2] * v[0] - axis[0] * v[2],
+    axis[0] * v[1] - axis[1] * v[0],
+  ];
+
+  return [
+    v[0] * cos + cross[0] * sin,
+    v[1] * cos + cross[1] * sin,
+    v[2] * cos + cross[2] * sin,
+  ];
+}
+
+function distance3(a, b) {
+  return Math.sqrt(
+    (a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2 + (a[2] - b[2]) ** 2
+  );
+}
+
+/**
+ * A hand-authored PlanarSliceBasis used to unit-test planarRenderCamera in
+ * isolation from planarSliceBasis.ts. Chosen so the canvas aspect ratio
+ * (200x100 => 2:1) exactly matches the slice aspect ratio (200x100 world
+ * units => 2:1), which keeps fitParallelScale/worldWidth/worldHeight
+ * arithmetic free of aspect-correction terms:
+ *   fitParallelScale = 50  => worldHeight at zoom=1 is 100, worldWidth is 200
+ *   sliceCenterWorld = [10, 20, 30]
+ *   viewPlaneNormal = [0, 0, 1] (already unit, "looking" from +z)
+ *   viewUp = [0, -1, 0] (already unit)
+ *   cameraDistance = 500
+ */
+function createSliceBasisA() {
+  return {
+    sliceCenterWorld: [10, 20, 30],
+    viewPlaneNormal: [0, 0, 1],
+    viewUp: [0, -1, 0],
+    fitParallelScale: 50,
+    sliceWidthWorld: 200,
+    sliceHeightWorld: 100,
+    cameraDistance: 500,
+  };
+}
+
+const CANVAS_A = { canvasWidth: 200, canvasHeight: 100 };
+
+describe('setVtkCameraClippingRange', () => {
+  it('sets a symmetric clipping range for parallel projection', () => {
+    const camera = {
+      getParallelProjection: jest.fn(() => true),
+      setClippingRange: jest.fn(),
+    };
+
+    setVtkCameraClippingRange(camera);
+
+    expect(camera.setClippingRange).toHaveBeenCalledTimes(1);
+    const [near, far] = camera.setClippingRange.mock.calls[0];
+
+    expect(near).toBeCloseTo(-RENDERING_DEFAULTS.MAXIMUM_RAY_DISTANCE, 5);
+    expect(far).toBeCloseTo(RENDERING_DEFAULTS.MAXIMUM_RAY_DISTANCE, 5);
+  });
+
+  it('sets a near-plane clipping range for perspective projection', () => {
+    const camera = {
+      getParallelProjection: jest.fn(() => false),
+      setClippingRange: jest.fn(),
+    };
+
+    setVtkCameraClippingRange(camera);
+
+    expect(camera.setClippingRange).toHaveBeenCalledTimes(1);
+    const [near, far] = camera.setClippingRange.mock.calls[0];
+
+    expect(near).toBeCloseTo(RENDERING_DEFAULTS.MINIMUM_SLAB_THICKNESS, 5);
+    expect(far).toBeCloseTo(RENDERING_DEFAULTS.MAXIMUM_RAY_DISTANCE, 5);
+  });
+});
+
+describe('projectAnchorWorldToCurrentPlane', () => {
+  it('projects a point onto a plane defined by point + unit normal', () => {
+    // anchor = [5,5,5], plane through origin with normal [0,0,1] (the XY
+    // plane). distance = dot([5,5,5],[0,0,1]) = 5, so the projection
+    // subtracts 5 along the normal, landing at [5,5,0].
+    const result = projectAnchorWorldToCurrentPlane(
+      [5, 5, 5],
+      [0, 0, 0],
+      [0, 0, 1]
+    );
+
+    expectPoint3Close(result, [5, 5, 0]);
+  });
+
+  it('normalizes a non-unit plane normal before projecting', () => {
+    // Same geometry as above but the normal is supplied as [0,0,2]; the
+    // function must normalize it internally before computing distance.
+    const result = projectAnchorWorldToCurrentPlane(
+      [5, 5, 5],
+      [0, 0, 0],
+      [0, 0, 2]
+    );
+
+    expectPoint3Close(result, [5, 5, 0]);
+  });
+
+  it('returns the anchor unchanged when it already lies on the plane', () => {
+    const result = projectAnchorWorldToCurrentPlane(
+      [3, 4, 0],
+      [0, 0, 0],
+      [0, 0, 1]
+    );
+
+    expectPoint3Close(result, [3, 4, 0]);
+  });
+});
+
+describe('derivePlanarPresentation', () => {
+  it('resolves default pan/zoom/rotation for an undefined camera', () => {
+    const presentation = derivePlanarPresentation({
+      sliceBasis: createSliceBasisA(),
+      camera: undefined,
+      ...CANVAS_A,
+    });
+
+    expectPoint2Close(presentation.pan, [0, 0]);
+    expect(presentation.zoom).toBeCloseTo(1, 10);
+    expect(presentation.rotation).toBe(0);
+    expect(presentation.flipHorizontal).toBe(false);
+    expect(presentation.flipVertical).toBe(false);
+    expectPoint2Close(presentation.scale, [1, 1]);
+  });
+
+  it('derives pan from anchorCanvas relative to the canvas center', () => {
+    // anchorCanvas [0.6, 0.3] on a 200x100 canvas shifts by
+    // (0.6-0.5)*200 = 20 horizontally and (0.3-0.5)*100 = -20 vertically.
+    // anchorWorld is not set, so panFromAnchorWorld is zero.
+    const presentation = derivePlanarPresentation({
+      sliceBasis: createSliceBasisA(),
+      camera: { anchorCanvas: [0.6, 0.3] },
+      ...CANVAS_A,
+    });
+
+    expectPoint2Close(presentation.pan, [20, -20]);
+  });
+
+  it('normalizes rotation into [0, 360)', () => {
+    const basis = createSliceBasisA();
+
+    expect(
+      derivePlanarPresentation({
+        sliceBasis: basis,
+        camera: undefined,
+        ...CANVAS_A,
+      }).rotation
+    ).toBe(0);
+    expect(
+      derivePlanarPresentation({
+        sliceBasis: basis,
+        camera: { rotation: 450 },
+        ...CANVAS_A,
+      }).rotation
+    ).toBeCloseTo(90, 10);
+    expect(
+      derivePlanarPresentation({
+        sliceBasis: basis,
+        camera: { rotation: -90 },
+        ...CANVAS_A,
+      }).rotation
+    ).toBeCloseTo(270, 10);
+  });
+
+  it('only treats a strict boolean true as an active flip flag', () => {
+    // flipHorizontal is compared with `=== true`, so a truthy non-boolean
+    // value must resolve to false.
+    const presentation = derivePlanarPresentation({
+      sliceBasis: createSliceBasisA(),
+      camera: { flipHorizontal: 'yes' },
+      ...CANVAS_A,
+    });
+
+    expect(presentation.flipHorizontal).toBe(false);
+  });
+
+  it('produces finite values for a degenerate (zero-size) canvas', () => {
+    const presentation = derivePlanarPresentation({
+      sliceBasis: createSliceBasisA(),
+      camera: { anchorCanvas: [0.75, 0.5] },
+      canvasWidth: 0,
+      canvasHeight: 0,
+    });
+
+    expect(Number.isFinite(presentation.pan[0])).toBe(true);
+    expect(Number.isFinite(presentation.pan[1])).toBe(true);
+    expect(Number.isFinite(presentation.zoom)).toBe(true);
+  });
+
+  describe('displayArea overrides', () => {
+    // getSliceCanvasDimensionsAtFit for sliceBasisA on the 200x100 canvas:
+    //   worldHeightAtFit = fitParallelScale*2 = 100
+    //   worldWidthAtFit = 100 * (200/100) = 200
+    //   imageWidthAtFit = (sliceWidthWorld/worldWidthAtFit)*canvasWidth
+    //                   = (200/200)*200 = 200
+    //   imageHeightAtFit = (sliceHeightWorld/worldHeightAtFit)*canvasHeight
+    //                    = (100/100)*100 = 100
+    // i.e. imageWidthAtFit/imageHeightAtFit exactly match the canvas here,
+    // which keeps the derivations below simple.
+
+    it('type SCALE uses the explicit scale and zero pan without imageCanvasPoint', () => {
+      const presentation = derivePlanarPresentation({
+        sliceBasis: createSliceBasisA(),
+        camera: { displayArea: { type: 'SCALE', scale: [3, 4] } },
+        ...CANVAS_A,
+      });
+
+      expectPoint2Close(presentation.scale, [3, 4]);
+      expect(presentation.zoom).toBeCloseTo(4, 10);
+      expectPoint2Close(presentation.pan, [0, 0]);
+    });
+
+    it('type FIT with imageArea + fitWidth scaleMode + imageCanvasPoint derives scale and pan', () => {
+      // safeAreaX=0.5, safeAreaY=1
+      // fitScaleX = canvasWidth / (areaX*imageWidthAtFit) = 200/(0.5*200) = 2
+      // fitScaleY = canvasHeight / (areaY*imageHeightAtFit) = 100/(1*100) = 1
+      // scaleMode 'fitWidth' -> uniformFitScale = fitScaleX = 2
+      // resolvedScale = [2*scale.x, 2*scale.y] = [2, 2] (scale defaults to [1,1])
+      //
+      // pan.x = resolvedScale.x*imageWidthAtFit*(0.5-imageX) + canvasWidth*(canvasX-0.5)
+      //       = 2*200*(0.5-0.2) + 200*(0.3-0.5) = 120 - 40 = 80
+      // pan.y = resolvedScale.y*imageHeightAtFit*(0.5-imageY) + canvasHeight*(canvasY-0.5)
+      //       = 2*100*(0.5-0.8) + 100*(0.4-0.5) = -60 - 10 = -70
+      const presentation = derivePlanarPresentation({
+        sliceBasis: createSliceBasisA(),
+        camera: {
+          displayArea: {
+            type: 'FIT',
+            imageArea: [0.5, 1],
+            scaleMode: 'fitWidth',
+            imageCanvasPoint: {
+              imagePoint: [0.2, 0.8],
+              canvasPoint: [0.3, 0.4],
+            },
+          },
+        },
+        ...CANVAS_A,
+      });
+
+      expectPoint2Close(presentation.scale, [2, 2]);
+      expect(presentation.zoom).toBeCloseTo(2, 10);
+      expectPoint2Close(presentation.pan, [80, -70]);
+    });
+
+    it.each([
+      // fitScaleX = 2, fitScaleY = 1 (as derived above)
+      ['absolute', [2, 3], [4, 3]],
+      ['fitHeight', [1, 1], [1, 1]],
+      ['fitAspect', [1, 1], [1, 1]], // min(fitScaleX, fitScaleY) = 1
+      ['bogus-mode', [1, 1], [1, 1]], // falls back to fitAspect behavior
+    ])(
+      'scaleMode %s resolves the expected non-uniform/uniform scale',
+      (scaleMode, inputScale, expectedScale) => {
+        const presentation = derivePlanarPresentation({
+          sliceBasis: createSliceBasisA(),
+          camera: {
+            scale: inputScale,
+            displayArea: {
+              type: 'FIT',
+              imageArea: [0.5, 1],
+              scaleMode,
+            },
+          },
+          ...CANVAS_A,
+        });
+
+        expectPoint2Close(presentation.scale, expectedScale);
+      }
+    );
+  });
+});
+
+describe('resolvePlanarICamera', () => {
+  it('resolves focalPoint/position/viewUp/viewPlaneNormal/parallelScale for the default camera', () => {
+    // With no pan (anchorCanvas centered, no anchorWorld) the focalPoint is
+    // exactly sliceCenterWorld, and position = focalPoint + normal*cameraDistance.
+    const resolved = resolvePlanarICamera({
+      sliceBasis: createSliceBasisA(),
+      camera: undefined,
+      ...CANVAS_A,
+    });
+
+    expectPoint3Close(resolved.focalPoint, [10, 20, 30]);
+    expectPoint3Close(resolved.position, [10, 20, 530]);
+    expectPoint3Close(resolved.viewUp, [0, -1, 0]);
+    expectPoint3Close(resolved.viewPlaneNormal, [0, 0, 1]);
+    expect(resolved.parallelScale).toBeCloseTo(50, 10);
+    expect(resolved.parallelProjection).toBe(true);
+    expect(resolved.scaleMode).toBe('fit');
+  });
+
+  it('halves parallelScale when zoom (scale.y) doubles, without moving focalPoint/position', () => {
+    // parallelScale = fitParallelScale / scale.y = 50/2 = 25. Pan stays zero
+    // regardless of scale because there is no anchor offset, so the camera
+    // position is unaffected by zoom -- only parallelScale changes.
+    const resolved = resolvePlanarICamera({
+      sliceBasis: createSliceBasisA(),
+      camera: { scale: 2 },
+      ...CANVAS_A,
+    });
+
+    expect(resolved.parallelScale).toBeCloseTo(25, 10);
+    expectPoint3Close(resolved.focalPoint, [10, 20, 30]);
+    expectPoint3Close(resolved.position, [10, 20, 530]);
+  });
+
+  it('rotates viewUp by 90 degrees about the view plane normal without moving the camera', () => {
+    // Rodrigues rotation of viewUp=[0,-1,0] about axis=[0,0,1] by 90 deg:
+    // k x v = [1,0,0] (k.v = 0 since v is already perpendicular to k), so
+    // v_rot = v*cos(90) + (k x v)*sin(90) = [1, 0, 0].
+    const resolved = resolvePlanarICamera({
+      sliceBasis: createSliceBasisA(),
+      camera: { rotation: 90 },
+      ...CANVAS_A,
+    });
+
+    expectPoint3Close(resolved.viewUp, [1, 0, 0]);
+    expectPoint3Close(resolved.focalPoint, [10, 20, 30]);
+    expectPoint3Close(resolved.position, [10, 20, 530]);
+  });
+
+  it('rotates viewUp by an arbitrary angle consistently with independent Rodrigues formula', () => {
+    const expectedViewUp = rotatePerpendicular([0, -1, 0], [0, 0, 1], 37);
+    const resolved = resolvePlanarICamera({
+      sliceBasis: createSliceBasisA(),
+      camera: { rotation: 37 },
+      ...CANVAS_A,
+    });
+
+    expectPoint3Close(resolved.viewUp, expectedViewUp, 6);
+  });
+
+  it('produces the same viewUp for a rotation and its 360-wrapped equivalent', () => {
+    const base = resolvePlanarICamera({
+      sliceBasis: createSliceBasisA(),
+      camera: { rotation: 90 },
+      ...CANVAS_A,
+    });
+    const wrapped = resolvePlanarICamera({
+      sliceBasis: createSliceBasisA(),
+      camera: { rotation: 450 },
+      ...CANVAS_A,
+    });
+
+    expectPoint3Close(wrapped.viewUp, base.viewUp);
+  });
+
+  describe('flip combinations', () => {
+    // shouldFlipNormal = flipHorizontal XOR flipVertical; viewUp is negated
+    // only when flipVertical is true (independent of flipHorizontal).
+    it('flipHorizontal alone negates viewPlaneNormal but leaves viewUp untouched', () => {
+      const resolved = resolvePlanarICamera({
+        sliceBasis: createSliceBasisA(),
+        camera: { flipHorizontal: true },
+        ...CANVAS_A,
+      });
+
+      expectPoint3Close(resolved.viewPlaneNormal, [0, 0, -1]);
+      expectPoint3Close(resolved.viewUp, [0, -1, 0]);
+      expectPoint3Close(resolved.position, [10, 20, -470]);
+      expect(resolved.flipHorizontal).toBe(true);
+      expect(resolved.flipVertical).toBe(false);
+    });
+
+    it('flipVertical alone negates both viewPlaneNormal and viewUp', () => {
+      const resolved = resolvePlanarICamera({
+        sliceBasis: createSliceBasisA(),
+        camera: { flipVertical: true },
+        ...CANVAS_A,
+      });
+
+      expectPoint3Close(resolved.viewPlaneNormal, [0, 0, -1]);
+      expectPoint3Close(resolved.viewUp, [0, 1, 0]);
+      expectPoint3Close(resolved.position, [10, 20, -470]);
+    });
+
+    it('flipping both horizontal and vertical leaves viewPlaneNormal unchanged but negates viewUp', () => {
+      const resolved = resolvePlanarICamera({
+        sliceBasis: createSliceBasisA(),
+        camera: { flipHorizontal: true, flipVertical: true },
+        ...CANVAS_A,
+      });
+
+      expectPoint3Close(resolved.viewPlaneNormal, [0, 0, 1]);
+      expectPoint3Close(resolved.viewUp, [0, 1, 0]);
+      expectPoint3Close(resolved.position, [10, 20, 530]);
+    });
+  });
+
+  it('normalizes a non-unit sliceBasis viewPlaneNormal/viewUp before use', () => {
+    const nonUnitBasis = {
+      ...createSliceBasisA(),
+      viewPlaneNormal: [0, 0, 5],
+      viewUp: [0, -2, 0],
+    };
+    const resolved = resolvePlanarICamera({
+      sliceBasis: nonUnitBasis,
+      camera: undefined,
+      ...CANVAS_A,
+    });
+
+    expectPoint3Close(resolved.viewPlaneNormal, [0, 0, 1]);
+    expectPoint3Close(resolved.viewUp, [0, -1, 0]);
+    expectPoint3Close(resolved.position, [10, 20, 530]);
+  });
+
+  it('composes rotation (pre-flip frame) with a horizontal flip and an off-plane anchorWorld', () => {
+    // rotation=90 about normal=[0,0,1]: rotatedViewUp = [1,0,0] (as above).
+    // flipHorizontal=true (flipVertical=false) => shouldFlipNormal = true
+    // (true !== false), so viewPlaneNormal negates to [0,0,-1]; viewUp is
+    // NOT negated (that only happens when flipVertical is true), so
+    // flippedViewUp stays [1,0,0].
+    //
+    // right = cross(flippedViewUp=[1,0,0], flippedNormal=[0,0,-1]) = [0,1,0]
+    //
+    // anchorWorld=[10,25,30] is already on the slice plane (z=30 matches
+    // sliceCenterWorld.z and the plane normal is along z), so
+    // effectiveAnchorWorld === anchorWorld.
+    //
+    // deltaWorld = sliceCenterWorld - effectiveAnchorWorld = [0,-5,0]
+    // panFromAnchorWorld.x = dot(deltaWorld,right)*canvasWidth/effectiveWorldWidth
+    //                      = dot([0,-5,0],[0,1,0])*200/200 = -5
+    // panFromAnchorWorld.y = -dot(deltaWorld,flippedViewUp)*canvasHeight/worldHeight
+    //                      = -dot([0,-5,0],[1,0,0])*100/100 = 0
+    // => presentation.pan = [-5, 0]
+    //
+    // Because anchorCanvas is centered and scale is 1, resolving that pan
+    // back into world space is the exact inverse of the above, so the
+    // resolved focalPoint must land back on effectiveAnchorWorld -- this is
+    // the "zoom/pan to anchor" invariant.
+    const presentation = derivePlanarPresentation({
+      sliceBasis: createSliceBasisA(),
+      camera: { rotation: 90, flipHorizontal: true, anchorWorld: [10, 25, 30] },
+      ...CANVAS_A,
+    });
+
+    expectPoint2Close(presentation.pan, [-5, 0]);
+
+    const resolved = resolvePlanarICamera({
+      sliceBasis: createSliceBasisA(),
+      camera: { rotation: 90, flipHorizontal: true, anchorWorld: [10, 25, 30] },
+      ...CANVAS_A,
+    });
+
+    expectPoint3Close(resolved.focalPoint, [10, 25, 30]);
+    expectPoint3Close(resolved.viewUp, [1, 0, 0]);
+    expectPoint3Close(resolved.viewPlaneNormal, [0, 0, -1]);
+    expectPoint3Close(resolved.position, [10, 25, -470]);
+  });
+
+  it('falls back to a [1,0,0] in-plane right vector when viewUp is parallel to viewPlaneNormal, and the anchor invariant still holds', () => {
+    // Degenerate basis: viewUp colinear with viewPlaneNormal means
+    // cross(viewUp, viewPlaneNormal) is the zero vector, which triggers the
+    // hard-coded [1,0,0] fallback for `right` inside both
+    // derivePlanarPresentation and getResolvedPanOffset. Since both call
+    // sites recompute the same fallback, the anchor invariant (focalPoint
+    // lands on the projected anchorWorld when anchorCanvas is centered and
+    // scale is 1) must still hold, and no NaNs should appear.
+    const degenerateBasis = {
+      ...createSliceBasisA(),
+      viewPlaneNormal: [0, 0, 1],
+      viewUp: [0, 0, 1],
+    };
+    const resolved = resolvePlanarICamera({
+      sliceBasis: degenerateBasis,
+      camera: { anchorWorld: [15, 20, 30] },
+      ...CANVAS_A,
+    });
+
+    expect(Number.isFinite(resolved.focalPoint[0])).toBe(true);
+    expectPoint3Close(resolved.focalPoint, [15, 20, 30]);
+  });
+});
+
+describe('applyPlanarICameraToRenderer', () => {
+  function createFakeRenderer() {
+    const camera = {
+      setParallelProjection: jest.fn(),
+      setDirectionOfProjection: jest.fn(),
+      setParallelScale: jest.fn(),
+      setFocalPoint: jest.fn(),
+      setPosition: jest.fn(),
+      setViewUp: jest.fn(),
+    };
+    const renderer = { getActiveCamera: () => camera };
+
+    return { renderer, camera };
+  }
+
+  it('pushes the resolved ICamera fields onto the vtk camera setters', () => {
+    const { renderer, camera } = createFakeRenderer();
+    const resolvedICamera = resolvePlanarICamera({
+      sliceBasis: createSliceBasisA(),
+      camera: undefined,
+      ...CANVAS_A,
+    });
+
+    const returned = applyPlanarICameraToRenderer({
+      renderer,
+      activeSourceICamera: resolvedICamera,
+    });
+
+    expect(returned).toBe(resolvedICamera);
+    expect(camera.setParallelProjection).toHaveBeenCalledWith(true);
+
+    const [dopX, dopY, dopZ] = camera.setDirectionOfProjection.mock.calls[0];
+    // direction of projection is the negated view plane normal [0,0,1] -> [0,0,-1]
+    expect(dopX).toBeCloseTo(0, 10);
+    expect(dopY).toBeCloseTo(0, 10);
+    expect(dopZ).toBeCloseTo(-1, 10);
+
+    const [pScale] = camera.setParallelScale.mock.calls[0];
+    expect(pScale).toBeCloseTo(50, 10);
+
+    const [fx, fy, fz] = camera.setFocalPoint.mock.calls[0];
+    expect(fx).toBeCloseTo(10, 10);
+    expect(fy).toBeCloseTo(20, 10);
+    expect(fz).toBeCloseTo(30, 10);
+
+    const [px, py, pz] = camera.setPosition.mock.calls[0];
+    expect(px).toBeCloseTo(10, 10);
+    expect(py).toBeCloseTo(20, 10);
+    expect(pz).toBeCloseTo(530, 10);
+
+    const [ux, uy, uz] = camera.setViewUp.mock.calls[0];
+    expect(ux).toBeCloseTo(0, 10);
+    expect(uy).toBeCloseTo(-1, 10);
+    expect(uz).toBeCloseTo(0, 10);
+  });
+
+  const completeCamera = {
+    focalPoint: [0, 0, 0],
+    position: [0, 0, 1],
+    viewPlaneNormal: [0, 0, 1],
+    viewUp: [0, 1, 0],
+    parallelScale: 10,
+  };
+
+  it.each([
+    ['an undefined camera', undefined],
+    ['a missing focalPoint', { ...completeCamera, focalPoint: undefined }],
+    ['a missing position', { ...completeCamera, position: undefined }],
+    [
+      'a missing viewPlaneNormal',
+      { ...completeCamera, viewPlaneNormal: undefined },
+    ],
+    ['a missing viewUp', { ...completeCamera, viewUp: undefined }],
+    [
+      'a non-numeric parallelScale',
+      { ...completeCamera, parallelScale: undefined },
+    ],
+  ])(
+    'returns undefined and never touches the renderer camera for %s',
+    (_label, cam) => {
+      const { renderer, camera } = createFakeRenderer();
+
+      const result = applyPlanarICameraToRenderer({
+        renderer,
+        activeSourceICamera: cam,
+      });
+
+      expect(result).toBeUndefined();
+      expect(camera.setFocalPoint).not.toHaveBeenCalled();
+      expect(camera.setPosition).not.toHaveBeenCalled();
+    }
+  );
+});
+
+describe('setPlanarVolumeCameraClippingRange', () => {
+  it('delegates to setVtkCameraClippingRange using the renderer active camera', () => {
+    const vtkCamera = {
+      getParallelProjection: jest.fn(() => true),
+      setClippingRange: jest.fn(),
+    };
+    const renderer = { getActiveCamera: () => vtkCamera };
+
+    setPlanarVolumeCameraClippingRange(renderer);
+
+    expect(vtkCamera.setClippingRange).toHaveBeenCalledTimes(1);
+    const [near, far] = vtkCamera.setClippingRange.mock.calls[0];
+
+    expect(near).toBeCloseTo(-RENDERING_DEFAULTS.MAXIMUM_RAY_DISTANCE, 5);
+    expect(far).toBeCloseTo(RENDERING_DEFAULTS.MAXIMUM_RAY_DISTANCE, 5);
+  });
+});
+
+describe('createPlanarPresentationScaleMatrix / applyPlanarICameraToActor', () => {
+  it('returns an identity matrix when presentationScale is uniform (ratio 1)', () => {
+    const matrix = createPlanarPresentationScaleMatrix({
+      focalPoint: [13.5, 29, 48],
+      presentationScale: [1, 1],
+      viewPlaneNormal: [0, 0, -1],
+      viewUp: [0, -1, 0],
+    });
+
+    expect(Array.from(matrix)).toEqual([
+      1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1,
+    ]);
+  });
+
+  it('returns an identity matrix when the camera is missing required fields', () => {
+    expect(Array.from(createPlanarPresentationScaleMatrix(undefined))).toEqual([
+      1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1,
+    ]);
+    expect(
+      Array.from(
+        createPlanarPresentationScaleMatrix({
+          presentationScale: [2, 1],
+          viewPlaneNormal: [0, 0, -1],
+          // viewUp missing
+        })
+      )
+    ).toEqual([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+  });
+
+  it('builds a non-uniform in-plane scale matrix for an anisotropic presentationScale', () => {
+    // presentationScale [2,1] -> ratioX = 2/1 = 2, ratioDelta = 1.
+    // right = cross(viewUp=[0,-1,0], viewPlaneNormal=[0,0,-1]) = [1,0,0]
+    // (rx,ry,rz) = (1,0,0), so the linear part is a pure scale-by-2 along x:
+    //   linear = [2,0,0, 0,1,0, 0,0,1]
+    // transformedCenter = linear * focalPoint(13.5,29,48) = (27,29,48)
+    // translation = focalPoint - transformedCenter = (-13.5, 0, 0)
+    const matrix = createPlanarPresentationScaleMatrix({
+      focalPoint: [13.5, 29, 48],
+      presentationScale: [2, 1],
+      viewPlaneNormal: [0, 0, -1],
+      viewUp: [0, -1, 0],
+    });
+
+    expect(matrix[0]).toBeCloseTo(2, 8);
+    expect(matrix[1]).toBeCloseTo(0, 8);
+    expect(matrix[2]).toBeCloseTo(0, 8);
+    expect(matrix[4]).toBeCloseTo(0, 8);
+    expect(matrix[5]).toBeCloseTo(1, 8);
+    expect(matrix[6]).toBeCloseTo(0, 8);
+    expect(matrix[8]).toBeCloseTo(0, 8);
+    expect(matrix[9]).toBeCloseTo(0, 8);
+    expect(matrix[10]).toBeCloseTo(1, 8);
+    expect(matrix[12]).toBeCloseTo(-13.5, 8);
+    expect(matrix[13]).toBeCloseTo(0, 8);
+    expect(matrix[14]).toBeCloseTo(0, 8);
+    expect(matrix[15]).toBeCloseTo(1, 8);
+  });
+
+  it('falls back to a [1,0,0] right vector when viewUp is parallel to viewPlaneNormal', () => {
+    // Degenerate axis: cross(viewUp, viewPlaneNormal) is zero when they are
+    // colinear, so getPlanarICameraRight falls back to [1,0,0]. With
+    // presentationScale [2,1] the resulting linear part is still a pure
+    // scale-by-2 along x (same shape as the non-degenerate case above),
+    // computed around focalPoint (5,5,5):
+    //   transformedCenter = (10,5,5); translation = (5-10,0,0) = (-5,0,0)
+    const matrix = createPlanarPresentationScaleMatrix({
+      focalPoint: [5, 5, 5],
+      presentationScale: [2, 1],
+      viewPlaneNormal: [0, 0, 1],
+      viewUp: [0, 0, 1],
+    });
+
+    expect(matrix[0]).toBeCloseTo(2, 8);
+    expect(matrix[5]).toBeCloseTo(1, 8);
+    expect(matrix[10]).toBeCloseTo(1, 8);
+    expect(matrix[12]).toBeCloseTo(-5, 8);
+    expect(matrix[13]).toBeCloseTo(0, 8);
+    expect(matrix[14]).toBeCloseTo(0, 8);
+  });
+
+  it('applies the computed matrix to an actor exposing setUserMatrix', () => {
+    const actor = { setUserMatrix: jest.fn() };
+    const activeSourceICamera = {
+      focalPoint: [13.5, 29, 48],
+      presentationScale: [2, 1],
+      viewPlaneNormal: [0, 0, -1],
+      viewUp: [0, -1, 0],
+    };
+
+    applyPlanarICameraToActor({ actor, activeSourceICamera });
+
+    expect(actor.setUserMatrix).toHaveBeenCalledTimes(1);
+    const [appliedMatrix] = actor.setUserMatrix.mock.calls[0];
+
+    expect(appliedMatrix[0]).toBeCloseTo(2, 8);
+    expect(appliedMatrix[12]).toBeCloseTo(-13.5, 8);
+  });
+
+  it('does not throw when the actor has no setUserMatrix', () => {
+    expect(() =>
+      applyPlanarICameraToActor({ actor: {}, activeSourceICamera: undefined })
+    ).not.toThrow();
+    expect(() =>
+      applyPlanarICameraToActor({
+        actor: undefined,
+        activeSourceICamera: undefined,
+      })
+    ).not.toThrow();
+  });
+});
+
+describe('updatePlanarVolumeClippingPlanes', () => {
+  function createFakeMapper(initialPlanes = []) {
+    let planes = [...initialPlanes];
+
+    return {
+      getClippingPlanes: jest.fn(() => planes),
+      addClippingPlane: jest.fn((plane) => {
+        planes = [...planes, plane];
+      }),
+    };
+  }
+
+  it('creates two clipping planes when the mapper has fewer than two', () => {
+    const mapper = createFakeMapper([]);
+    const camera = { focalPoint: [10, 20, 30], viewPlaneNormal: [0, 0, 1] };
+
+    updatePlanarVolumeClippingPlanes({ camera, mapper, slabThickness: 5 });
+
+    expect(mapper.addClippingPlane).toHaveBeenCalledTimes(2);
+
+    const planes = mapper.getClippingPlanes();
+
+    expect(planes).toHaveLength(2);
+    // plane 0: normal = viewPlaneNormal, origin = focalPoint - normal*slabThickness
+    expectPoint3Close(planes[0].getNormal(), [0, 0, 1]);
+    expectPoint3Close(planes[0].getOrigin(), [10, 20, 25]);
+    // plane 1: normal = -viewPlaneNormal, origin = focalPoint + normal*slabThickness
+    expectPoint3Close(planes[1].getNormal(), [0, 0, -1]);
+    expectPoint3Close(planes[1].getOrigin(), [10, 20, 35]);
+  });
+
+  it('reuses existing clipping planes instead of creating new ones', () => {
+    const existingPlanes = [
+      { setNormal: jest.fn(), setOrigin: jest.fn() },
+      { setNormal: jest.fn(), setOrigin: jest.fn() },
+    ];
+    const mapper = createFakeMapper(existingPlanes);
+    const camera = { focalPoint: [1, 2, 3], viewPlaneNormal: [1, 0, 0] };
+
+    updatePlanarVolumeClippingPlanes({ camera, mapper, slabThickness: 2 });
+
+    expect(mapper.addClippingPlane).not.toHaveBeenCalled();
+    expect(existingPlanes[0].setNormal).toHaveBeenCalledWith(1, 0, 0);
+    expect(existingPlanes[0].setOrigin).toHaveBeenCalledWith(-1, 2, 3);
+    expect(existingPlanes[1].setNormal).toHaveBeenCalledWith(-1, -0, -0);
+    expect(existingPlanes[1].setOrigin).toHaveBeenCalledWith(3, 2, 3);
+  });
+
+  it('defaults slabThickness to RENDERING_DEFAULTS.MINIMUM_SLAB_THICKNESS', () => {
+    const existingPlanes = [
+      { setNormal: jest.fn(), setOrigin: jest.fn() },
+      { setNormal: jest.fn(), setOrigin: jest.fn() },
+    ];
+    const mapper = createFakeMapper(existingPlanes);
+    const camera = { focalPoint: [0, 0, 0], viewPlaneNormal: [0, 1, 0] };
+
+    updatePlanarVolumeClippingPlanes({ camera, mapper });
+
+    const expectedOffset = RENDERING_DEFAULTS.MINIMUM_SLAB_THICKNESS;
+    const [ox, oy, oz] = existingPlanes[0].setOrigin.mock.calls[0];
+
+    expect(ox).toBeCloseTo(0, 10);
+    expect(oy).toBeCloseTo(-expectedOffset, 10);
+    expect(oz).toBeCloseTo(0, 10);
+  });
+});
+
+describe('PlanarVolumeResolvedView (parity with PlanarStackResolvedView)', () => {
+  // Same volume fixture used by planarComputedCamera.jest.js. dimensions
+  // [8,10,12], identity direction, spacing [1,2,3]; indexToWorld([i,j,k]) =
+  // [10+i, 20+j*2, 30+k*3]; extentToBounds -> x:[10,17] y:[20,38] z:[30,63].
+  function createImageVolume() {
+    return {
+      dimensions: [8, 10, 12],
+      direction: [1, 0, 0, 0, 1, 0, 0, 0, 1],
+      spacing: [1, 2, 3],
+      metadata: {
+        FrameOfReferenceUID: 'volume-for',
+      },
+      imageData: {
+        getDimensions: () => [8, 10, 12],
+        getDirection: () => [1, 0, 0, 0, 1, 0, 0, 0, 1],
+        getExtent: () => [0, 7, 0, 9, 0, 11],
+        extentToBounds: () => [10, 17, 20, 38, 30, 63],
+        indexToWorld: ([i, j, k]) => [10 + i, 20 + j * 2, 30 + k * 3],
+      },
+    };
+  }
+
+  function createVolumeCamera(viewStateOverrides = {}) {
+    return new PlanarVolumeResolvedView({
+      viewState: {
+        orientation: OrientationAxis.AXIAL,
+        ...viewStateOverrides,
+      },
+      canvasHeight: 256,
+      canvasWidth: 256,
+      currentImageIdIndex: 5,
+      frameOfReferenceUID: 'volume-for',
+      imageVolume: createImageVolume(),
+      maxImageIdIndex: 11,
+      usePixelGridCenter: false,
+    });
+  }
+
+  // Geometric derivation for the AXIAL slice basis of this volume on a
+  // 256x256 canvas (see also planarSliceBasis.ts):
+  //   MPR AXIAL viewPlaneNormal=[0,0,-1], viewUp=[0,-1,0].
+  //   sliceAxis (max |dot(axis,normal)|) is the k-axis, exactly aligned, so
+  //   the center ijk snaps to [ (8-1)/2, (10-1)/2, floor(12/2) ] = [3.5,4.5,6]
+  //   -> indexToWorld -> center = [13.5, 29, 48].
+  //   Volume corners project onto normal=[0,0,-1] as -z, z in [30,63], so
+  //   min=-63, max=-30 (range 33). spacingInNormalDirection = |spacing.z| = 3.
+  //   No explicit slice/imageIdIndex was requested, so sliceCenterWorld stays
+  //   at the volume center: [13.5, 29, 48]. cameraDistance = max(33,3,1)=33.
+  //   getOrthogonalVolumeSliceGeometry for AXIAL picks columns from the row
+  //   axis (dim 8, spacing 1) and rows from the column axis (dim 10, spacing 2):
+  //     sliceWidthWorld=8, sliceHeightWorld=20
+  //     fitParallelScale = max(rows*rowSpacing, cols*colSpacing/aspect)*0.5
+  //                      = max(20, 8)*0.5 = 10   (square canvas, aspect=1)
+  const EXPECTED_FOCAL_POINT = [13.5, 29, 48];
+  const EXPECTED_POSITION = [13.5, 29, 15]; // focal + [0,0,-1]*33
+  const EXPECTED_VIEW_UP = [0, -1, 0];
+  const EXPECTED_VIEW_PLANE_NORMAL = [0, 0, -1];
+  const EXPECTED_PARALLEL_SCALE = 10;
+
+  it('round-trips canvas -> world -> canvas for center and off-center points', () => {
+    const camera = createVolumeCamera();
+
+    for (const canvasPoint of [
+      [128, 128],
+      [47, 123],
+      [0, 0],
+      [256, 256],
+    ]) {
+      const worldPoint = camera.canvasToWorld(canvasPoint);
+
+      expectPoint2Close(camera.worldToCanvas(worldPoint), canvasPoint);
+    }
+  });
+
+  it('resolves toICamera consistently with a direct resolvePlanarICamera call', () => {
+    const camera = createVolumeCamera();
+    const resolved = camera.toICamera();
+
+    expectPoint3Close(resolved.focalPoint, EXPECTED_FOCAL_POINT);
+    expectPoint3Close(resolved.position, EXPECTED_POSITION);
+    expectPoint3Close(resolved.viewUp, EXPECTED_VIEW_UP);
+    expectPoint3Close(resolved.viewPlaneNormal, EXPECTED_VIEW_PLANE_NORMAL);
+    expect(resolved.parallelScale).toBeCloseTo(EXPECTED_PARALLEL_SCALE, 5);
+
+    const directlyResolved = resolvePlanarICamera({
+      sliceBasis: camera.getSliceBasis(),
+      camera: camera.state.viewState,
+      canvasWidth: camera.state.canvasWidth,
+      canvasHeight: camera.state.canvasHeight,
+    });
+
+    expectPoint3Close(resolved.focalPoint, directlyResolved.focalPoint);
+    expectPoint3Close(resolved.position, directlyResolved.position);
+    expectPoint3Close(resolved.viewUp, directlyResolved.viewUp);
+    expect(resolved.parallelScale).toBeCloseTo(
+      directlyResolved.parallelScale,
+      10
+    );
+  });
+
+  it('withZoom(2) halves the world-per-pixel footprint', () => {
+    const camera = createVolumeCamera();
+    const beforeA = camera.canvasToWorld([118, 128]);
+    const beforeB = camera.canvasToWorld([138, 128]);
+    const beforeDistance = distance3(beforeA, beforeB);
+
+    const zoomed = camera.withZoom(2);
+    const afterA = zoomed.canvasToWorld([118, 128]);
+    const afterB = zoomed.canvasToWorld([138, 128]);
+    const afterDistance = distance3(afterA, afterB);
+
+    expect(zoomed.zoom).toBeCloseTo(2, 5);
+    expect(afterDistance).toBeCloseTo(beforeDistance / 2, 5);
+  });
+
+  it('keeps the zoom anchor stable when zooming at a canvas point', () => {
+    const camera = createVolumeCamera();
+    const anchorCanvasPoint = [96, 144];
+    const anchorWorldPoint = camera.canvasToWorld(anchorCanvasPoint);
+    const zoomedCamera = camera.withZoom(2, anchorCanvasPoint);
+
+    expectPoint3Close(
+      zoomedCamera.canvasToWorld(anchorCanvasPoint),
+      anchorWorldPoint
+    );
+    expect(zoomedCamera.zoom).toBeCloseTo(2, 5);
+  });
+
+  it('updates pan-derived transforms without recomputing ad hoc viewport math', () => {
+    const camera = createVolumeCamera();
+    const centerWorldPoint = camera.canvasToWorld([128, 128]);
+    const pannedCamera = camera.withPan([24, -18]);
+
+    expectPoint2Close(pannedCamera.pan, [24, -18]);
+    // Panning is a pure canvas-space translation of the focal point: the
+    // point that used to render at [128,128] now renders at
+    // [128+24, 128-18] = [152, 110], matching the stack-camera recipe.
+    expectPoint2Close(pannedCamera.worldToCanvas(centerWorldPoint), [152, 110]);
+  });
+
+  it('mirrors transforms when flipped horizontally or vertically', () => {
+    const camera = createVolumeCamera();
+    const referencePoint = [196, 84];
+    const worldPoint = camera.canvasToWorld(referencePoint);
+    const horizontalFlip = camera.flipHorizontal();
+    const verticalFlip = camera.flipVertical();
+
+    // Flips mirror around the canvas center (256/2 = 128).
+    expectPoint2Close(horizontalFlip.worldToCanvas(worldPoint), [60, 84]);
+    expectPoint2Close(verticalFlip.worldToCanvas(worldPoint), [196, 172]);
+    expect(horizontalFlip.state.viewState.flipHorizontal).toBe(true);
+    expect(verticalFlip.state.viewState.flipVertical).toBe(true);
+  });
+
+  it('exposes the volume frame of reference', () => {
+    const camera = createVolumeCamera();
+
+    expect(camera.getFrameOfReferenceUID()).toBe('volume-for');
+  });
+
+  it('indexToWorld returns undefined when the volume has no imageData', () => {
+    const camera = new PlanarVolumeResolvedView({
+      viewState: { orientation: OrientationAxis.AXIAL },
+      canvasHeight: 256,
+      canvasWidth: 256,
+      currentImageIdIndex: 0,
+      frameOfReferenceUID: 'volume-for',
+      imageVolume: {
+        dimensions: [1, 1, 1],
+        direction: [1, 0, 0, 0, 1, 0, 0, 0, 1],
+        spacing: [1, 1, 1],
+      },
+      maxImageIdIndex: 0,
+      usePixelGridCenter: false,
+    });
+
+    expect(camera.indexToWorld([0, 0, 0])).toBeUndefined();
+  });
+});

--- a/packages/core/test/planarSliceBasis.jest.js
+++ b/packages/core/test/planarSliceBasis.jest.js
@@ -1,0 +1,868 @@
+jest.mock('../src/metaData', () => ({
+  addProvider: jest.fn(),
+  get: jest.fn(),
+}));
+
+import { vec3 } from 'gl-matrix';
+import {
+  InterpolationType,
+  OrientationAxis,
+  VOILUTFunctionType,
+} from '../src/enums';
+import * as metaData from '../src/metaData';
+import {
+  createPlanarImageSliceBasis,
+  createPlanarCpuImageSliceBasis,
+  createPlanarVolumeSliceBasis,
+  createPlanarCpuVolumeSliceBasis,
+  resolvePlanarVolumeImageIdIndex,
+  shouldUsePlanarCpuVolumeSliceBasis,
+} from '../src/RenderingEngine/GenericViewport/Planar/planarSliceBasis';
+
+// Mutable per-test override merged into the mocked imagePlaneModule so each
+// test can control rowCosines/columnCosines/imagePositionPatient/spacing
+// without redefining the whole metaData mock.
+let imagePlaneModuleOverrides = {};
+
+function createImage(overrides = {}) {
+  return {
+    imageId: 'image-1',
+    minPixelValue: 0,
+    maxPixelValue: 255,
+    slope: 1,
+    intercept: 0,
+    windowCenter: 127,
+    windowWidth: 255,
+    voiLUTFunction: VOILUTFunctionType.LINEAR,
+    getPixelData: () => new Uint8Array(64 * 64),
+    getCanvas: () => document.createElement('canvas'),
+    rows: 64,
+    columns: 64,
+    height: 64,
+    width: 64,
+    color: false,
+    rgba: false,
+    numberOfComponents: 1,
+    columnPixelSpacing: 1,
+    rowPixelSpacing: 1,
+    invert: false,
+    sizeInBytes: 64 * 64,
+    photometricInterpretation: 'MONOCHROME2',
+    dataType: 'Uint8Array',
+    ...overrides,
+  };
+}
+
+// A simple axis-aligned volume: dimensions=[10,8,6], anisotropic spacing
+// [0.5,1,2], identity direction, origin offset to [100,200,300] so that
+// world coordinates are never confused with index coordinates.
+//
+// bounds = [xMin,xMax,yMin,yMax,zMin,zMax]
+//   x: 100 .. 100 + 9*0.5 = 104.5
+//   y: 200 .. 200 + 7*1   = 207
+//   z: 300 .. 300 + 5*2   = 310
+function createOrthonormalVolume() {
+  const dimensions = [10, 8, 6];
+  const spacing = [0.5, 1, 2];
+  const direction = [1, 0, 0, 0, 1, 0, 0, 0, 1];
+  const origin = [100, 200, 300];
+
+  return {
+    dimensions,
+    direction,
+    spacing,
+    imageData: {
+      getDimensions: () => dimensions,
+      getDirection: () => direction,
+      getExtent: () => [0, 9, 0, 7, 0, 5],
+      extentToBounds: () => [
+        origin[0],
+        origin[0] + 9 * spacing[0],
+        origin[1],
+        origin[1] + 7 * spacing[1],
+        origin[2],
+        origin[2] + 5 * spacing[2],
+      ],
+      // vtkImageData exposes a half-voxel padded spatial extent used by
+      // rotateToViewCoordinates (only exercised by the getCubeSizeInView
+      // fallback path).
+      getSpatialExtent: () => [-0.5, 9.5, -0.5, 7.5, -0.5, 5.5],
+      // Supports both the single-arg (returns new array) and the
+      // vtk.js-style (ijk, out) mutate-in-place call conventions.
+      indexToWorld: (ijk, out) => {
+        const world = [
+          origin[0] + ijk[0] * spacing[0],
+          origin[1] + ijk[1] * spacing[1],
+          origin[2] + ijk[2] * spacing[2],
+        ];
+
+        if (out) {
+          out[0] = world[0];
+          out[1] = world[1];
+          out[2] = world[2];
+
+          return out;
+        }
+
+        return world;
+      },
+    },
+  };
+}
+
+// Same geometry as createOrthonormalVolume, but the k axis (scan direction)
+// is negated -- a "flipped" volume such as one acquired feet-first.
+function createFlippedZVolume() {
+  const dimensions = [10, 8, 6];
+  const spacing = [0.5, 1, 2];
+  const direction = [1, 0, 0, 0, 1, 0, 0, 0, -1];
+  const origin = [100, 200, 300];
+
+  return {
+    dimensions,
+    direction,
+    spacing,
+    imageData: {
+      getDimensions: () => dimensions,
+      getDirection: () => direction,
+      getExtent: () => [0, 9, 0, 7, 0, 5],
+      extentToBounds: () => [
+        origin[0],
+        origin[0] + 9 * spacing[0],
+        origin[1],
+        origin[1] + 7 * spacing[1],
+        origin[2] - 5 * spacing[2],
+        origin[2],
+      ],
+      indexToWorld: ([i, j, k]) => [
+        origin[0] + i * spacing[0],
+        origin[1] + j * spacing[1],
+        origin[2] - k * spacing[2],
+      ],
+    },
+  };
+}
+
+// A single-slice (2D-ish) volume: dimensions=[5,5,1], identity direction,
+// unit spacing, origin at [0,0,0].
+function createSingleSliceVolume() {
+  const dimensions = [5, 5, 1];
+  const spacing = [1, 1, 1];
+  const direction = [1, 0, 0, 0, 1, 0, 0, 0, 1];
+
+  return {
+    dimensions,
+    direction,
+    spacing,
+    imageData: {
+      getDimensions: () => dimensions,
+      getDirection: () => direction,
+      getExtent: () => [0, 4, 0, 4, 0, 0],
+      extentToBounds: () => [0, 4, 0, 4, 0, 0],
+      indexToWorld: ([i, j, k]) => [i, j, k],
+    },
+  };
+}
+
+// A volume whose row/column axes are rotated 45 degrees in-plane (direction
+// matrix is not axis-aligned), while the scan axis (k) stays pure +z. This
+// direction matrix fails isOrthonormalDirection's "axis aligned" check, so
+// buildImageVolumeCorners must fall back to computing corners via
+// indexToWorld instead of extentToBounds -- extentToBounds is made to throw
+// so an accidental use of that path fails loudly.
+function createRotatedVolume() {
+  const dimensions = [4, 4, 4];
+  const spacing = [1, 1, 1];
+  const c = Math.SQRT1_2;
+  const direction = [c, c, 0, -c, c, 0, 0, 0, 1];
+
+  return {
+    dimensions,
+    direction,
+    spacing,
+    imageData: {
+      getDimensions: () => dimensions,
+      getDirection: () => direction,
+      getExtent: () => [0, 3, 0, 3, 0, 3],
+      extentToBounds: () => {
+        throw new Error(
+          'extentToBounds should not be used for a non-axis-aligned direction'
+        );
+      },
+      // Half-voxel padded spatial extent, used only by the
+      // getCubeSizeInView fallback (rows/columns are rotated relative to the
+      // fixed MPR axes, so the fit-metrics computation also falls back here).
+      getSpatialExtent: () => [-0.5, 3.5, -0.5, 3.5, -0.5, 3.5],
+      indexToWorld: ([i, j, k], out) => {
+        const world = [
+          i * direction[0] + j * direction[3],
+          i * direction[1] + j * direction[4],
+          k * direction[8],
+        ];
+
+        if (out) {
+          out[0] = world[0];
+          out[1] = world[1];
+          out[2] = world[2];
+
+          return out;
+        }
+
+        return world;
+      },
+    },
+  };
+}
+
+function expectPoint3Close(actual, expected, precision = 5) {
+  expect(actual[0]).toBeCloseTo(expected[0], precision);
+  expect(actual[1]).toBeCloseTo(expected[1], precision);
+  expect(actual[2]).toBeCloseTo(expected[2], precision);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  imagePlaneModuleOverrides = {};
+  metaData.get.mockImplementation((type) => {
+    if (type === 'imagePixelModule') {
+      return {
+        bitsAllocated: 16,
+        bitsStored: 16,
+        highBit: 15,
+        photometricInterpretation: 'MONOCHROME2',
+        pixelRepresentation: 0,
+        samplesPerPixel: 1,
+      };
+    }
+
+    if (type === 'generalSeriesModule') {
+      return {
+        modality: 'CT',
+      };
+    }
+
+    if (type === 'scalingModule' || type === 'calibrationModule') {
+      return undefined;
+    }
+
+    if (type === 'imagePlaneModule') {
+      return {
+        columnPixelSpacing: 1,
+        rowPixelSpacing: 1,
+        columnCosines: [0, 1, 0],
+        rowCosines: [1, 0, 0],
+        frameOfReferenceUID: 'image-for',
+        imageOrientationPatient: [1, 0, 0, 0, 1, 0],
+        imagePositionPatient: [0, 0, 0],
+        ...imagePlaneModuleOverrides,
+      };
+    }
+  });
+});
+
+describe('createPlanarImageSliceBasis (stack image basis)', () => {
+  it('derives the slice basis from row/column cosines and spacing for an axial image', () => {
+    imagePlaneModuleOverrides = {
+      rowCosines: [1, 0, 0],
+      columnCosines: [0, 1, 0],
+      imagePositionPatient: [0, 0, 0],
+      columnPixelSpacing: 1,
+      rowPixelSpacing: 1,
+    };
+
+    const image = createImage({
+      columns: 4,
+      rows: 6,
+      columnPixelSpacing: 1,
+      rowPixelSpacing: 1,
+    });
+    const basis = createPlanarImageSliceBasis({
+      image,
+      canvasWidth: 256,
+      canvasHeight: 256,
+    });
+
+    // rowVector = rowCosines = [1,0,0]; columnVector = columnCosines = [0,1,0]
+    // scanAxisNormal = rowVector x columnVector = [0,0,1]
+    // viewPlaneNormal = -scanAxisNormal
+    expectPoint3Close(basis.viewPlaneNormal, [0, 0, -1]);
+    // viewUp = -columnVector
+    expectPoint3Close(basis.viewUp, [0, -1, 0]);
+    // rowOffset = ((columns-1)/2)*columnPixelSpacing = (3/2)*1 = 1.5
+    // columnOffset = ((rows-1)/2)*rowPixelSpacing = (5/2)*1 = 2.5
+    // sliceCenterWorld = origin + rowOffset*rowVector + columnOffset*columnVector
+    expectPoint3Close(basis.sliceCenterWorld, [1.5, 2.5, 0]);
+    expect(basis.sliceWidthWorld).toBeCloseTo(4, 5);
+    expect(basis.sliceHeightWorld).toBeCloseTo(6, 5);
+    // physicalHeight = 6, physicalWidth = 4, canvas aspect = 1
+    // fitParallelScale = max(6, 4/1) * 0.5 = 3
+    expect(basis.fitParallelScale).toBeCloseTo(3, 5);
+    expect(basis.cameraDistance).toBe(1);
+  });
+
+  it('keeps an orthonormal, correctly-handed basis for an oblique image orientation', () => {
+    const cos45 = Math.SQRT1_2;
+    const rowCosines = [cos45, cos45, 0];
+    const columnCosines = [-cos45, cos45, 0];
+
+    imagePlaneModuleOverrides = {
+      rowCosines,
+      columnCosines,
+      imagePositionPatient: [10, -5, 3],
+      columnPixelSpacing: 1,
+      rowPixelSpacing: 1,
+    };
+
+    const image = createImage({ columns: 8, rows: 8 });
+    const basis = createPlanarImageSliceBasis({
+      image,
+      canvasWidth: 200,
+      canvasHeight: 200,
+    });
+
+    const rowVec = vec3.fromValues(...rowCosines);
+    const colVec = vec3.fromValues(...columnCosines);
+    const expectedNormal = Array.from(
+      vec3.negate(vec3.create(), vec3.cross(vec3.create(), rowVec, colVec))
+    );
+    const expectedViewUp = Array.from(vec3.negate(vec3.create(), colVec));
+
+    expectPoint3Close(basis.viewPlaneNormal, expectedNormal);
+    expectPoint3Close(basis.viewUp, expectedViewUp);
+
+    // orthonormality: unit length, mutually perpendicular
+    expect(vec3.length(basis.viewPlaneNormal)).toBeCloseTo(1, 6);
+    expect(vec3.length(basis.viewUp)).toBeCloseTo(1, 6);
+    expect(vec3.dot(basis.viewPlaneNormal, basis.viewUp)).toBeCloseTo(0, 6);
+
+    // handedness: rowVector x columnVector must point opposite viewPlaneNormal
+    // (viewPlaneNormal is defined as the negated cross product), i.e. rowVector,
+    // columnVector, -viewPlaneNormal form a right-handed triple.
+    const crossRowCol = vec3.cross(vec3.create(), rowVec, colVec);
+
+    expectPoint3Close(
+      Array.from(vec3.negate(vec3.create(), crossRowCol)),
+      basis.viewPlaneNormal
+    );
+  });
+
+  it('handles a single-row image without collapsing the column offset incorrectly', () => {
+    imagePlaneModuleOverrides = {
+      rowCosines: [1, 0, 0],
+      columnCosines: [0, 1, 0],
+      imagePositionPatient: [0, 0, 0],
+    };
+
+    const image = createImage({ columns: 5, rows: 1 });
+    const basis = createPlanarImageSliceBasis({
+      image,
+      canvasWidth: 100,
+      canvasHeight: 100,
+    });
+
+    // columnOffset = ((rows-1)/2)*rowPixelSpacing = 0
+    // rowOffset = ((columns-1)/2)*columnPixelSpacing = 2
+    expectPoint3Close(basis.sliceCenterWorld, [2, 0, 0]);
+    expect(basis.sliceHeightWorld).toBeCloseTo(1, 5);
+  });
+
+  it('produces an identical basis for the CPU and VTK stack image paths', () => {
+    imagePlaneModuleOverrides = {
+      rowCosines: [1, 0, 0],
+      columnCosines: [0, 1, 0],
+      imagePositionPatient: [2, 3, 4],
+      columnPixelSpacing: 0.5,
+      rowPixelSpacing: 0.75,
+    };
+
+    const image = createImage({
+      columns: 10,
+      rows: 12,
+      columnPixelSpacing: 0.5,
+      rowPixelSpacing: 0.75,
+    });
+    const args = { image, canvasWidth: 320, canvasHeight: 240 };
+
+    // createPlanarCpuImageSliceBasis is documented to simply delegate to
+    // createPlanarImageSliceBasis so stack rendering is invariant across
+    // render modes -- assert that relationship holds (value equality).
+    expect(createPlanarCpuImageSliceBasis(args)).toEqual(
+      createPlanarImageSliceBasis(args)
+    );
+  });
+});
+
+describe('createPlanarVolumeSliceBasis (volume slice basis)', () => {
+  it('derives an axial volume slice basis with the geometric center as the default slice', () => {
+    const imageVolume = createOrthonormalVolume();
+    const { sliceBasis, currentImageIdIndex, maxImageIdIndex } =
+      createPlanarVolumeSliceBasis({
+        canvasWidth: 256,
+        canvasHeight: 256,
+        imageVolume,
+        orientation: OrientationAxis.AXIAL,
+      });
+
+    expectPoint3Close(sliceBasis.viewPlaneNormal, [0, 0, -1]);
+    expectPoint3Close(sliceBasis.viewUp, [0, -1, 0]);
+    // getVolumeCenterIJK snaps the axis aligned with viewPlaneNormal (k, dim=6)
+    // to floor(6/2)=3, the other two axes use (d-1)/2: ijk=[4.5, 3.5, 3]
+    // world = origin + ijk*spacing = [100+2.25, 200+3.5, 300+6] = [102.25, 203.5, 306]
+    expectPoint3Close(sliceBasis.sliceCenterWorld, [102.25, 203.5, 306]);
+    // dims[2]-1 = 5 slices available along the normal
+    expect(maxImageIdIndex).toBe(5);
+    // viewPlaneNormal is -z, so index 0 <-> z=310 (max k) and index 5 <-> z=300
+    // (min k); the geometric center (k=3, z=306) falls 4/10 of the way from
+    // min(z=310) to max(z=300), i.e. floatingIndex = 0.4*5 = 2.
+    expect(currentImageIdIndex).toBe(2);
+  });
+
+  it.each([
+    [0, 310],
+    [5, 300],
+    [-3, 310], // clamps below 0 to index 0
+    [100, 300], // clamps above maxImageIdIndex (5) to index 5
+  ])(
+    'positions the axial slice center at the requested index %i (clamped to [0,5])',
+    (requestedIndex, expectedZ) => {
+      const imageVolume = createOrthonormalVolume();
+      const { sliceBasis, currentImageIdIndex } = createPlanarVolumeSliceBasis({
+        canvasWidth: 256,
+        canvasHeight: 256,
+        imageVolume,
+        orientation: OrientationAxis.AXIAL,
+        imageIdIndex: requestedIndex,
+      });
+      const expectedIndex = Math.min(Math.max(requestedIndex, 0), 5);
+
+      expect(currentImageIdIndex).toBe(expectedIndex);
+      expectPoint3Close(sliceBasis.sliceCenterWorld, [
+        102.25,
+        203.5,
+        expectedZ,
+      ]);
+    }
+  );
+
+  it('computes fit metrics for the axial orientation from the projected in-plane axes', () => {
+    const imageVolume = createOrthonormalVolume();
+    const { sliceBasis } = createPlanarVolumeSliceBasis({
+      canvasWidth: 256,
+      canvasHeight: 256,
+      imageVolume,
+      orientation: OrientationAxis.AXIAL,
+    });
+
+    // For AXIAL, the in-plane axes are x (columns=10, spacing 0.5) and
+    // y (rows=8, spacing 1): sliceWidthWorld = 10*0.5 = 5, sliceHeightWorld = 8*1 = 8
+    expect(sliceBasis.sliceWidthWorld).toBeCloseTo(5, 5);
+    expect(sliceBasis.sliceHeightWorld).toBeCloseTo(8, 5);
+    // physicalHeight=8, physicalWidth/aspect=5/1=5 -> fitParallelScale=max(8,5)*0.5=4
+    expect(sliceBasis.fitParallelScale).toBeCloseTo(4, 5);
+  });
+
+  it('derives a sagittal volume slice basis with a direct index-to-depth mapping', () => {
+    const imageVolume = createOrthonormalVolume();
+    const { sliceBasis, currentImageIdIndex, maxImageIdIndex } =
+      createPlanarVolumeSliceBasis({
+        canvasWidth: 256,
+        canvasHeight: 256,
+        imageVolume,
+        orientation: OrientationAxis.SAGITTAL,
+      });
+
+    expectPoint3Close(sliceBasis.viewPlaneNormal, [1, 0, 0]);
+    expectPoint3Close(sliceBasis.viewUp, [0, 0, 1]);
+    // sliceAxis snaps to i (dim=10): ijk=[floor(10/2)=5, (8-1)/2=3.5, (6-1)/2=2.5]
+    // world = [100+2.5, 203.5, 305] = [102.5, 203.5, 305]
+    expectPoint3Close(sliceBasis.sliceCenterWorld, [102.5, 203.5, 305]);
+    expect(maxImageIdIndex).toBe(9);
+    // viewPlaneNormal is +x here, so index maps directly to i (no inversion);
+    // i=5 out of [0,9] -> currentImageIdIndex = 5.
+    expect(currentImageIdIndex).toBe(5);
+  });
+
+  it.each([
+    [0, 100],
+    [9, 104.5],
+  ])(
+    'positions the sagittal slice center at the requested index %i',
+    (requestedIndex, expectedX) => {
+      const imageVolume = createOrthonormalVolume();
+      const { sliceBasis } = createPlanarVolumeSliceBasis({
+        canvasWidth: 256,
+        canvasHeight: 256,
+        imageVolume,
+        orientation: OrientationAxis.SAGITTAL,
+        imageIdIndex: requestedIndex,
+      });
+
+      expectPoint3Close(sliceBasis.sliceCenterWorld, [expectedX, 203.5, 305]);
+    }
+  );
+
+  it('derives a coronal volume slice basis with an inverted index-to-depth mapping', () => {
+    const imageVolume = createOrthonormalVolume();
+    const { sliceBasis, currentImageIdIndex, maxImageIdIndex } =
+      createPlanarVolumeSliceBasis({
+        canvasWidth: 256,
+        canvasHeight: 256,
+        imageVolume,
+        orientation: OrientationAxis.CORONAL,
+      });
+
+    expectPoint3Close(sliceBasis.viewPlaneNormal, [0, -1, 0]);
+    expectPoint3Close(sliceBasis.viewUp, [0, 0, 1]);
+    // sliceAxis snaps to j (dim=8): ijk=[(10-1)/2=4.5, floor(8/2)=4, (6-1)/2=2.5]
+    // world = [102.25, 204, 305]
+    expectPoint3Close(sliceBasis.sliceCenterWorld, [102.25, 204, 305]);
+    expect(maxImageIdIndex).toBe(7);
+    // viewPlaneNormal is -y, so mapping inverts like the AXIAL case:
+    // j=4 out of [0,7] centered -> currentImageIdIndex = 3.
+    expect(currentImageIdIndex).toBe(3);
+  });
+
+  it('honors an explicit volumePoint slice request over the geometric center', () => {
+    const imageVolume = createOrthonormalVolume();
+    const { sliceBasis } = createPlanarVolumeSliceBasis({
+      canvasWidth: 256,
+      canvasHeight: 256,
+      imageVolume,
+      orientation: OrientationAxis.AXIAL,
+      viewState: {
+        orientation: OrientationAxis.AXIAL,
+        slice: {
+          kind: 'volumePoint',
+          sliceWorldPoint: [104.5, 207, 310],
+        },
+      },
+    });
+
+    // Only the requested point's projection onto viewPlaneNormal ([0,0,-1])
+    // matters, so only the z coordinate is honored; x/y stay at the volume's
+    // geometric center (102.25, 203.5) computed for the AXIAL orientation.
+    expectPoint3Close(sliceBasis.sliceCenterWorld, [102.25, 203.5, 310]);
+  });
+
+  it('returns a fallback slice basis when no orientation can be resolved', () => {
+    const imageVolume = createOrthonormalVolume();
+    const { sliceBasis, currentImageIdIndex, maxImageIdIndex } =
+      createPlanarVolumeSliceBasis({
+        canvasWidth: 256,
+        canvasHeight: 256,
+        imageVolume,
+      });
+
+    expectPoint3Close(sliceBasis.sliceCenterWorld, [0, 0, 0]);
+    expectPoint3Close(sliceBasis.viewPlaneNormal, [0, 0, 1]);
+    expectPoint3Close(sliceBasis.viewUp, [0, -1, 0]);
+    expect(sliceBasis.fitParallelScale).toBe(1);
+    expect(sliceBasis.sliceWidthWorld).toBe(2);
+    expect(sliceBasis.sliceHeightWorld).toBe(2);
+    expect(sliceBasis.cameraDistance).toBe(1);
+    expect(currentImageIdIndex).toBe(0);
+    expect(maxImageIdIndex).toBe(0);
+  });
+
+  it('falls back to the origin center when the volume has no vtkImageData', () => {
+    const imageVolume = {
+      dimensions: [10, 8, 6],
+      direction: [1, 0, 0, 0, 1, 0, 0, 0, 1],
+      spacing: [0.5, 1, 2],
+    };
+    const { sliceBasis, currentImageIdIndex, maxImageIdIndex } =
+      createPlanarVolumeSliceBasis({
+        canvasWidth: 256,
+        canvasHeight: 256,
+        imageVolume,
+        orientation: OrientationAxis.AXIAL,
+      });
+
+    expectPoint3Close(sliceBasis.sliceCenterWorld, [0, 0, 0]);
+    expect(currentImageIdIndex).toBe(0);
+    expect(maxImageIdIndex).toBe(0);
+    // With no corners to project, min=max=0; cameraDistance falls back to
+    // max(0, spacingInNormalDirection, 1) = max(0, 2, 1) = 2.
+    expect(sliceBasis.cameraDistance).toBeCloseTo(2, 5);
+  });
+
+  it('clamps to a single slice for a one-slice-thick volume', () => {
+    const imageVolume = createSingleSliceVolume();
+    const { sliceBasis, currentImageIdIndex, maxImageIdIndex } =
+      createPlanarVolumeSliceBasis({
+        canvasWidth: 256,
+        canvasHeight: 256,
+        imageVolume,
+        orientation: OrientationAxis.AXIAL,
+        imageIdIndex: 7,
+      });
+
+    expect(maxImageIdIndex).toBe(0);
+    expect(currentImageIdIndex).toBe(0);
+    // ijk=[(5-1)/2=2, (5-1)/2=2, floor(1/2)=0] -> world=[2,2,0]
+    expectPoint3Close(sliceBasis.sliceCenterWorld, [2, 2, 0]);
+  });
+
+  it('derives volume geometry from indexToWorld corners when the direction matrix is not axis-aligned', () => {
+    const imageVolume = createRotatedVolume();
+    const { sliceBasis, currentImageIdIndex, maxImageIdIndex } =
+      createPlanarVolumeSliceBasis({
+        canvasWidth: 256,
+        canvasHeight: 256,
+        imageVolume,
+        orientation: OrientationAxis.AXIAL,
+      });
+
+    // scanAxis (k) is still pure +z, so it aligns with the AXIAL normal
+    // ([0,0,-1]) even though rows/columns are rotated 45 degrees in-plane.
+    expect(maxImageIdIndex).toBe(3);
+    // ijk=[(4-1)/2=1.5, 1.5, floor(4/2)=2]
+    // x = 1.5*cos45 + 1.5*(-cos45) = 0
+    // y = 1.5*cos45 + 1.5*cos45 = 1.5*sqrt(2)
+    // z = 2
+    expectPoint3Close(sliceBasis.sliceCenterWorld, [0, 1.5 * Math.SQRT2, 2]);
+    // z corners are 0 (k=0) and 3 (k=3); projected onto normal [0,0,-1] gives
+    // min=-3 (k=3), max=0 (k=0); center k=2 -> fraction=(-2-(-3))/3=1/3 -> index=1
+    expect(currentImageIdIndex).toBe(1);
+  });
+
+  it('resolves correct slice depths for a volume with a flipped (negative) direction axis', () => {
+    const imageVolume = createFlippedZVolume();
+    const { sliceBasis, currentImageIdIndex, maxImageIdIndex } =
+      createPlanarVolumeSliceBasis({
+        canvasWidth: 256,
+        canvasHeight: 256,
+        imageVolume,
+        orientation: OrientationAxis.AXIAL,
+      });
+
+    expect(maxImageIdIndex).toBe(5);
+    // getVolumeCenterIJK uses abs(dot(...)) for alignment, so the flipped k
+    // axis still snaps: ijk=[4.5, 3.5, floor(6/2)=3]
+    // world z = origin_z - k*spacing_z = 300 - 3*2 = 294
+    expectPoint3Close(sliceBasis.sliceCenterWorld, [102.25, 203.5, 294]);
+    // Both the direction (k axis) and the viewPlaneNormal are negative in z,
+    // so the two sign flips cancel out and the index-to-k mapping is direct.
+    expect(currentImageIdIndex).toBe(3);
+  });
+
+  it.each([
+    [0, 300],
+    [5, 290],
+  ])(
+    'maps flipped-volume index %i to the correct world depth',
+    (requestedIndex, expectedZ) => {
+      const imageVolume = createFlippedZVolume();
+      const { sliceBasis } = createPlanarVolumeSliceBasis({
+        canvasWidth: 256,
+        canvasHeight: 256,
+        imageVolume,
+        orientation: OrientationAxis.AXIAL,
+        imageIdIndex: requestedIndex,
+      });
+
+      expectPoint3Close(sliceBasis.sliceCenterWorld, [
+        102.25,
+        203.5,
+        expectedZ,
+      ]);
+    }
+  );
+
+  it('derives ACQUISITION orientation vectors from the volume direction, not fixed MPR axes', () => {
+    const imageVolume = createRotatedVolume();
+    const { sliceBasis } = createPlanarVolumeSliceBasis({
+      canvasWidth: 256,
+      canvasHeight: 256,
+      imageVolume,
+      orientation: OrientationAxis.ACQUISITION,
+    });
+    const c = Math.SQRT1_2;
+
+    // getAcquisitionPlaneOrientation: viewPlaneNormal = -scanAxis = [0,0,-1]
+    // (same as fixed AXIAL here because scanAxis happens to be pure z), but
+    // viewUp = -columnCosines = -[-c, c, 0] = [c, -c, 0], which differs from
+    // the fixed MPR axial viewUp of [0, -1, 0].
+    expectPoint3Close(sliceBasis.viewPlaneNormal, [0, 0, -1]);
+    expectPoint3Close(sliceBasis.viewUp, [c, -c, 0]);
+  });
+
+  it('accepts explicit orientation vectors, bypassing the MPR/ACQUISITION presets', () => {
+    const imageVolume = createOrthonormalVolume();
+    const customNormal = [0, 0.6, 0.8];
+    const customUp = [0, 0.8, -0.6];
+    const { sliceBasis } = createPlanarVolumeSliceBasis({
+      canvasWidth: 256,
+      canvasHeight: 256,
+      imageVolume,
+      orientation: { viewPlaneNormal: customNormal, viewUp: customUp },
+    });
+
+    expectPoint3Close(sliceBasis.viewPlaneNormal, customNormal);
+    expectPoint3Close(sliceBasis.viewUp, customUp);
+  });
+
+  it('falls back to the acquisition viewUp when explicit orientation vectors omit it', () => {
+    const imageVolume = createOrthonormalVolume();
+    const { sliceBasis } = createPlanarVolumeSliceBasis({
+      canvasWidth: 256,
+      canvasHeight: 256,
+      imageVolume,
+      orientation: { viewPlaneNormal: [0, 0, -1] },
+    });
+
+    // Acquisition viewUp = -columnCosines(direction) = -[0,1,0] = [0,-1,0]
+    expectPoint3Close(sliceBasis.viewUp, [0, -1, 0]);
+  });
+
+  it('falls back to the rotated bounding-box cube size when orientation axes are not aligned to any volume axis', () => {
+    const imageVolume = createOrthonormalVolume();
+    const sqrt2 = Math.SQRT2;
+    const sqrt3 = Math.sqrt(3);
+    const sqrt6 = Math.sqrt(6);
+    const viewPlaneNormal = [1 / sqrt3, 1 / sqrt3, 1 / sqrt3];
+    const viewUp = [1 / sqrt2, -1 / sqrt2, 0];
+
+    const { sliceBasis } = createPlanarVolumeSliceBasis({
+      canvasWidth: 256,
+      canvasHeight: 256,
+      imageVolume,
+      orientation: { viewPlaneNormal, viewUp },
+    });
+
+    // viewRight = normalize(cross(viewPlaneNormal, viewUp)) = (1,1,-2)/sqrt(6).
+    // None of viewRight/viewUp/viewPlaneNormal is >= 0.995-aligned with a
+    // volume axis, so getOrthogonalVolumeSliceGeometry bails out and the fit
+    // falls back to the rotated bounding-box support size (getCubeSizeInView).
+    //
+    // For a linear functional f(index) = dot(origin + spacing*index, v) over
+    // an axis-aligned index-space box, max-min per axis is
+    // |spacing_i * v_i| * indexRange_i. Index ranges from the half-voxel
+    // padded spatial extent: x=10, y=8, z=6.
+    const expectedWidth =
+      0.5 * (1 / sqrt6) * 10 + 1 * (1 / sqrt6) * 8 + 2 * (2 / sqrt6) * 6;
+    const expectedHeight = 0.5 * (1 / sqrt2) * 10 + 1 * (1 / sqrt2) * 8;
+
+    expect(sliceBasis.sliceWidthWorld).toBeCloseTo(expectedWidth, 4);
+    expect(sliceBasis.sliceHeightWorld).toBeCloseTo(expectedHeight, 4);
+    // widthWorld > heightWorld with a square canvas, so fitParallelScale = widthWorld/2
+    expect(sliceBasis.fitParallelScale).toBeCloseTo(expectedWidth / 2, 4);
+  });
+
+  it('falls back to nominal fit metrics when neither an axis-aligned geometry nor a bounding-box cube size can be computed', () => {
+    const imageVolume = {
+      dimensions: [10, 8, 6],
+      direction: [1, 0, 0, 0, 1, 0, 0, 0, 1],
+      spacing: [0.5, 1, 2],
+      // No imageData, so getCubeSizeInView's imageData-dependent branch is
+      // also unavailable -- combined with a non-axis-aligned orientation
+      // (getOrthogonalVolumeSliceGeometry returns undefined), this forces
+      // getCpuVolumeSliceFitMetrics all the way to createFallbackVolumeSliceFitMetrics.
+    };
+    const sqrt2 = Math.SQRT2;
+    const sqrt3 = Math.sqrt(3);
+
+    const { sliceBasis } = createPlanarVolumeSliceBasis({
+      canvasWidth: 256,
+      canvasHeight: 256,
+      imageVolume,
+      orientation: {
+        viewPlaneNormal: [1 / sqrt3, 1 / sqrt3, 1 / sqrt3],
+        viewUp: [1 / sqrt2, -1 / sqrt2, 0],
+      },
+    });
+
+    expect(sliceBasis.fitParallelScale).toBe(1);
+    expect(sliceBasis.sliceWidthWorld).toBe(2);
+    expect(sliceBasis.sliceHeightWorld).toBe(2);
+  });
+
+  it('produces an identical basis for the CPU and VTK volume slice paths', () => {
+    const imageVolume = createOrthonormalVolume();
+    const args = {
+      canvasWidth: 256,
+      canvasHeight: 256,
+      imageVolume,
+      orientation: OrientationAxis.CORONAL,
+    };
+
+    // createPlanarCpuVolumeSliceBasis is documented to delegate directly to
+    // createPlanarVolumeSliceBasis.
+    expect(createPlanarCpuVolumeSliceBasis(args)).toEqual(
+      createPlanarVolumeSliceBasis(args)
+    );
+  });
+});
+
+describe('resolvePlanarVolumeImageIdIndex', () => {
+  it('returns undefined for a volumePoint slice regardless of fallback', () => {
+    expect(
+      resolvePlanarVolumeImageIdIndex({
+        viewState: {
+          slice: { kind: 'volumePoint', sliceWorldPoint: [0, 0, 0] },
+        },
+        fallbackImageIdIndex: 4,
+      })
+    ).toBeUndefined();
+  });
+
+  it('returns the explicit index for a stackIndex slice', () => {
+    expect(
+      resolvePlanarVolumeImageIdIndex({
+        viewState: { slice: { kind: 'stackIndex', imageIdIndex: 9 } },
+        fallbackImageIdIndex: 4,
+      })
+    ).toBe(9);
+  });
+
+  it('does not clamp an out-of-range stackIndex slice', () => {
+    // resolvePlanarVolumeImageIdIndex has no knowledge of the volume's slice
+    // count (it never receives the volume or imageIds), so clamping happens
+    // downstream in clampImageIdIndex/buildPlanarVolumeSliceBasis, not here.
+    expect(
+      resolvePlanarVolumeImageIdIndex({
+        viewState: { slice: { kind: 'stackIndex', imageIdIndex: 999 } },
+      })
+    ).toBe(999);
+  });
+
+  it('falls back to fallbackImageIdIndex for ACQUISITION orientation without an explicit slice', () => {
+    expect(
+      resolvePlanarVolumeImageIdIndex({
+        viewState: { orientation: OrientationAxis.ACQUISITION },
+        fallbackImageIdIndex: 7,
+      })
+    ).toBe(7);
+  });
+
+  it('returns undefined for a non-acquisition orientation without an explicit slice', () => {
+    expect(
+      resolvePlanarVolumeImageIdIndex({
+        viewState: { orientation: OrientationAxis.AXIAL },
+        fallbackImageIdIndex: 7,
+      })
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when neither a slice nor a viewState is provided', () => {
+    expect(resolvePlanarVolumeImageIdIndex({})).toBeUndefined();
+  });
+});
+
+describe('shouldUsePlanarCpuVolumeSliceBasis', () => {
+  it('selects the CPU basis only for nearest-neighbor interpolation', () => {
+    expect(shouldUsePlanarCpuVolumeSliceBasis(InterpolationType.NEAREST)).toBe(
+      true
+    );
+  });
+
+  it('selects the VTK basis for linear interpolation', () => {
+    expect(shouldUsePlanarCpuVolumeSliceBasis(InterpolationType.LINEAR)).toBe(
+      false
+    );
+  });
+
+  it('defaults to the VTK basis when no interpolation type is provided', () => {
+    expect(shouldUsePlanarCpuVolumeSliceBasis()).toBe(false);
+  });
+});

--- a/packages/core/test/planarViewReference.jest.js
+++ b/packages/core/test/planarViewReference.jest.js
@@ -1,0 +1,1564 @@
+jest.mock('../src/metaData', () => ({
+  addProvider: jest.fn(),
+  get: jest.fn(),
+}));
+
+import { OrientationAxis } from '../src/enums';
+import { ActorRenderMode } from '../src/types';
+import * as metaData from '../src/metaData';
+import imageIdToURI from '../src/utilities/imageIdToURI';
+import getVolumeViewReferenceId from '../src/utilities/getVolumeViewReferenceId';
+import {
+  getPlanarReferencedImageId,
+  getPlanarViewReference,
+  getPlanarViewReferenceId,
+  isPlanarPlaneViewable,
+  isPlanarReferenceViewable,
+} from '../src/RenderingEngine/GenericViewport/Planar/planarViewReference';
+import { resolvePlanarViewportView } from '../src/RenderingEngine/GenericViewport/Planar/PlanarResolvedView';
+import PlanarViewReferenceController from '../src/RenderingEngine/GenericViewport/Planar/PlanarViewReferenceController';
+import PlanarMountedData from '../src/RenderingEngine/GenericViewport/Planar/PlanarMountedData';
+
+const IMAGE_FOR = 'image-for';
+const VOLUME_FOR = 'volume-for';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function createImage(imageId = 'image-1') {
+  return {
+    imageId,
+    minPixelValue: 0,
+    maxPixelValue: 255,
+    slope: 1,
+    intercept: 0,
+    windowCenter: 127,
+    windowWidth: 255,
+    getPixelData: () => new Uint8Array(64 * 64),
+    getCanvas: () => document.createElement('canvas'),
+    rows: 64,
+    columns: 64,
+    height: 64,
+    width: 64,
+    color: false,
+    rgba: false,
+    numberOfComponents: 1,
+    columnPixelSpacing: 1,
+    rowPixelSpacing: 1,
+    invert: false,
+    sizeInBytes: 64 * 64,
+    photometricInterpretation: 'MONOCHROME2',
+    dataType: 'Uint8Array',
+  };
+}
+
+// Volume imageIds are encoded as `volumeImage:<volumeId>:<numSlices>:<index>`
+// so the shared metaData mock can derive a consistent imagePositionPatient
+// for `getClosestImageId` without any extra bookkeeping.
+function createImageVolume({
+  volumeId = 'volume-1',
+  numSlices = 5,
+  rows = 4,
+  columns = 4,
+  frameOfReferenceUID = VOLUME_FOR,
+} = {}) {
+  const imageIds = Array.from(
+    { length: numSlices },
+    (_, k) => `volumeImage:${volumeId}:${numSlices}:${k}`
+  );
+
+  return {
+    volumeId,
+    imageIds,
+    dimensions: [columns, rows, numSlices],
+    direction: [1, 0, 0, 0, 1, 0, 0, 0, 1],
+    spacing: [1, 1, 1],
+    metadata: { FrameOfReferenceUID: frameOfReferenceUID },
+    imageData: {
+      getDimensions: () => [columns, rows, numSlices],
+      getDirection: () => [1, 0, 0, 0, 1, 0, 0, 0, 1],
+      getExtent: () => [0, columns - 1, 0, rows - 1, 0, numSlices - 1],
+      extentToBounds: (extent) => extent,
+      indexToWorld: ([i, j, k]) => [i, j, k],
+    },
+  };
+}
+
+function createCanvas(width = 256, height = 256) {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = width;
+  canvas.height = height;
+
+  return canvas;
+}
+
+function createRenderContext({ activeDataId = 'data' } = {}) {
+  return {
+    viewportId: 'viewport',
+    renderingEngineId: 'rendering-engine',
+    type: 'planar',
+    viewport: {
+      element: document.createElement('div'),
+      getActiveDataId: () => activeDataId,
+      getOverlayActors: () => [],
+      getViewState: () => ({}),
+      isCurrentDataId: (dataId) => dataId === activeDataId,
+    },
+    renderPath: { renderMode: ActorRenderMode.CPU_IMAGE },
+    view: {},
+    display: {
+      activateRenderMode: jest.fn(),
+      renderNow: jest.fn(),
+      requestRender: jest.fn(),
+    },
+    cpu: {
+      canvas: createCanvas(),
+      composition: { clearedRenderPassId: 0, renderPassId: 0 },
+      context: {},
+    },
+    vtk: {
+      canvas: createCanvas(),
+      renderer: {},
+    },
+  };
+}
+
+function configureMetaDataMock() {
+  metaData.get.mockImplementation((type, imageId) => {
+    if (type === 'imagePlaneModule') {
+      if (typeof imageId === 'string' && imageId.startsWith('volumeImage:')) {
+        const parts = imageId.split(':');
+        const index = Number(parts[parts.length - 1]);
+        const numSlices = Number(parts[parts.length - 2]);
+
+        return {
+          columnPixelSpacing: 1,
+          rowPixelSpacing: 1,
+          columnCosines: [0, 1, 0],
+          rowCosines: [1, 0, 0],
+          frameOfReferenceUID: VOLUME_FOR,
+          imageOrientationPatient: [1, 0, 0, 0, 1, 0],
+          imagePositionPatient: [0, 0, numSlices - 1 - index],
+        };
+      }
+
+      return {
+        columnPixelSpacing: 1,
+        rowPixelSpacing: 1,
+        columnCosines: [0, 1, 0],
+        rowCosines: [1, 0, 0],
+        frameOfReferenceUID: IMAGE_FOR,
+        imageOrientationPatient: [1, 0, 0, 0, 1, 0],
+        imagePositionPatient: [0, 0, 0],
+      };
+    }
+
+    if (type === 'imagePixelModule') {
+      return {
+        bitsAllocated: 16,
+        bitsStored: 16,
+        highBit: 15,
+        photometricInterpretation: 'MONOCHROME2',
+        pixelRepresentation: 0,
+        samplesPerPixel: 1,
+      };
+    }
+
+    if (type === 'generalSeriesModule') {
+      return { modality: 'CT' };
+    }
+
+    if (type === 'scalingModule' || type === 'calibratedPixelSpacing') {
+      return undefined;
+    }
+
+    return undefined;
+  });
+}
+
+// Stack (CPU_IMAGE) fixtures -------------------------------------------------
+
+const STACK_IMAGE_IDS = ['stack:img-0', 'stack:img-1', 'stack:img-2'];
+
+function createStackData() {
+  return {
+    imageIds: STACK_IMAGE_IDS,
+    volumeId: undefined,
+    renderMode: ActorRenderMode.CPU_IMAGE,
+  };
+}
+
+function createStackRendering(currentImageIdIndex = 0) {
+  return {
+    renderMode: ActorRenderMode.CPU_IMAGE,
+    currentImageIdIndex,
+    maxImageIdIndex: STACK_IMAGE_IDS.length - 1,
+    enabledElement: {
+      image: createImage(STACK_IMAGE_IDS[currentImageIdIndex]),
+    },
+  };
+}
+
+// Expected geometry for the 64x64, unit-spacing, identity-orientation stack
+// image used throughout: sliceCenterWorld = [31.5, 31.5, 0].
+const STACK_FOCAL_POINT = [31.5, 31.5, 0];
+const STACK_VIEW_PLANE_NORMAL = [0, 0, -1];
+const STACK_VIEW_UP = [0, -1, 0];
+
+// Volume (VTK_VOLUME_SLICE / AXIAL) fixtures --------------------------------
+
+function createVolumeRendering(volume, currentImageIdIndex) {
+  return {
+    renderMode: ActorRenderMode.VTK_VOLUME_SLICE,
+    currentImageIdIndex,
+    maxImageIdIndex: volume.imageIds.length - 1,
+    imageVolume: volume,
+    imageIds: volume.imageIds,
+  };
+}
+
+function createVolumeData(volume) {
+  return {
+    imageIds: volume.imageIds,
+    volumeId: volume.volumeId,
+    renderMode: ActorRenderMode.VTK_VOLUME_SLICE,
+    imageVolume: volume,
+  };
+}
+
+function axialViewState(imageIdIndex) {
+  return {
+    orientation: OrientationAxis.AXIAL,
+    slice: { kind: 'stackIndex', imageIdIndex },
+  };
+}
+
+// For the identity-direction, unit-spacing volume built by createImageVolume,
+// AXIAL orientation resolves to viewPlaneNormal [0, 0, -1] and a focal point
+// whose z coordinate is (numSlices - 1 - imageIdIndex). See the geometry
+// derivation notes in the accompanying report.
+function expectedAxialFocalZ(numSlices, imageIdIndex) {
+  return numSlices - 1 - imageIdIndex;
+}
+
+describe('planarViewReference', () => {
+  const renderContext = createRenderContext();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    configureMetaDataMock();
+  });
+
+  describe('getPlanarReferencedImageId - stack bindings', () => {
+    it('returns the currently mounted imageId when no override is given', () => {
+      const data = createStackData();
+      const rendering = createStackRendering(1);
+
+      expect(
+        getPlanarReferencedImageId({
+          viewState: {},
+          data,
+          rendering,
+          renderContext,
+        })
+      ).toBe('stack:img-1');
+    });
+
+    it('honors an explicit sliceIndex specifier over the mounted index', () => {
+      const data = createStackData();
+      const rendering = createStackRendering(0);
+
+      expect(
+        getPlanarReferencedImageId({
+          viewState: {},
+          data,
+          rendering,
+          renderContext,
+          viewRefSpecifier: { sliceIndex: 2 },
+        })
+      ).toBe('stack:img-2');
+    });
+
+    it('honors a stackIndex slice on the viewState when no specifier overrides it', () => {
+      const data = createStackData();
+      const rendering = createStackRendering(0);
+
+      expect(
+        getPlanarReferencedImageId({
+          viewState: { slice: { kind: 'stackIndex', imageIdIndex: 2 } },
+          data,
+          rendering,
+          renderContext,
+        })
+      ).toBe('stack:img-2');
+    });
+
+    it('prefers the specifier sliceIndex over a conflicting viewState slice', () => {
+      const data = createStackData();
+      const rendering = createStackRendering(0);
+
+      expect(
+        getPlanarReferencedImageId({
+          viewState: { slice: { kind: 'stackIndex', imageIdIndex: 1 } },
+          data,
+          rendering,
+          renderContext,
+          viewRefSpecifier: { sliceIndex: 2 },
+        })
+      ).toBe('stack:img-2');
+    });
+
+    it('clamps out-of-range slice indices to the available image range', () => {
+      const data = createStackData();
+      const rendering = createStackRendering(0);
+
+      expect(
+        getPlanarReferencedImageId({
+          viewState: {},
+          data,
+          rendering,
+          renderContext,
+          viewRefSpecifier: { sliceIndex: 99 },
+        })
+      ).toBe('stack:img-2');
+      expect(
+        getPlanarReferencedImageId({
+          viewState: {},
+          data,
+          rendering,
+          renderContext,
+          viewRefSpecifier: { sliceIndex: -5 },
+        })
+      ).toBe('stack:img-0');
+    });
+
+    it('returns undefined when no rendering is mounted', () => {
+      const data = createStackData();
+
+      expect(
+        getPlanarReferencedImageId({ viewState: {}, data, renderContext })
+      ).toBeUndefined();
+    });
+
+    it('returns undefined when there are no imageIds to reference', () => {
+      const data = { imageIds: [] };
+      const rendering = createStackRendering(0);
+
+      expect(
+        getPlanarReferencedImageId({
+          viewState: {},
+          data,
+          rendering,
+          renderContext,
+        })
+      ).toBeUndefined();
+    });
+  });
+
+  describe('getPlanarReferencedImageId - volume bindings', () => {
+    it('finds the closest imageId for the current slice via the resolved camera', () => {
+      const volume = createImageVolume({ volumeId: 'vol-a', numSlices: 5 });
+      const data = createVolumeData(volume);
+      const rendering = createVolumeRendering(volume, 2);
+
+      expect(
+        getPlanarReferencedImageId({
+          viewState: axialViewState(2),
+          data,
+          rendering,
+          renderContext,
+        })
+      ).toBe(volume.imageIds[2]);
+    });
+
+    it('resolves a different slice via an explicit sliceIndex specifier', () => {
+      const volume = createImageVolume({ volumeId: 'vol-a', numSlices: 5 });
+      const data = createVolumeData(volume);
+      const rendering = createVolumeRendering(volume, 2);
+
+      expect(
+        getPlanarReferencedImageId({
+          viewState: axialViewState(2),
+          data,
+          rendering,
+          renderContext,
+          viewRefSpecifier: { sliceIndex: 4 },
+        })
+      ).toBe(volume.imageIds[4]);
+    });
+  });
+
+  describe('getPlanarViewReference - stack bindings', () => {
+    it('builds a ViewReference with FrameOfReferenceUID, focal point, orientation and referencedImageId', () => {
+      const data = createStackData();
+      const rendering = createStackRendering(1);
+      const viewRef = getPlanarViewReference({
+        viewState: {},
+        dataId: 'stack-data',
+        frameOfReferenceUID: 'for-x',
+        data,
+        rendering,
+        renderContext,
+      });
+
+      expect(viewRef.FrameOfReferenceUID).toBe('for-x');
+      expect(viewRef.dataId).toBe('stack-data');
+      expect(viewRef.referencedImageId).toBe('stack:img-1');
+      expect(viewRef.referencedImageURI).toBe(imageIdToURI('stack:img-1'));
+      expect(viewRef.volumeId).toBeUndefined();
+      expect(viewRef.sliceIndex).toBe(1);
+      viewRef.cameraFocalPoint.forEach((value, index) =>
+        expect(value).toBeCloseTo(STACK_FOCAL_POINT[index], 5)
+      );
+      viewRef.viewPlaneNormal.forEach((value, index) =>
+        expect(value).toBeCloseTo(STACK_VIEW_PLANE_NORMAL[index], 5)
+      );
+      viewRef.viewUp.forEach((value, index) =>
+        expect(value).toBeCloseTo(STACK_VIEW_UP[index], 5)
+      );
+      expect(viewRef.planeRestriction).toBeDefined();
+      expect(viewRef.planeRestriction.FrameOfReferenceUID).toBe('for-x');
+      expect(viewRef.planeRestriction.point).toEqual(viewRef.cameraFocalPoint);
+      viewRef.planeRestriction.inPlaneVector1.forEach((value, index) =>
+        expect(value).toBeCloseTo(STACK_VIEW_UP[index], 5)
+      );
+    });
+
+    it('reports a different referencedImageId for a sliceIndex specifier without recomputing the mounted image geometry', () => {
+      // Stack render paths mount exactly one IImage at a time; the camera
+      // basis is derived from that mounted image's own geometry, not from
+      // an index. Overriding sliceIndex therefore changes which imageId is
+      // reported, while cameraFocalPoint still reflects the mounted image.
+      const data = createStackData();
+      const rendering = createStackRendering(1);
+      const viewRef = getPlanarViewReference({
+        viewState: {},
+        frameOfReferenceUID: 'for-x',
+        data,
+        rendering,
+        renderContext,
+        viewRefSpecifier: { sliceIndex: 2 },
+      });
+
+      expect(viewRef.referencedImageId).toBe('stack:img-2');
+      expect(viewRef.sliceIndex).toBe(2);
+      viewRef.cameraFocalPoint.forEach((value, index) =>
+        expect(value).toBeCloseTo(STACK_FOCAL_POINT[index], 5)
+      );
+    });
+
+    it('populates multiSliceReference when rangeEndSliceIndex is beyond sliceIndex', () => {
+      const data = createStackData();
+      const rendering = createStackRendering(0);
+      const viewRef = getPlanarViewReference({
+        viewState: {},
+        frameOfReferenceUID: 'for-x',
+        data,
+        rendering,
+        renderContext,
+        viewRefSpecifier: { sliceIndex: 0, rangeEndSliceIndex: 2 },
+      });
+
+      expect(viewRef.multiSliceReference).toEqual({
+        FrameOfReferenceUID: 'for-x',
+        referencedImageId: 'stack:img-2',
+        referencedImageURI: imageIdToURI('stack:img-2'),
+        sliceIndex: 2,
+      });
+    });
+
+    it('omits multiSliceReference when rangeEndSliceIndex does not exceed sliceIndex', () => {
+      const data = createStackData();
+      const rendering = createStackRendering(1);
+      const viewRef = getPlanarViewReference({
+        viewState: {},
+        frameOfReferenceUID: 'for-x',
+        data,
+        rendering,
+        renderContext,
+        viewRefSpecifier: { sliceIndex: 1, rangeEndSliceIndex: 1 },
+      });
+
+      expect(viewRef.multiSliceReference).toBeUndefined();
+    });
+  });
+
+  describe('getPlanarViewReference - volume bindings', () => {
+    it('includes volumeId and a slice-specific focal point/orientation for AXIAL orientation', () => {
+      const volume = createImageVolume({ volumeId: 'vol-a', numSlices: 5 });
+      const data = createVolumeData(volume);
+      const rendering = createVolumeRendering(volume, 2);
+      const viewRef = getPlanarViewReference({
+        viewState: axialViewState(2),
+        frameOfReferenceUID: VOLUME_FOR,
+        data,
+        rendering,
+        renderContext,
+      });
+
+      expect(viewRef.volumeId).toBe('vol-a');
+      expect(viewRef.referencedImageId).toBe(volume.imageIds[2]);
+      expect(viewRef.viewPlaneNormal).toEqual([0, 0, -1]);
+      expect(viewRef.viewUp).toEqual([0, -1, 0]);
+      expect(viewRef.cameraFocalPoint[2]).toBeCloseTo(
+        expectedAxialFocalZ(5, 2),
+        5
+      );
+      expect(viewRef.sliceIndex).toBe(2);
+    });
+
+    it('recomputes the focal point for a different orientation-relative slice via viewRefSpecifier', () => {
+      const volume = createImageVolume({ volumeId: 'vol-a', numSlices: 5 });
+      const data = createVolumeData(volume);
+      const rendering = createVolumeRendering(volume, 2);
+      const viewRef = getPlanarViewReference({
+        viewState: axialViewState(2),
+        frameOfReferenceUID: VOLUME_FOR,
+        data,
+        rendering,
+        renderContext,
+        viewRefSpecifier: { sliceIndex: 4 },
+      });
+
+      expect(viewRef.referencedImageId).toBe(volume.imageIds[4]);
+      expect(viewRef.sliceIndex).toBe(4);
+      expect(viewRef.cameraFocalPoint[2]).toBeCloseTo(
+        expectedAxialFocalZ(5, 4),
+        5
+      );
+    });
+
+    it('omits volumeId when forFrameOfReference is explicitly false', () => {
+      const volume = createImageVolume({ volumeId: 'vol-a', numSlices: 5 });
+      const data = createVolumeData(volume);
+      const rendering = createVolumeRendering(volume, 2);
+      const viewRef = getPlanarViewReference({
+        viewState: axialViewState(2),
+        frameOfReferenceUID: VOLUME_FOR,
+        data,
+        rendering,
+        renderContext,
+        viewRefSpecifier: { forFrameOfReference: false },
+      });
+
+      expect(viewRef.volumeId).toBeUndefined();
+      // referencedImageId is still populated for image-level sync.
+      expect(viewRef.referencedImageId).toBe(volume.imageIds[2]);
+    });
+  });
+
+  describe('getPlanarViewReferenceId', () => {
+    it('returns an imageId-based id for stack bindings', () => {
+      const data = createStackData();
+      const rendering = createStackRendering(1);
+
+      expect(
+        getPlanarViewReferenceId({
+          viewState: {},
+          data,
+          rendering,
+          renderContext,
+        })
+      ).toBe('imageId:stack:img-1');
+    });
+
+    it('changes with the requested stack slice index', () => {
+      const data = createStackData();
+      const rendering = createStackRendering(0);
+
+      expect(
+        getPlanarViewReferenceId({
+          viewState: {},
+          data,
+          rendering,
+          renderContext,
+          viewRefSpecifier: { sliceIndex: 2 },
+        })
+      ).toBe('imageId:stack:img-2');
+    });
+
+    it('returns null when no rendering is mounted', () => {
+      const data = createStackData();
+
+      expect(
+        getPlanarViewReferenceId({ viewState: {}, data, renderContext })
+      ).toBeNull();
+    });
+
+    it('returns a volume-scoped id that varies with slice index and orientation for volume bindings', () => {
+      const volume = createImageVolume({ volumeId: 'vol-a', numSlices: 5 });
+      const data = createVolumeData(volume);
+      const rendering = createVolumeRendering(volume, 2);
+      const axialId = getPlanarViewReferenceId({
+        viewState: axialViewState(2),
+        data,
+        rendering,
+        renderContext,
+      });
+
+      expect(axialId).toBe(
+        getVolumeViewReferenceId({
+          sliceIndex: 2,
+          viewPlaneNormal: [0, 0, -1],
+          volumeId: 'vol-a',
+        })
+      );
+
+      const otherSliceId = getPlanarViewReferenceId({
+        viewState: axialViewState(2),
+        data,
+        rendering,
+        renderContext,
+        viewRefSpecifier: { sliceIndex: 3 },
+      });
+
+      expect(otherSliceId).not.toBe(axialId);
+      expect(otherSliceId).toContain('sliceIndex=3');
+    });
+
+    it('returns null for a volume binding without a volumeId', () => {
+      const volume = createImageVolume({ volumeId: 'vol-a', numSlices: 5 });
+      const data = { ...createVolumeData(volume), volumeId: undefined };
+      const rendering = createVolumeRendering(volume, 2);
+
+      expect(
+        getPlanarViewReferenceId({
+          viewState: axialViewState(2),
+          data,
+          rendering,
+          renderContext,
+        })
+      ).toBeNull();
+    });
+  });
+
+  describe('isPlanarPlaneViewable', () => {
+    const rendering = createStackRendering(0);
+    const base = {
+      viewState: {},
+      frameOfReferenceUID: 'for-x',
+      renderContext,
+      rendering,
+    };
+
+    it('accepts a plane restriction that is coplanar with the current view', () => {
+      const coplanar = {
+        FrameOfReferenceUID: 'for-x',
+        point: [10, 10, 0],
+        inPlaneVector1: [0, -1, 0],
+        inPlaneVector2: [1, 0, 0],
+      };
+
+      expect(
+        isPlanarPlaneViewable({ ...base, planeRestriction: coplanar })
+      ).toBe(true);
+    });
+
+    it('rejects a plane restriction offset along the view plane normal', () => {
+      const offPlane = {
+        FrameOfReferenceUID: 'for-x',
+        point: [10, 10, 5],
+        inPlaneVector1: [0, -1, 0],
+        inPlaneVector2: [1, 0, 0],
+      };
+
+      expect(
+        isPlanarPlaneViewable({ ...base, planeRestriction: offPlane })
+      ).toBe(false);
+    });
+
+    it('rejects a plane restriction whose in-plane vectors are not orthogonal to the view plane normal', () => {
+      const tilted = {
+        FrameOfReferenceUID: 'for-x',
+        point: STACK_FOCAL_POINT,
+        inPlaneVector1: [0, 0, 1],
+        inPlaneVector2: [1, 0, 0],
+      };
+
+      expect(isPlanarPlaneViewable({ ...base, planeRestriction: tilted })).toBe(
+        false
+      );
+    });
+
+    it('rejects a plane restriction from a different FrameOfReferenceUID', () => {
+      const mismatched = {
+        FrameOfReferenceUID: 'for-other',
+        point: STACK_FOCAL_POINT,
+        inPlaneVector1: [0, -1, 0],
+        inPlaneVector2: [1, 0, 0],
+      };
+
+      expect(
+        isPlanarPlaneViewable({ ...base, planeRestriction: mismatched })
+      ).toBe(false);
+    });
+
+    it('accepts withOrientation regardless of the plane point when the FrameOfReferenceUID matches', () => {
+      const offPlane = {
+        FrameOfReferenceUID: 'for-x',
+        point: [10, 10, 999],
+        inPlaneVector1: [0, -1, 0],
+        inPlaneVector2: [1, 0, 0],
+      };
+
+      expect(
+        isPlanarPlaneViewable({
+          ...base,
+          planeRestriction: offPlane,
+          options: { withOrientation: true },
+        })
+      ).toBe(true);
+    });
+
+    it('accepts withNavigation for an off-plane point but still requires compatible orientation', () => {
+      const offPlaneCompatible = {
+        FrameOfReferenceUID: 'for-x',
+        point: [10, 10, 999],
+        inPlaneVector1: [0, -1, 0],
+        inPlaneVector2: [1, 0, 0],
+      };
+      const offPlaneIncompatible = {
+        FrameOfReferenceUID: 'for-x',
+        point: [10, 10, 999],
+        inPlaneVector1: [0, 0, 1],
+        inPlaneVector2: [1, 0, 0],
+      };
+
+      expect(
+        isPlanarPlaneViewable({
+          ...base,
+          planeRestriction: offPlaneCompatible,
+          options: { withNavigation: true },
+        })
+      ).toBe(true);
+      expect(
+        isPlanarPlaneViewable({
+          ...base,
+          planeRestriction: offPlaneIncompatible,
+          options: { withNavigation: true },
+        })
+      ).toBe(false);
+    });
+
+    it('returns false when there is no active rendering to resolve a camera from', () => {
+      const coplanar = {
+        FrameOfReferenceUID: 'for-x',
+        point: [10, 10, 0],
+        inPlaneVector1: [0, -1, 0],
+        inPlaneVector2: [1, 0, 0],
+      };
+
+      expect(
+        isPlanarPlaneViewable({
+          ...base,
+          rendering: undefined,
+          planeRestriction: coplanar,
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe('isPlanarReferenceViewable', () => {
+    const rendering = createStackRendering(1);
+    const base = {
+      viewState: {},
+      frameOfReferenceUID: 'for-x',
+      imageIds: STACK_IMAGE_IDS,
+      renderContext,
+      rendering,
+    };
+
+    it('returns false when no ViewReference is given', () => {
+      expect(isPlanarReferenceViewable({ ...base, viewRef: undefined })).toBe(
+        false
+      );
+    });
+
+    it('rejects a mismatched FrameOfReferenceUID', () => {
+      expect(
+        isPlanarReferenceViewable({
+          ...base,
+          viewRef: { FrameOfReferenceUID: 'for-other' },
+        })
+      ).toBe(false);
+    });
+
+    it('matches the currently displayed imageId', () => {
+      expect(
+        isPlanarReferenceViewable({
+          ...base,
+          viewRef: {
+            FrameOfReferenceUID: 'for-x',
+            referencedImageId: 'stack:img-1',
+          },
+        })
+      ).toBe(true);
+    });
+
+    it('rejects a reference to another imageId without withNavigation', () => {
+      expect(
+        isPlanarReferenceViewable({
+          ...base,
+          viewRef: {
+            FrameOfReferenceUID: 'for-x',
+            referencedImageId: 'stack:img-2',
+          },
+        })
+      ).toBe(false);
+    });
+
+    it('accepts a reference to another imageId when withNavigation is set', () => {
+      expect(
+        isPlanarReferenceViewable({
+          ...base,
+          options: { withNavigation: true },
+          viewRef: {
+            FrameOfReferenceUID: 'for-x',
+            referencedImageId: 'stack:img-2',
+          },
+        })
+      ).toBe(true);
+    });
+
+    it('rejects a reference to an imageId that is not part of this viewport', () => {
+      expect(
+        isPlanarReferenceViewable({
+          ...base,
+          options: { withNavigation: true },
+          viewRef: {
+            FrameOfReferenceUID: 'for-x',
+            referencedImageId: 'not-a-member:image',
+          },
+        })
+      ).toBe(false);
+    });
+
+    it('accepts an in-range multiSliceReference around the current slice', () => {
+      expect(
+        isPlanarReferenceViewable({
+          ...base,
+          viewRef: {
+            FrameOfReferenceUID: 'for-x',
+            referencedImageId: 'stack:img-0',
+            multiSliceReference: { referencedImageId: 'stack:img-2' },
+          },
+        })
+      ).toBe(true);
+    });
+
+    it('rejects a multiSliceReference range that does not include the current slice', () => {
+      const otherRendering = createStackRendering(0);
+
+      expect(
+        isPlanarReferenceViewable({
+          ...base,
+          rendering: otherRendering,
+          viewRef: {
+            FrameOfReferenceUID: 'for-x',
+            referencedImageId: 'stack:img-1',
+            multiSliceReference: { referencedImageId: 'stack:img-2' },
+          },
+        })
+      ).toBe(false);
+    });
+
+    it('rejects an orientation (viewPlaneNormal) mismatch by default', () => {
+      expect(
+        isPlanarReferenceViewable({
+          ...base,
+          viewRef: {
+            FrameOfReferenceUID: 'for-x',
+            viewPlaneNormal: [1, 0, 0],
+          },
+        })
+      ).toBe(false);
+    });
+
+    it('accepts an orientation mismatch when withOrientation is set', () => {
+      expect(
+        isPlanarReferenceViewable({
+          ...base,
+          options: { withOrientation: true },
+          viewRef: {
+            FrameOfReferenceUID: 'for-x',
+            viewPlaneNormal: [1, 0, 0],
+          },
+        })
+      ).toBe(true);
+    });
+
+    it('treats a negated (flipped) viewPlaneNormal as orientation-compatible', () => {
+      expect(
+        isPlanarReferenceViewable({
+          ...base,
+          viewRef: {
+            FrameOfReferenceUID: 'for-x',
+            viewPlaneNormal: [0, 0, 1],
+          },
+        })
+      ).toBe(true);
+    });
+
+    it('matches by sliceIndex when no image identity is given', () => {
+      expect(
+        isPlanarReferenceViewable({
+          ...base,
+          viewRef: { FrameOfReferenceUID: 'for-x', sliceIndex: 1 },
+        })
+      ).toBe(true);
+      expect(
+        isPlanarReferenceViewable({
+          ...base,
+          viewRef: { FrameOfReferenceUID: 'for-x', sliceIndex: 0 },
+        })
+      ).toBe(false);
+    });
+
+    it('matches an inclusive sliceIndex range', () => {
+      expect(
+        isPlanarReferenceViewable({
+          ...base,
+          viewRef: { FrameOfReferenceUID: 'for-x', sliceIndex: [0, 2] },
+        })
+      ).toBe(true);
+      expect(
+        isPlanarReferenceViewable({
+          ...base,
+          viewRef: { FrameOfReferenceUID: 'for-x', sliceIndex: [2, 2] },
+        })
+      ).toBe(false);
+    });
+
+    it('treats a reference with no sliceIndex or image identity as viewable', () => {
+      expect(
+        isPlanarReferenceViewable({
+          ...base,
+          viewRef: { FrameOfReferenceUID: 'for-x' },
+        })
+      ).toBe(true);
+    });
+
+    it('delegates to isPlanarPlaneViewable when a planeRestriction is present', () => {
+      const coplanar = {
+        FrameOfReferenceUID: 'for-x',
+        point: STACK_FOCAL_POINT,
+        inPlaneVector1: [0, -1, 0],
+        inPlaneVector2: [1, 0, 0],
+      };
+      const offPlane = { ...coplanar, point: [10, 10, 5] };
+
+      expect(
+        isPlanarReferenceViewable({
+          ...base,
+          viewRef: { FrameOfReferenceUID: 'for-x', planeRestriction: coplanar },
+        })
+      ).toBe(true);
+      expect(
+        isPlanarReferenceViewable({
+          ...base,
+          viewRef: { FrameOfReferenceUID: 'for-x', planeRestriction: offPlane },
+        })
+      ).toBe(false);
+    });
+
+    it('returns false for any reference when there is no active rendering', () => {
+      expect(
+        isPlanarReferenceViewable({
+          ...base,
+          rendering: undefined,
+          viewRef: { FrameOfReferenceUID: 'for-x' },
+        })
+      ).toBe(false);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PlanarViewReferenceController
+// ---------------------------------------------------------------------------
+
+function createMountedData(bindings) {
+  return new PlanarMountedData({
+    getBinding: (dataId) => bindings.get(dataId),
+    getFirstBinding: () => bindings.values().next().value,
+    getBindings: () => bindings.entries(),
+    removeData: (dataId) => bindings.delete(dataId),
+  });
+}
+
+function createStackBinding({
+  dataId,
+  frameOfReferenceUID = 'for-1',
+  imageIds,
+  role = 'overlay',
+  currentImageIdIndex = 0,
+}) {
+  return {
+    data: {
+      id: dataId,
+      type: 'image',
+      imageIds,
+      initialImageIdIndex: currentImageIdIndex,
+      volumeId: undefined,
+    },
+    role,
+    rendering: {
+      renderMode: ActorRenderMode.CPU_IMAGE,
+      currentImageIdIndex,
+      maxImageIdIndex: imageIds.length - 1,
+      enabledElement: { image: createImage(imageIds[currentImageIdIndex]) },
+    },
+    applyViewState: jest.fn(),
+    getActorEntry: () => ({
+      actor: {},
+      referencedId: dataId,
+      uid: `${dataId}-actor`,
+    }),
+    getFrameOfReferenceUID: () => frameOfReferenceUID,
+    removeData: jest.fn(),
+    updateDataPresentation: jest.fn(),
+  };
+}
+
+function createVolumeBinding({
+  dataId,
+  volume,
+  role = 'overlay',
+  currentImageIdIndex,
+}) {
+  const idx =
+    currentImageIdIndex ?? Math.floor((volume.imageIds.length - 1) / 2);
+
+  return {
+    data: {
+      id: dataId,
+      type: 'volume',
+      volumeId: volume.volumeId,
+      imageIds: volume.imageIds,
+      imageVolume: volume,
+    },
+    role,
+    rendering: createVolumeRendering(volume, idx),
+    applyViewState: jest.fn(),
+    getActorEntry: () => ({
+      actor: {},
+      referencedId: volume.volumeId,
+      uid: `${dataId}-actor`,
+    }),
+    getFrameOfReferenceUID: () => volume.metadata.FrameOfReferenceUID,
+    removeData: jest.fn(),
+    updateDataPresentation: jest.fn(),
+  };
+}
+
+// Builds a PlanarViewReferenceController host backed by real bindings, a real
+// PlanarMountedData instance, and the real resolvePlanarViewportView/
+// getPlanar* functions (not stubs), so the controller tests exercise the same
+// geometry pipeline as the pure-function tests above.
+function createControllerHarness(bindingEntries) {
+  const bindings = new Map(bindingEntries);
+  const mountedData = createMountedData(bindings);
+  const renderContext = createRenderContext();
+  let viewState = {};
+
+  const render = jest.fn();
+  const setImageIdIndex = jest.fn((imageIdIndex) => {
+    const binding = mountedData.getCurrentBinding();
+
+    binding.rendering.currentImageIdIndex = imageIdIndex;
+
+    return Promise.resolve(binding.data.imageIds[imageIdIndex]);
+  });
+  const setViewState = jest.fn((patch) => {
+    viewState = { ...viewState, ...patch };
+  });
+  const updateBindingsCameraState = jest.fn();
+  const promoteSourceDataId = jest.fn((dataId) =>
+    mountedData.promoteSourceDataId(dataId)
+  );
+  const getVolumeSliceWorldPointForImageIdIndex = jest.fn((imageIdIndex) => [
+    0,
+    0,
+    imageIdIndex,
+  ]);
+
+  const host = {
+    viewportId: 'viewport-1',
+    viewportType: 'planar',
+    getActiveDataId: () => mountedData.getActiveDataId(),
+    getBinding: (dataId) => bindings.get(dataId),
+    getBindings: () => bindings.entries(),
+    getCurrentBinding: () => mountedData.getCurrentBinding(),
+    getRenderContext: () => renderContext,
+    getResolvedView: (args = {}) => {
+      const binding = mountedData.getCurrentBinding();
+
+      if (!binding) {
+        return undefined;
+      }
+
+      const resolved = resolvePlanarViewportView({
+        viewState,
+        data: binding.data,
+        frameOfReferenceUID:
+          args.frameOfReferenceUID ?? binding.getFrameOfReferenceUID(),
+        rendering: binding.rendering,
+        renderContext,
+        sliceIndex: args.sliceIndex,
+      });
+
+      if (!resolved) {
+        return undefined;
+      }
+
+      return {
+        getFrameOfReferenceUID: () => binding.getFrameOfReferenceUID(),
+        toICamera: () => resolved.toICamera(),
+      };
+    },
+    getViewState: () => viewState,
+    getVolumeSliceWorldPointForImageIdIndex,
+    promoteSourceDataId,
+    render,
+    setImageIdIndex,
+    setViewState,
+    updateBindingsCameraState,
+  };
+  const controller = new PlanarViewReferenceController(host);
+
+  return {
+    bindings,
+    controller,
+    getVolumeSliceWorldPointForImageIdIndex,
+    getViewState: () => viewState,
+    host,
+    mountedData,
+    promoteSourceDataId,
+    render,
+    // Seeds the initial viewState directly, bypassing the setViewState spy
+    // so test setup doesn't pollute the call history asserted on below.
+    seedViewState: (patch) => {
+      viewState = { ...viewState, ...patch };
+    },
+    setImageIdIndex,
+    setViewState,
+    updateBindingsCameraState,
+  };
+}
+
+describe('PlanarViewReferenceController', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    configureMetaDataMock();
+  });
+
+  describe('stack + stack overlay bindings', () => {
+    function createHarness() {
+      const source = createStackBinding({
+        dataId: 'source',
+        imageIds: ['src:0', 'src:1', 'src:2'],
+        role: 'source',
+        currentImageIdIndex: 1,
+      });
+      const overlay = createStackBinding({
+        dataId: 'overlay',
+        imageIds: ['ovl:0'],
+      });
+      const harness = createControllerHarness([
+        ['source', source],
+        ['overlay', overlay],
+      ]);
+
+      harness.mountedData.promoteSourceDataId('source');
+
+      return harness;
+    }
+
+    it('activates the binding that owns a referenced imageId before navigating', () => {
+      const harness = createHarness();
+
+      harness.controller.setViewReference({
+        FrameOfReferenceUID: 'for-1',
+        referencedImageId: 'ovl:0',
+      });
+
+      expect(harness.mountedData.getActiveDataId()).toBe('overlay');
+      expect(harness.updateBindingsCameraState).toHaveBeenCalledTimes(1);
+      expect(harness.setImageIdIndex).toHaveBeenCalledWith(0);
+      // Applying the reference succeeded, so no extra forced render is needed.
+      expect(harness.render).not.toHaveBeenCalled();
+    });
+
+    it('navigates within the active binding via referencedImageId without switching bindings', () => {
+      const harness = createHarness();
+
+      harness.controller.setViewReference({
+        FrameOfReferenceUID: 'for-1',
+        referencedImageId: 'src:2',
+      });
+
+      expect(harness.mountedData.getActiveDataId()).toBe('source');
+      expect(harness.promoteSourceDataId).not.toHaveBeenCalled();
+      expect(harness.setImageIdIndex).toHaveBeenCalledWith(2);
+    });
+
+    it('navigates within the active binding via a bare sliceIndex', () => {
+      const harness = createHarness();
+
+      harness.controller.setViewReference({
+        FrameOfReferenceUID: 'for-1',
+        sliceIndex: 2,
+      });
+
+      expect(harness.setImageIdIndex).toHaveBeenCalledWith(2);
+    });
+
+    it('is a silent no-op for a FrameOfReference-only reference on the already-active binding', () => {
+      const harness = createHarness();
+
+      harness.controller.setViewReference({ FrameOfReferenceUID: 'for-1' });
+
+      expect(harness.promoteSourceDataId).not.toHaveBeenCalled();
+      expect(harness.setImageIdIndex).not.toHaveBeenCalled();
+      expect(harness.render).not.toHaveBeenCalled();
+    });
+
+    it('refuses (no-ops) a reference whose FrameOfReferenceUID matches no binding and carries no other identity', () => {
+      const harness = createHarness();
+
+      harness.controller.setViewReference({
+        FrameOfReferenceUID: 'for-unknown',
+      });
+
+      expect(harness.promoteSourceDataId).not.toHaveBeenCalled();
+      expect(harness.updateBindingsCameraState).not.toHaveBeenCalled();
+      expect(harness.setImageIdIndex).not.toHaveBeenCalled();
+      expect(harness.render).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when setViewReference is called with a falsy reference', () => {
+      const harness = createHarness();
+
+      harness.controller.setViewReference(undefined);
+
+      expect(harness.promoteSourceDataId).not.toHaveBeenCalled();
+      expect(harness.render).not.toHaveBeenCalled();
+    });
+
+    it('activates a targeted binding by dataId and forces a render even when no image reference applies', () => {
+      const harness = createHarness();
+
+      harness.controller.setViewReference({ dataId: 'overlay' });
+
+      expect(harness.mountedData.getActiveDataId()).toBe('overlay');
+      // Activation succeeded but nothing could be applied (no imageId or
+      // sliceIndex on the reference), so the controller forces a render to
+      // reflect the promoted binding.
+      expect(harness.setImageIdIndex).not.toHaveBeenCalled();
+      expect(harness.render).toHaveBeenCalledTimes(1);
+    });
+
+    it('delegates getViewReference/getViewReferenceId/getCurrentImageId to the active binding', () => {
+      const harness = createHarness();
+
+      expect(harness.controller.getCurrentImageId()).toBe('src:1');
+      expect(harness.controller.getViewReference().referencedImageId).toBe(
+        'src:1'
+      );
+      expect(harness.controller.getViewReferenceId()).toBe('imageId:src:1');
+    });
+
+    it('reports the resolved FrameOfReferenceUID from the active binding, falling back to a synthetic id without one', () => {
+      const harness = createHarness();
+
+      expect(harness.controller.getFrameOfReferenceUID()).toBe('for-1');
+
+      const emptyHarness = createControllerHarness([]);
+
+      expect(emptyHarness.controller.getFrameOfReferenceUID()).toBe(
+        'planar-viewport-viewport-1'
+      );
+    });
+
+    it('reports isPlaneViewable consistently with the standalone isPlanarPlaneViewable check', () => {
+      const harness = createHarness();
+      const coplanar = {
+        FrameOfReferenceUID: 'for-1',
+        point: STACK_FOCAL_POINT,
+        inPlaneVector1: [0, -1, 0],
+        inPlaneVector2: [1, 0, 0],
+      };
+      const offPlane = { ...coplanar, point: [10, 10, 5] };
+
+      expect(harness.controller.isPlaneViewable(coplanar)).toBe(true);
+      expect(harness.controller.isPlaneViewable(offPlane)).toBe(false);
+    });
+
+    it('builds per-binding reference view contexts for both source and overlay bindings', () => {
+      const harness = createHarness();
+      const contexts = harness.controller.getReferenceViewContexts([]);
+
+      expect(contexts).toHaveLength(2);
+
+      const overlayContext = contexts.find((ctx) => ctx.dataId === 'overlay');
+      const sourceContext = contexts.find((ctx) => ctx.dataId === 'source');
+
+      expect(overlayContext.imageIds).toEqual(['ovl:0']);
+      expect(overlayContext.currentImageIdIndex).toBe(0);
+      expect(sourceContext.imageIds).toEqual(['src:0', 'src:1', 'src:2']);
+      expect(sourceContext.currentImageIdIndex).toBe(1);
+    });
+
+    it('falls back to the supplied contexts when there are no bindings', () => {
+      const harness = createControllerHarness([]);
+      const fallback = [{ dataId: 'fallback', imageIds: [] }];
+
+      expect(harness.controller.getReferenceViewContexts(fallback)).toBe(
+        fallback
+      );
+    });
+  });
+
+  describe('stack source + volume overlay bindings', () => {
+    function createHarness() {
+      const volume = createImageVolume({
+        volumeId: 'vol-shared',
+        numSlices: 5,
+      });
+      const source = createStackBinding({
+        dataId: 'source',
+        imageIds: ['src:0', 'src:1', 'src:2'],
+        role: 'source',
+        currentImageIdIndex: 0,
+      });
+      const overlay = createVolumeBinding({
+        dataId: 'overlay',
+        volume,
+        currentImageIdIndex: 2,
+      });
+      const harness = createControllerHarness([
+        ['source', source],
+        ['overlay', overlay],
+      ]);
+
+      harness.mountedData.promoteSourceDataId('source');
+      // The overlay binding needs a viewState carrying an explicit
+      // orientation + slice for its AXIAL camera to resolve deterministically
+      // once activated.
+      harness.seedViewState(axialViewState(2));
+
+      return { harness, volume };
+    }
+
+    it('resolves getViewReference by volumeId to a non-active binding', () => {
+      const { harness, volume } = createHarness();
+      const viewRef = harness.controller.getViewReference({
+        volumeId: volume.volumeId,
+      });
+
+      expect(viewRef.volumeId).toBe(volume.volumeId);
+      expect(viewRef.referencedImageId).toBe(volume.imageIds[2]);
+    });
+
+    it('getVolumeId falls back to the active binding volumeId when unspecified, and is undefined for a stack source', () => {
+      const { harness } = createHarness();
+
+      expect(harness.controller.getVolumeId()).toBeUndefined();
+    });
+
+    it('activates the volume overlay by volumeId even though it also matches no imageId reference', () => {
+      const { harness, volume } = createHarness();
+
+      harness.controller.setViewReference({
+        FrameOfReferenceUID: volume.metadata.FrameOfReferenceUID,
+        volumeId: volume.volumeId,
+        viewPlaneNormal: [0, 0, -1],
+        sliceIndex: 3,
+      });
+
+      expect(harness.mountedData.getActiveDataId()).toBe('overlay');
+      expect(harness.setViewState).toHaveBeenCalled();
+      expect(harness.getViewState().slice).toEqual({
+        kind: 'volumePoint',
+        sliceWorldPoint: [0, 0, 3],
+      });
+    });
+
+    it('falls back to imageId membership to pick the right binding when volumeId does not match any binding', () => {
+      const { harness } = createHarness();
+
+      harness.controller.setViewReference({
+        FrameOfReferenceUID: 'for-1',
+        volumeId: 'no-such-volume',
+        referencedImageId: 'src:2',
+      });
+
+      expect(harness.mountedData.getActiveDataId()).toBe('source');
+      expect(harness.setImageIdIndex).toHaveBeenCalledWith(2);
+    });
+  });
+
+  describe('volume binding navigation', () => {
+    function createHarness({ numSlices = 5 } = {}) {
+      const volume = createImageVolume({ volumeId: 'vol-a', numSlices });
+      const binding = createVolumeBinding({
+        dataId: 'volume-data',
+        volume,
+        role: 'source',
+        currentImageIdIndex: 2,
+      });
+      const harness = createControllerHarness([['volume-data', binding]]);
+
+      harness.mountedData.promoteSourceDataId('volume-data');
+      harness.seedViewState(axialViewState(2));
+
+      return { harness, volume };
+    }
+
+    it('navigates to a sliceIndex on the same orientation without reorienting', () => {
+      const { harness, volume } = createHarness();
+
+      harness.controller.setViewReference({
+        FrameOfReferenceUID: volume.metadata.FrameOfReferenceUID,
+        volumeId: volume.volumeId,
+        viewPlaneNormal: [0, 0, -1],
+        sliceIndex: 4,
+      });
+
+      const patch = harness.setViewState.mock.calls[0][0];
+
+      expect(patch.orientation).toBeUndefined();
+      expect(patch.slice).toEqual({
+        kind: 'volumePoint',
+        sliceWorldPoint: [0, 0, 4],
+      });
+    });
+
+    it('resolves a world focal point to the geometrically closest slice', () => {
+      const { harness, volume } = createHarness();
+
+      harness.controller.setViewReference({
+        FrameOfReferenceUID: volume.metadata.FrameOfReferenceUID,
+        volumeId: volume.volumeId,
+        viewPlaneNormal: [0, 0, -1],
+        cameraFocalPoint: [0, 0, 2],
+      });
+
+      expect(harness.getViewState().slice).toEqual({
+        kind: 'volumePoint',
+        sliceWorldPoint: [0, 0, 2],
+      });
+      // The volume-point slice state should resolve, geometrically, back to
+      // imageId index 2 (z = numSlices - 1 - index = 5 - 1 - 2 = 2).
+      expect(harness.controller.getCurrentImageId()).toBe(volume.imageIds[2]);
+    });
+
+    it('reorients to a new viewPlaneNormal/viewUp supplied directly on the reference', () => {
+      const { harness, volume } = createHarness();
+
+      harness.controller.setViewReference({
+        FrameOfReferenceUID: volume.metadata.FrameOfReferenceUID,
+        volumeId: volume.volumeId,
+        viewPlaneNormal: [1, 0, 0],
+        viewUp: [0, 0, 1],
+        sliceIndex: 1,
+      });
+
+      const patch = harness.setViewState.mock.calls[0][0];
+
+      expect(patch.orientation).toEqual({
+        viewPlaneNormal: [1, 0, 0],
+        viewUp: [0, 0, 1],
+      });
+      expect(patch.slice).toEqual({
+        kind: 'volumePoint',
+        sliceWorldPoint: [0, 0, 1],
+      });
+    });
+
+    it('flips the target sliceIndex when the requested normal is the exact opposite of the current one', () => {
+      const { harness, volume } = createHarness({ numSlices: 5 });
+
+      harness.controller.setViewReference({
+        FrameOfReferenceUID: volume.metadata.FrameOfReferenceUID,
+        volumeId: volume.volumeId,
+        viewPlaneNormal: [0, 0, 1],
+        sliceIndex: 1,
+      });
+
+      const patch = harness.setViewState.mock.calls[0][0];
+
+      // Opposite normal: no reorientation is recorded (the view direction is
+      // considered equivalent), but the slice index is flipped around
+      // maxImageIdIndex (4 - 1 = 3) to keep the same physical slice visible.
+      expect(patch.orientation).toBeUndefined();
+      expect(patch.slice).toEqual({
+        kind: 'volumePoint',
+        sliceWorldPoint: [0, 0, 3],
+      });
+    });
+
+    it('derives a compatible orientation from a planeRestriction without reorienting when the plane matches the current normal', () => {
+      const { harness, volume } = createHarness();
+
+      harness.controller.setViewReference({
+        FrameOfReferenceUID: volume.metadata.FrameOfReferenceUID,
+        volumeId: volume.volumeId,
+        planeRestriction: {
+          FrameOfReferenceUID: volume.metadata.FrameOfReferenceUID,
+          point: [0, 0, 1],
+          inPlaneVector1: [0, -1, 0],
+          inPlaneVector2: [1, 0, 0],
+        },
+      });
+
+      const patch = harness.setViewState.mock.calls[0][0];
+
+      expect(patch.orientation).toBeUndefined();
+      expect(patch.slice).toEqual({
+        kind: 'volumePoint',
+        sliceWorldPoint: [0, 0, 1],
+      });
+    });
+
+    it('derives a new orientation from an incompatible planeRestriction via the cross product of its in-plane vectors', () => {
+      const { harness, volume } = createHarness();
+
+      harness.controller.setViewReference({
+        FrameOfReferenceUID: volume.metadata.FrameOfReferenceUID,
+        volumeId: volume.volumeId,
+        planeRestriction: {
+          FrameOfReferenceUID: volume.metadata.FrameOfReferenceUID,
+          point: [0, 0, 0],
+          inPlaneVector1: [0, 1, 0],
+          inPlaneVector2: [0, 0, 1],
+        },
+      });
+
+      const patch = harness.setViewState.mock.calls[0][0];
+
+      expect(patch.orientation.viewPlaneNormal[0]).toBeCloseTo(-1, 5);
+      expect(patch.orientation.viewPlaneNormal[1]).toBeCloseTo(0, 5);
+      expect(patch.orientation.viewPlaneNormal[2]).toBeCloseTo(0, 5);
+      expect(patch.orientation.viewUp).toEqual([0, 1, 0]);
+      expect(patch.slice).toEqual({
+        kind: 'volumePoint',
+        sliceWorldPoint: [0, 0, 0],
+      });
+    });
+
+    it('is a no-op when the reference cannot be resolved to any slice or point', () => {
+      const { harness, volume } = createHarness();
+
+      harness.controller.setViewReference({
+        FrameOfReferenceUID: volume.metadata.FrameOfReferenceUID,
+        volumeId: volume.volumeId,
+      });
+
+      expect(harness.setViewState).not.toHaveBeenCalled();
+      expect(harness.render).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/core/test/wsiTransformUtils.jest.js
+++ b/packages/core/test/wsiTransformUtils.jest.js
@@ -1,0 +1,420 @@
+import { mat4 } from 'gl-matrix';
+import {
+  computeWSITransforms,
+  worldToIndexWSIMetadata,
+  indexToWorldWSIMetadata,
+  buildWSIImageData,
+  buildWSIColorTransform,
+  canvasToIndexForWSI,
+  indexToCanvasForWSI,
+} from '../src/RenderingEngine/GenericViewport/WSI/wsiTransformUtils';
+
+// Identity-oriented WSI: row cosines [1,0,0], column cosines [0,1,0],
+// scan-axis normal (cross product) [0,0,1]. Origin offset from slide corner
+// and non-uniform pixel spacing to make round-trips non-trivial.
+function makeIdentityMetadata(overrides = {}) {
+  return {
+    bitsAllocated: 8,
+    numberOfComponents: 3,
+    origin: [10, 20, 0],
+    direction: [1, 0, 0, 0, 1, 0, 0, 0, 1],
+    dimensions: [2000, 1000, 1],
+    spacing: [0.25, 0.5, 1],
+    hasPixelSpacing: true,
+    numVoxels: 2000 * 1000,
+    imagePlaneModule: {},
+    ...overrides,
+  };
+}
+
+// A WSI rotated 90 degrees about the scan axis: row cosines [0,1,0], column
+// cosines [-1,0,0], scan-axis normal = row x col = [0,0,1].
+function makeRotatedMetadata(overrides = {}) {
+  return {
+    bitsAllocated: 8,
+    numberOfComponents: 3,
+    origin: [5, 5, 0],
+    direction: [0, 1, 0, -1, 0, 0, 0, 0, 1],
+    dimensions: [800, 400, 1],
+    spacing: [0.5, 0.5, 1],
+    hasPixelSpacing: true,
+    numVoxels: 800 * 400,
+    imagePlaneModule: {},
+    ...overrides,
+  };
+}
+
+describe('wsiTransformUtils', () => {
+  describe('computeWSITransforms', () => {
+    it('returns undefined when metadata is undefined', () => {
+      expect(computeWSITransforms(undefined)).toBeUndefined();
+    });
+
+    it('builds indexToWorld/worldToIndex matrices that compose to identity', () => {
+      const metadata = makeIdentityMetadata();
+      const transforms = computeWSITransforms(metadata);
+
+      expect(transforms).toBeDefined();
+
+      const composed = mat4.create();
+      mat4.multiply(
+        composed,
+        transforms.worldToIndexMatrix,
+        transforms.indexToWorld
+      );
+
+      // indexToWorld followed by worldToIndex should be the identity matrix.
+      for (let i = 0; i < 16; i++) {
+        const expected = i % 5 === 0 ? 1 : 0; // identity has 1s on the diagonal (0,5,10,15)
+        expect(composed[i]).toBeCloseTo(expected, 6);
+      }
+    });
+
+    it('encodes origin as translation and spacing as scale for the identity-oriented metadata', () => {
+      const metadata = makeIdentityMetadata();
+      const transforms = computeWSITransforms(metadata);
+      const m = transforms.indexToWorld;
+
+      // Column-major mat4: translation lives in m[12..14].
+      expect(m[12]).toBeCloseTo(metadata.origin[0], 6);
+      expect(m[13]).toBeCloseTo(metadata.origin[1], 6);
+      expect(m[14]).toBeCloseTo(metadata.origin[2], 6);
+      // Diagonal scale terms equal the spacing for an identity direction.
+      expect(m[0]).toBeCloseTo(metadata.spacing[0], 6);
+      expect(m[5]).toBeCloseTo(metadata.spacing[1], 6);
+      expect(m[10]).toBeCloseTo(metadata.spacing[2], 6);
+    });
+  });
+
+  describe('worldToIndexWSIMetadata / indexToWorldWSIMetadata', () => {
+    it('returns [0,0,0] when metadata is undefined', () => {
+      expect(worldToIndexWSIMetadata(undefined, [1, 2, 3])).toEqual([0, 0, 0]);
+      expect(indexToWorldWSIMetadata(undefined, [1, 2, 3])).toEqual([0, 0, 0]);
+    });
+
+    it('maps index (0,0,0) to the metadata origin for identity orientation', () => {
+      const metadata = makeIdentityMetadata();
+
+      expect(indexToWorldWSIMetadata(metadata, [0, 0, 0])).toEqual(
+        metadata.origin
+      );
+    });
+
+    it('applies spacing per index unit for identity orientation', () => {
+      const metadata = makeIdentityMetadata();
+      // index [4, 10, 0] -> world = origin + [4*0.25, 10*0.5, 0*1]
+      const world = indexToWorldWSIMetadata(metadata, [4, 10, 0]);
+
+      expect(world[0]).toBeCloseTo(10 + 4 * 0.25, 6);
+      expect(world[1]).toBeCloseTo(20 + 10 * 0.5, 6);
+      expect(world[2]).toBeCloseTo(0, 6);
+    });
+
+    it('round-trips world -> index -> world for identity orientation', () => {
+      const metadata = makeIdentityMetadata();
+      const worldPoint = [123.5, 456.75, 0];
+      const indexPoint = worldToIndexWSIMetadata(metadata, worldPoint);
+      const roundTripped = indexToWorldWSIMetadata(metadata, indexPoint);
+
+      expect(roundTripped[0]).toBeCloseTo(worldPoint[0], 6);
+      expect(roundTripped[1]).toBeCloseTo(worldPoint[1], 6);
+      expect(roundTripped[2]).toBeCloseTo(worldPoint[2], 6);
+    });
+
+    it('round-trips index -> world -> index for a rotated WSI orientation', () => {
+      const metadata = makeRotatedMetadata();
+      const indexPoint = [40, 100, 0];
+      const worldPoint = indexToWorldWSIMetadata(metadata, indexPoint);
+      const roundTripped = worldToIndexWSIMetadata(metadata, worldPoint);
+
+      expect(roundTripped[0]).toBeCloseTo(indexPoint[0], 6);
+      expect(roundTripped[1]).toBeCloseTo(indexPoint[1], 6);
+      expect(roundTripped[2]).toBeCloseTo(indexPoint[2], 6);
+    });
+
+    it('applies the rotated direction so index x moves along world y', () => {
+      const metadata = makeRotatedMetadata();
+      // direction row-cosine = [0,1,0]: moving one unit along index-x should
+      // move spacing[0] units along world-y (not world-x), starting at origin.
+      const world = indexToWorldWSIMetadata(metadata, [1, 0, 0]);
+
+      expect(world[0]).toBeCloseTo(metadata.origin[0], 6);
+      expect(world[1]).toBeCloseTo(metadata.origin[1] + metadata.spacing[0], 6);
+      expect(world[2]).toBeCloseTo(metadata.origin[2], 6);
+    });
+  });
+
+  describe('buildWSIImageData', () => {
+    it('returns null when metadata is undefined', () => {
+      expect(buildWSIImageData({ metadata: undefined })).toBeNull();
+    });
+
+    it('maps metadata fields onto the CPU image data shape, defaulting modality to SM', () => {
+      const metadata = makeIdentityMetadata();
+      const imageData = buildWSIImageData({ metadata });
+
+      expect(imageData.dimensions).toBe(metadata.dimensions);
+      expect(imageData.spacing).toBe(metadata.spacing);
+      expect(imageData.numberOfComponents).toBe(3);
+      expect(imageData.origin).toBe(metadata.origin);
+      expect(imageData.direction).toBe(metadata.direction);
+      expect(imageData.metadata).toEqual({
+        Modality: 'SM',
+        FrameOfReferenceUID: '',
+      });
+      expect(imageData.hasPixelSpacing).toBe(true);
+      expect(imageData.preScale).toEqual({ scaled: false });
+      expect(imageData.scalarData).toBeNull();
+    });
+
+    it('honors an explicit modality and frameOfReferenceUID', () => {
+      const metadata = makeIdentityMetadata();
+      const imageData = buildWSIImageData({
+        metadata,
+        modality: 'XC',
+        frameOfReferenceUID: 'frame-123',
+      });
+
+      expect(imageData.metadata).toEqual({
+        Modality: 'XC',
+        FrameOfReferenceUID: 'frame-123',
+      });
+    });
+
+    it('falls back to an empty FrameOfReferenceUID when it is null', () => {
+      const metadata = makeIdentityMetadata();
+      const imageData = buildWSIImageData({
+        metadata,
+        frameOfReferenceUID: null,
+      });
+
+      expect(imageData.metadata.FrameOfReferenceUID).toBe('');
+    });
+
+    it('wires the embedded imageData helper functions to the transform utilities', () => {
+      const metadata = makeIdentityMetadata();
+      const imageData = buildWSIImageData({ metadata });
+
+      expect(imageData.imageData.getDimensions()).toBe(metadata.dimensions);
+      expect(imageData.imageData.getSpacing()).toBe(metadata.spacing);
+      expect(imageData.imageData.getRange()).toEqual([0, 255]);
+      expect(imageData.imageData.getDirection()).toBe(metadata.direction);
+      expect(imageData.imageData.getScalarData()).toBeNull();
+
+      const worldPoint = [15, 25, 0];
+      const indexPoint = imageData.imageData.worldToIndex(worldPoint);
+      const roundTripped = imageData.imageData.indexToWorld(indexPoint);
+
+      expect(roundTripped[0]).toBeCloseTo(worldPoint[0], 6);
+      expect(roundTripped[1]).toBeCloseTo(worldPoint[1], 6);
+    });
+  });
+
+  describe('buildWSIColorTransform', () => {
+    it('returns undefined when neither voiRange nor averageWhite is provided', () => {
+      expect(buildWSIColorTransform(undefined, undefined)).toBeUndefined();
+    });
+
+    it('produces an SVG data-URL color matrix filter when voiRange is provided', () => {
+      const result = buildWSIColorTransform({ lower: 0, upper: 255 });
+
+      expect(result).toEqual(
+        expect.stringContaining("url('data:image/svg+xml,")
+      );
+      expect(result).toEqual(expect.stringContaining('feColorMatrix'));
+    });
+
+    it('defaults lower/upper to 0/255 (identity window) when voiRange fields are missing', () => {
+      // wlScale = (255-0+1)/255 = 1.0039..., wlDelta = 0
+      const withEmptyRange = buildWSIColorTransform({});
+      const wlScale = (255 - 0 + 1) / 255;
+
+      expect(withEmptyRange).toEqual(
+        expect.stringContaining(`${1 * wlScale} 0 0 0 0`)
+      );
+    });
+
+    it('scales each color channel by maxWhite/channel when averageWhite is provided', () => {
+      // white = [255, 200, 100], maxWhite = 255
+      // scaleWhite = [1, 255/200, 2.55]
+      // voiRange defaults to lower=0, upper=255 -> wlScale = 256/255, wlDelta = 0
+      const result = buildWSIColorTransform(undefined, [255, 200, 100]);
+      const wlScale = (255 - 0 + 1) / 255;
+      const scaleWhiteG = (255 / 200) * wlScale;
+      const scaleWhiteB = (255 / 100) * wlScale;
+
+      expect(result).toEqual(expect.stringContaining(`${1 * wlScale} 0 0 0 0`));
+      expect(result).toEqual(expect.stringContaining(`0 ${scaleWhiteG} 0 0 0`));
+      expect(result).toEqual(expect.stringContaining(`0 0 ${scaleWhiteB} 0 0`));
+    });
+
+    it('applies a non-zero window lower bound as a wlDelta offset', () => {
+      // lower=51, upper=255 -> wlDelta = 51/255 = 0.2
+      const result = buildWSIColorTransform({ lower: 51, upper: 255 });
+
+      expect(result).toEqual(expect.stringContaining(' 0.2 '));
+    });
+  });
+
+  describe('canvasToIndexForWSI / indexToCanvasForWSI', () => {
+    function makeView({
+      resolution = 1,
+      rotation = 0,
+      center = [100, 50],
+    } = {}) {
+      return {
+        getResolution: () => resolution,
+        getRotation: () => rotation,
+        getCenter: () => center,
+      };
+    }
+
+    const originalDPR = window.devicePixelRatio;
+
+    afterEach(() => {
+      Object.defineProperty(window, 'devicePixelRatio', {
+        configurable: true,
+        value: originalDPR,
+      });
+    });
+
+    it('maps the canvas center to the view center with no rotation (devicePixelRatio 1)', () => {
+      Object.defineProperty(window, 'devicePixelRatio', {
+        configurable: true,
+        value: 1,
+      });
+      const view = makeView({ resolution: 1, center: [100, 50] });
+
+      const indexPos = canvasToIndexForWSI({
+        canvasPos: [100, 100], // half of a 200x200 canvas
+        canvasWidth: 200,
+        canvasHeight: 200,
+        view,
+      });
+
+      expect(indexPos[0]).toBeCloseTo(100, 6);
+      expect(indexPos[1]).toBeCloseTo(50, 6);
+      expect(indexPos[2]).toBe(0);
+    });
+
+    it('round-trips canvas -> index -> canvas for an off-center point with resolution and rotation', () => {
+      Object.defineProperty(window, 'devicePixelRatio', {
+        configurable: true,
+        value: 1,
+      });
+      const view = makeView({ resolution: 2, rotation: 0.4, center: [30, 70] });
+      const canvasWidth = 300;
+      const canvasHeight = 150;
+      const originalCanvasPos = [220, 40];
+
+      const indexPos = canvasToIndexForWSI({
+        canvasPos: originalCanvasPos,
+        canvasWidth,
+        canvasHeight,
+        view,
+      });
+      const roundTrippedCanvasPos = indexToCanvasForWSI({
+        indexPos,
+        canvasWidth,
+        canvasHeight,
+        view,
+      });
+
+      expect(roundTrippedCanvasPos[0]).toBeCloseTo(originalCanvasPos[0], 6);
+      expect(roundTrippedCanvasPos[1]).toBeCloseTo(originalCanvasPos[1], 6);
+    });
+
+    it('maps index (view center) back to the canvas center regardless of rotation', () => {
+      const view = makeView({
+        resolution: 1.5,
+        rotation: 1.1,
+        center: [10, -5],
+      });
+      const canvasWidth = 400;
+      const canvasHeight = 200;
+
+      const canvasPos = indexToCanvasForWSI({
+        indexPos: [10, -5, 0],
+        canvasWidth,
+        canvasHeight,
+        view,
+      });
+
+      expect(canvasPos[0]).toBeCloseTo(canvasWidth / 2, 6);
+      expect(canvasPos[1]).toBeCloseTo(canvasHeight / 2, 6);
+    });
+
+    it('scales index displacement inversely with resolution: doubling resolution halves canvas displacement', () => {
+      const lowRes = makeView({ resolution: 1, center: [0, 0] });
+      const highRes = makeView({ resolution: 2, center: [0, 0] });
+      const canvasWidth = 200;
+      const canvasHeight = 200;
+
+      const lowResCanvasPos = indexToCanvasForWSI({
+        indexPos: [50, 0, 0],
+        canvasWidth,
+        canvasHeight,
+        view: lowRes,
+      });
+      const highResCanvasPos = indexToCanvasForWSI({
+        indexPos: [50, 0, 0],
+        canvasWidth,
+        canvasHeight,
+        view: highRes,
+      });
+
+      const lowResDisplacement = lowResCanvasPos[0] - canvasWidth / 2;
+      const highResDisplacement = highResCanvasPos[0] - canvasWidth / 2;
+
+      expect(highResDisplacement).toBeCloseTo(lowResDisplacement / 2, 6);
+    });
+
+    it('flips the y axis: increasing index-y decreases canvas-y', () => {
+      const view = makeView({ resolution: 1, center: [0, 0] });
+      const canvasWidth = 200;
+      const canvasHeight = 200;
+
+      const canvasPos = indexToCanvasForWSI({
+        indexPos: [0, 10, 0],
+        canvasWidth,
+        canvasHeight,
+        view,
+      });
+
+      expect(canvasPos[1]).toBeLessThan(canvasHeight / 2);
+    });
+
+    it('divides the whole transformed point by an explicit devicePixelRatio argument rather than window.devicePixelRatio', () => {
+      Object.defineProperty(window, 'devicePixelRatio', {
+        configurable: true,
+        value: 3, // should be ignored because an explicit value is passed
+      });
+      const view = makeView({ resolution: 1, center: [0, 0] });
+      const canvasWidth = 200;
+      const canvasHeight = 200;
+
+      const canvasPosDpr1 = indexToCanvasForWSI({
+        indexPos: [20, 0, 0],
+        canvasWidth,
+        canvasHeight,
+        view,
+        devicePixelRatio: 1,
+      });
+      const canvasPosDpr2 = indexToCanvasForWSI({
+        indexPos: [20, 0, 0],
+        canvasWidth,
+        canvasHeight,
+        view,
+        devicePixelRatio: 2,
+      });
+
+      // getWSICanvasTransform builds its translation from the raw canvasWidth/
+      // canvasHeight (independent of devicePixelRatio); indexToCanvasForWSI then
+      // divides the entire resulting point -- center offset included -- by
+      // devicePixelRatio. So the whole point scales by 1/dpr, not just the
+      // displacement from the canvas center.
+      expect(canvasPosDpr2[0]).toBeCloseTo(canvasPosDpr1[0] / 2, 6);
+      expect(canvasPosDpr2[1]).toBeCloseTo(canvasPosDpr1[1] / 2, 6);
+    });
+  });
+});


### PR DESCRIPTION
## Context

The GenericViewport architecture in `packages/core` had large critical areas with little or no unit test coverage. This PR is a first round targeting the 5 most important undertested aspects, chosen from a per-file jest coverage audit (legacy Stack/Volume viewports and WebGL/VTK render paths intentionally excluded).

## What is added

279 new jest tests across six files in `packages/core/test/`:

| File | Targets | Tests |
|---|---|---|
| `genericViewportBase.jest.js` | `GenericViewport` base class + `genericViewportDisplaySetAccess` | 55 |
| `planarSliceBasis.jest.js` | `planarSliceBasis` slice geometry | 37 |
| `planarViewReference.jest.js` | `planarViewReference` + `PlanarViewReferenceController` | 67 |
| `planarRenderCamera.jest.js` | `planarRenderCamera`, `setVtkCameraClippingRange`, `PlanarVolumeResolvedView` | 52 |
| `modalityViewportCameras.jest.js` | Video/ECG/Volume3D camera math | 43 |
| `wsiTransformUtils.jest.js` | WSI world/index/canvas transforms | 25 |

Highlights:
- Base-class binding lifecycle including the subtle mid-await races: stale mount requests discarded, destroy during `addData`, remount supersede, source-role demotion of other bindings.
- Slice basis geometry verified against hand-derived expected values for axial/sagittal/coronal, oblique 45 degree orientations, anisotropic spacing, and flipped/negative direction matrices.
- View reference navigation depth: world focal point to slice resolution, opposite-normal slice index flip, plane-restriction-derived reorientation.
- Camera resolve/derive round-trips: zoom, pan, rotation (including wrap and flip composition), display area SCALE/FIT modes, anchor-world invariants; volume resolved view now mirrors the existing stack parity suite.
- All exports of the pure Video/ECG/Volume3D camera helpers and WSI transforms covered.

## Coverage over `src/RenderingEngine/GenericViewport`

Overall: 33.7% -> 44.0% lines, 26.3% -> 38.1% branches.

| Module | Lines | Branches |
|---|---|---|
| `GenericViewport.ts` | 19.9 -> 88.7 | 5.0 -> 82.0 |
| `planarViewReference.ts` | 0 -> 97.1 | 0 -> 91.5 |
| `PlanarViewReferenceController.ts` | 30.7 -> 89.9 | 22.0 -> 80.9 |
| `planarRenderCamera.ts` | 37.9 -> 100 | 21.7 -> 86.7 |
| `planarSliceBasis.ts` | 67.2 -> 96.7 | 45.8 -> 89.8 |
| `videoViewportCamera.ts` | 59.5 -> 100 | 61.3 -> 100 |
| `wsiTransformUtils.ts` | 0 -> 100 | 0 -> 92.6 |
| `genericViewportDisplaySetAccess.ts` | 0 -> 100 | 0 -> 100 |

## Findings surfaced while testing (no source changes in this PR)

- `wsiTransformUtils.ts`: `canvasToIndexForWSI` multiplies the input canvas point by `devicePixelRatio` but `indexToCanvasForWSI` divides the entire transformed point (center translation included) by it — asymmetric DPR handling worth a look.
- `planarSliceBasis.ts` (`getGeometricImageVolumeCenter`): the corner-averaging fallback loop is unreachable dead code because `buildImageVolumeCorners` returns `[]` whenever `imageData` is falsy.
- `planarViewReference.ts`: for stack bindings a `sliceIndex` specifier override changes `referencedImageId` but not `cameraFocalPoint` (camera geometry comes from the single mounted image) — looks intentional, documented in a test.

## Verification

Full `packages/core` jest suite: 30 suites, 514 passed, 2 skipped. No changes under `packages/core/src` or to existing tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated coverage across viewport behavior, camera math, planar rendering, view references, and WSI transforms.
  * Added stronger validation for zoom, pan, rotation, clipping, slice selection, and coordinate conversion across image and volume workflows.
  * Improved coverage for edge cases like missing data, destroyed views, empty inputs, and zero-size canvases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->