### PR TITLE
fix(planar): map dynamic-volume flattened indices to their group-local slice

### DIFF
--- a/packages/core/src/RenderingEngine/GenericViewport/Planar/planarSliceBasis.ts
+++ b/packages/core/src/RenderingEngine/GenericViewport/Planar/planarSliceBasis.ts
@@ -344,7 +344,21 @@ export function getVolumeImageIdIndexWorldPoint(
   }
 
   const dimensions = imageData.getDimensions();
-  const k = Math.min(Math.max(0, imageIdIndex), dimensions[2] - 1);
+  // Dynamic (4D) volumes flatten their imageIds across dimension groups while
+  // dimensions[2] is the slice count of a SINGLE group, so an image from any
+  // later group has a flattened index >= dimensions[2] — clamping that raw
+  // index would pin every such image to the final slice. Map it to its
+  // group-local slice first (the k axis repeats per group).
+  const flatToGroupLocal = (
+    imageVolume as {
+      flatImageIdIndexToImageIdIndex?: (flatImageIdIndex: number) => number;
+    }
+  ).flatImageIdIndexToImageIdIndex;
+  const groupLocalIndex =
+    typeof flatToGroupLocal === 'function'
+      ? flatToGroupLocal.call(imageVolume, Math.max(0, imageIdIndex))
+      : imageIdIndex;
+  const k = Math.min(Math.max(0, groupLocalIndex), dimensions[2] - 1);
 
   return imageData.indexToWorld([
     (dimensions[0] - 1) / 2,

--- a/packages/core/test/planarSliceBasis.jest.js
+++ b/packages/core/test/planarSliceBasis.jest.js
@@ -851,6 +851,28 @@ describe('resolvePlanarVolumeImageIdIndex', () => {
 });
 
 describe('getVolumeImageIdIndexWorldPoint', () => {
+  it('maps a flattened dynamic-volume index to its group-local slice', () => {
+    // A 4D volume flattens its imageIds across dimension groups (here 3
+    // groups of 6 slices) while dimensions[2] stays the per-group slice
+    // count, and exposes the flat -> group-local mapping.
+    const volume = createOrthonormalVolume();
+
+    volume.flatImageIdIndexToImageIdIndex = (flatImageIdIndex) =>
+      flatImageIdIndex % 6;
+
+    // Flattened index 14 = group 3, local slice 2 — NOT the last slice (5)
+    // that a raw clamp against dimensions[2] - 1 would produce.
+    expectPoint3Close(
+      getVolumeImageIdIndexWorldPoint(volume, 14),
+      [102.25, 203.5, 304]
+    );
+    // Indices inside the first group pass through the mapping unchanged.
+    expectPoint3Close(
+      getVolumeImageIdIndexWorldPoint(volume, 2),
+      [102.25, 203.5, 304]
+    );
+  });
+
   it('returns the exact IJK slice center for an imageId-list index', () => {
     const volume = createOrthonormalVolume();
 


### PR DESCRIPTION
### Context

Follow-up to #2800. `getVolumeImageIdIndexWorldPoint` assumes a one-to-one imageId-to-k-slice mapping, but `StreamingDynamicImageVolume` flattens its imageIds across all dimension groups while `dimensions[2]` is the slice count of a single group. A referenced image (navigation) or an explicitly carried initial slice from any later dimension group therefore has a flattened index of at least `dimensions[2]`, and the clamp sent every such image to the final slice instead of its group-local k.

### Changes & Results

- Convert the flattened index through the volume's own `flatImageIdIndexToImageIdIndex` mapping (the k axis repeats per dimension group) before resolving the IJK world center. Duck-typed: static volumes have no such method and pass through unchanged, keeping #2800's behavior identical for 3D volumes.
- Both consumers (view-reference navigation by `referencedImageId` / snapped plane points, and the mount-time `initialImageIdIndex`) route through this shared helper, so one conversion covers both.
- New test: a 3-group dynamic-volume mock asserts flattened index 14 (group 3, local slice 2) resolves to slice 2's world center rather than the raw-clamp result (final slice), and that first-group indices pass through unchanged.

### Testing

- `npx jest` (packages/core): 31 suites, 535 passed.
- `pnpm --filter @cornerstonejs/core run build:esm` clean.

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved world-point calculations for dynamic 4D volumes with flattened image indexes.
  * Ensured slice positions are mapped to the correct dimension group instead of being incorrectly clamped.

* **Tests**
  * Added coverage for flattened dynamic-volume index mapping, including cross-group and first-group scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->