### PR TITLE
fix(ci): use medium resource class for NPM_PUBLISH

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
 
   NPM_PUBLISH:
     <<: *defaults
-    resource_class: small
+    resource_class: medium
     steps:
       - attach_workspace:
           at: ~/repo


### PR DESCRIPTION
### Context

The `NPM_PUBLISH` job runs `lerna version`, which executes `pnpm install --lockfile-only` across the monorepo. On `resource_class: small` (~2GB) this is getting SIGKILL'd mid-resolution (OOM), so releases never finish — e.g. `5.4.13` never reached npm.

### Changes & Results

- Bump `NPM_PUBLISH` from `small` to `medium`.

### Testing

- Merge to main; confirm the next `TEST_AND_RELEASE` / `NPM_PUBLISH` job completes the version bump and publish.

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

- [ ] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: macOS
- [x] Node version: 24.x
- [x] Browser: n/a (CI config only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the publishing process by allocating additional build resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->