### PR TITLE
fix(planar): remap initialImageIdIndex to the volume imageId ordering

### DIFF
--- a/packages/core/src/RenderingEngine/GenericViewport/Planar/DefaultPlanarDataProvider.ts
+++ b/packages/core/src/RenderingEngine/GenericViewport/Planar/DefaultPlanarDataProvider.ts
@@ -71,6 +71,12 @@ export class DefaultPlanarDataProvider implements PlanarDataProvider {
         const remappedIndex = imageIds.indexOf(requestedImageId);
         if (remappedIndex >= 0) {
           volumeInitialImageIdIndex = remappedIndex;
+        } else {
+          console.warn(
+            `[PlanarViewport] initialImageIdIndex remap failed: imageId ` +
+              `"${requestedImageId}" not found in the volume imageIds; ` +
+              `using the original index ${initialImageIdIndex}`
+          );
         }
       }
 

--- a/packages/core/src/RenderingEngine/GenericViewport/Planar/DefaultPlanarDataProvider.ts
+++ b/packages/core/src/RenderingEngine/GenericViewport/Planar/DefaultPlanarDataProvider.ts
@@ -60,11 +60,25 @@ export class DefaultPlanarDataProvider implements PlanarDataProvider {
         ? imageVolume.imageIds
         : dataSet.imageIds;
 
+      // The volume sorts its imageIds by position along the scan axis, which can
+      // reorder (commonly reverse) them relative to the registered dataSet order
+      // the caller computed initialImageIdIndex against. Remap the index through
+      // the imageId so the payload index addresses the slice the caller asked
+      // for in the payload's (volume) ordering.
+      let volumeInitialImageIdIndex = initialImageIdIndex;
+      if (initialImageIdIndex !== undefined && imageIds !== dataSet.imageIds) {
+        const requestedImageId = dataSet.imageIds[initialImageIdIndex];
+        const remappedIndex = imageIds.indexOf(requestedImageId);
+        if (remappedIndex >= 0) {
+          volumeInitialImageIdIndex = remappedIndex;
+        }
+      }
+
       return {
         id: dataId,
         type: 'image',
         imageIds,
-        initialImageIdIndex,
+        initialImageIdIndex: volumeInitialImageIdIndex,
         acquisitionOrientation: options.acquisitionOrientation,
         imageData: dataSet.imageData,
         imageVolume,

--- a/packages/core/test/defaultPlanarDataProvider.jest.js
+++ b/packages/core/test/defaultPlanarDataProvider.jest.js
@@ -1,0 +1,118 @@
+jest.mock('../src/loaders/volumeLoader', () => ({
+  __esModule: true,
+  createAndCacheVolume: jest.fn(),
+}));
+
+jest.mock('../src/loaders/imageLoader', () => ({
+  __esModule: true,
+  loadAndCacheImage: jest.fn(async (imageId) => ({ imageId })),
+}));
+
+jest.mock(
+  '../src/RenderingEngine/GenericViewport/genericViewportDisplaySetAccess',
+  () => ({
+    __esModule: true,
+    getGenericViewportPlanarDisplaySet: jest.fn(),
+  })
+);
+
+import { ActorRenderMode } from '../src/types';
+import { createAndCacheVolume } from '../src/loaders/volumeLoader';
+import { getGenericViewportPlanarDisplaySet } from '../src/RenderingEngine/GenericViewport/genericViewportDisplaySetAccess';
+import { DefaultPlanarDataProvider } from '../src/RenderingEngine/GenericViewport/Planar/DefaultPlanarDataProvider';
+
+const DATA_ID = 'display-set-1';
+
+function makeImageIds(count) {
+  return Array.from({ length: count }, (_, i) => `wadors:image-${i}`);
+}
+
+function registerDataSet(dataSet) {
+  getGenericViewportPlanarDisplaySet.mockReturnValue(dataSet);
+}
+
+function mockVolume(imageIds) {
+  createAndCacheVolume.mockResolvedValue({
+    imageIds,
+    load: jest.fn(),
+  });
+}
+
+describe('DefaultPlanarDataProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('volume-slice payloads', () => {
+    it('remaps initialImageIdIndex when the volume reorders the imageIds', async () => {
+      // The registered dataSet carries the caller's ordering; the cached volume
+      // sorts by position along the scan axis, here the exact reverse.
+      const dataSetImageIds = makeImageIds(30);
+      registerDataSet({ imageIds: dataSetImageIds, initialImageIdIndex: 12 });
+      mockVolume([...dataSetImageIds].reverse());
+
+      const provider = new DefaultPlanarDataProvider();
+      const payload = await provider.load(DATA_ID, {
+        orientation: 'acquisition',
+        renderMode: ActorRenderMode.VTK_VOLUME_SLICE,
+        volumeId: 'volume-1',
+      });
+
+      // Index 12 in dataSet order is imageId image-12; in the reversed volume
+      // ordering that image sits at index 17 — the payload must address it there,
+      // not land on the mirrored slice.
+      expect(payload.imageIds[payload.initialImageIdIndex]).toBe(
+        'wadors:image-12'
+      );
+      expect(payload.initialImageIdIndex).toBe(17);
+    });
+
+    it('keeps the index unchanged when the volume preserves the ordering', async () => {
+      const dataSetImageIds = makeImageIds(10);
+      registerDataSet({ imageIds: dataSetImageIds, initialImageIdIndex: 3 });
+      mockVolume([...dataSetImageIds]);
+
+      const provider = new DefaultPlanarDataProvider();
+      const payload = await provider.load(DATA_ID, {
+        orientation: 'acquisition',
+        renderMode: ActorRenderMode.VTK_VOLUME_SLICE,
+        volumeId: 'volume-1',
+      });
+
+      expect(payload.initialImageIdIndex).toBe(3);
+    });
+
+    it('preserves "no slice requested" (undefined) so the view can center', async () => {
+      const dataSetImageIds = makeImageIds(10);
+      registerDataSet({ imageIds: dataSetImageIds });
+      mockVolume([...dataSetImageIds].reverse());
+
+      const provider = new DefaultPlanarDataProvider();
+      const payload = await provider.load(DATA_ID, {
+        orientation: 'acquisition',
+        renderMode: ActorRenderMode.VTK_VOLUME_SLICE,
+        volumeId: 'volume-1',
+      });
+
+      expect(payload.initialImageIdIndex).toBeUndefined();
+    });
+  });
+
+  describe('image payloads', () => {
+    it('keeps the dataSet ordering and index on the image branch', async () => {
+      const dataSetImageIds = makeImageIds(5);
+      registerDataSet({ imageIds: dataSetImageIds, initialImageIdIndex: 2 });
+
+      const provider = new DefaultPlanarDataProvider();
+      const payload = await provider.load(DATA_ID, {
+        orientation: 'acquisition',
+        renderMode: ActorRenderMode.VTK_IMAGE,
+        volumeId: undefined,
+      });
+
+      expect(payload.imageIds).toEqual(dataSetImageIds);
+      expect(payload.initialImageIdIndex).toBe(2);
+      expect(payload.image.imageId).toBe('wadors:image-2');
+    });
+  });
+});

--- a/packages/core/test/defaultPlanarDataProvider.jest.js
+++ b/packages/core/test/defaultPlanarDataProvider.jest.js
@@ -82,6 +82,29 @@ describe('DefaultPlanarDataProvider', () => {
       expect(payload.initialImageIdIndex).toBe(3);
     });
 
+    it('warns and keeps the original index when the imageId is not in the volume', async () => {
+      const dataSetImageIds = makeImageIds(10);
+      registerDataSet({ imageIds: dataSetImageIds, initialImageIdIndex: 3 });
+      mockVolume(makeImageIds(10).map((id) => `${id}-other`));
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      try {
+        const provider = new DefaultPlanarDataProvider();
+        const payload = await provider.load(DATA_ID, {
+          orientation: 'acquisition',
+          renderMode: ActorRenderMode.VTK_VOLUME_SLICE,
+          volumeId: 'volume-1',
+        });
+
+        expect(payload.initialImageIdIndex).toBe(3);
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('initialImageIdIndex remap failed')
+        );
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
     it('preserves "no slice requested" (undefined) so the view can center', async () => {
       const dataSetImageIds = makeImageIds(10);
       registerDataSet({ imageIds: dataSetImageIds });


### PR DESCRIPTION
### Context

When a planar Generic Viewport mounts a dataset on the volume-slice render path, `DefaultPlanarDataProvider.load` builds the payload from `imageVolume.imageIds`. `createAndCacheVolume` sorts those imageIds by position along the scan axis, which can reorder — commonly exactly reverse — them relative to the registered dataSet ordering the caller computed `initialImageIdIndex` against. The index is then interpreted in the volume ordering and the viewport opens on the mirrored slice.

Observed in OHIF (next viewports): opening a SEG whose first segmented slice is index 12 of 30 lands on slice 18 instead of 13 (12 and 17 are mirror indices of a reversed 30-slice stack). The SEG overlay promotes the source series to the volume-slice path, which is why plain stack mounts don't show it.

### Changes & Results

- `DefaultPlanarDataProvider`: when the volume branch returns `imageVolume.imageIds` and an explicit `initialImageIdIndex` was registered, remap the index through the requested imageId (`imageIds.indexOf(dataSet.imageIds[index])`) so the payload index addresses the slice the caller asked for in the payload's own ordering. `undefined` (no slice requested) is preserved so the acquisition view still centers; the plain-image branch keeps the dataSet ordering and is unchanged.
- New `defaultPlanarDataProvider.jest.js` covering: reversed-order remap, same-order passthrough, undefined preservation, and the image branch.

### Testing

- `npx jest test/defaultPlanarDataProvider.jest.js` (4 passed)
- `npx jest test/planarOrchestration.jest.js test/planarViewReference.jest.js test/planarRenderBackend.jest.js test/planarViewportState.jest.js` (122 passed)
- Reproduced/verified in OHIF against a 30-slice MR + SEG study: initial slice now matches the legacy path.

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected initial slice selection when a volume’s `imageIds` ordering differs from the dataset’s ordering by remapping the requested starting index.
  * Preserved behavior when order matches and when no initial slice is specified (automatic centering).
  * Added graceful fallback (with a warning) when the dataset-selected `imageId` isn’t present in the volume.
* **Tests**
  * Added Jest coverage for reordered volumes, matching orders, missing `imageId` warning/fallback, undefined initial slice handling, and image-based rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->