### PR TITLE
refactor(tools): resolve targetsFilter through annotationTargetFilter metadata providers

### DIFF
--- a/packages/core/examples/tmtv/index.ts
+++ b/packages/core/examples/tmtv/index.ts
@@ -172,8 +172,8 @@ const rectangleROIHUToolName = 'RectangleROIHU';
 const instructions = document.createElement('p');
 instructions.innerText = `Select a tool from the drop down and drag on a viewport to create an ROI:
 - "Rectangle/Circle ROI (all pixel data - default)": the default configuration computes and shows the statistics of every display set containing pixel values, so on the fusion (bottom row) viewports both the CT (HU) and PT (SUV) values appear at once. SEG display sets are never included, even when they are the only thing shown.
-- "Circle ROI (PT SUV only)": configured with targetFilters.forModality('PT'), it shows the SUV statistics by preference - on the fusion viewports only the PT values appear, and on the CT-only viewports nothing is shown.
-- "Rectangle ROI (CT HU only)": configured with targetFilters.forModality('CT'), it shows the HU statistics by preference - on the fusion viewports only the CT values appear, and on the PT-only viewports nothing is shown.
+- "Circle ROI (PT SUV only)": configured with targetsFilter { key: 'modality', options: { modality: 'PT' } }, it shows the SUV statistics by preference - on the fusion viewports only the PT values appear, and on the CT-only viewports nothing is shown.
+- "Rectangle ROI (CT HU only)": configured with targetsFilter { key: 'modality', options: { modality: 'CT' } }, it shows the HU statistics by preference - on the fusion viewports only the CT values appear, and on the PT-only viewports nothing is shown.
 Annotations are shared across the viewports; a fusion viewport computes the statistics of each selected volume itself, even when no other viewport has computed them.
 Use the "Layout" drop down to test the tools on different viewport arrangements: the default CT/PT/Fusion grid with the PET MIP, just the three fusion views, or a mixed layout (CT sagittal, PT coronal and an oblique CT+PT fusion). Annotations survive the layout switches and statistics are recomputed as needed.`;
 document.getElementById('content').appendChild(instructions);
@@ -590,22 +590,23 @@ function setUpToolGroupsForStudy(studyKey) {
       getReferenceLineDraggableRotatable,
       getReferenceLineSlabThicknessControlsOn,
     });
-    // The default ROI configuration (targetFilters.allPixelData) shows the
+    // The default ROI configuration ({ key: 'allPixelData' }) shows the
     // statistics of every display set containing pixel values.
     toolGroup.addTool(RectangleROITool.toolName);
     toolGroup.addTool(CircleROITool.toolName);
     // Named instances demonstrating modality based filters: the SUV circle
     // shows PT statistics by preference (and nothing on CT-only viewports),
     // the HU rectangle shows CT statistics by preference (and nothing on
-    // PT-only viewports).
+    // PT-only viewports).  The targetsFilter names an annotationTargetFilter
+    // metadata provider key and its options.
     toolGroup.addToolInstance(circleROISUVToolName, CircleROITool.toolName, {
-      targetsFilter: CircleROITool.targetFilters.forModality('PT'),
+      targetsFilter: { key: 'modality', options: { modality: 'PT' } },
     });
     toolGroup.addToolInstance(
       rectangleROIHUToolName,
       RectangleROITool.toolName,
       {
-        targetsFilter: RectangleROITool.targetFilters.forModality('CT'),
+        targetsFilter: { key: 'modality', options: { modality: 'CT' } },
       }
     );
     toolGroup.addTool(LengthTool.toolName);
@@ -647,7 +648,7 @@ function setUpToolGroupsForStudy(studyKey) {
   // On the fusion viewports the `targetsFilter` configuration decides which
   // of the fused volumes (display sets) the tools compute and display
   // statistics for.  The default ROI tools show both the CT and PT values
-  // at once (targetFilters.allPixelData); the named instances restrict the
+  // at once ({ key: 'allPixelData' }); the named instances restrict the
   // statistics by modality.
   fusionToolGroup.addTool(RectangleROITool.toolName);
   fusionToolGroup.addTool(CircleROITool.toolName);
@@ -655,14 +656,14 @@ function setUpToolGroupsForStudy(studyKey) {
     circleROISUVToolName,
     CircleROITool.toolName,
     {
-      targetsFilter: CircleROITool.targetFilters.forModality('PT'),
+      targetsFilter: { key: 'modality', options: { modality: 'PT' } },
     }
   );
   fusionToolGroup.addToolInstance(
     rectangleROIHUToolName,
     RectangleROITool.toolName,
     {
-      targetsFilter: RectangleROITool.targetFilters.forModality('CT'),
+      targetsFilter: { key: 'modality', options: { modality: 'CT' } },
     }
   );
   fusionToolGroup.addTool(CircleROIStartEndThresholdTool.toolName, {

--- a/packages/docs/docs/concepts/cornerstone-tools/annotation/measurementTargets.md
+++ b/packages/docs/docs/concepts/cornerstone-tools/annotation/measurementTargets.md
@@ -26,10 +26,63 @@ when they are the only thing shown.
 
 ## The `targetsFilter` configuration
 
-Every annotation tool accepts a `targetsFilter` configuration option. The
-filter is called once per candidate display set of the viewport, in order.
-Its first parameter is the display set related information of the candidate,
-and its second parameter is the viewport the filter is applying to:
+Every annotation tool accepts a `targetsFilter` configuration option. It is a
+declarative spec naming an **`annotationTargetFilter` metadata provider key**
+and its options:
+
+```ts
+toolGroup.addTool(CircleROITool.toolName, {
+  targetsFilter: {
+    key: 'modality',
+    options: { modality: 'PT' },
+  },
+});
+```
+
+When selecting the measurement targets, `BaseTool` resolves the spec to a
+filter function through the existing metadata-provider system:
+
+```ts
+const filter = metaData.getMetaData(
+  'annotationTargetFilter',
+  targetsFilter.key,
+  targetsFilter.options
+);
+```
+
+so the generic behaviour of each key is registered once as a metadata
+provider, and the tool configuration only passes the value (`'PT'`, `'CT'`,
+a volume id, ...) as options. No tool class carries its own copy of the
+target-selection API, and applications can supply further target-selection
+behaviour through their existing metadata providers (see
+[Custom filters](#custom-filters) below).
+
+### Built-in provider keys
+
+The built-in provider (`utilities.annotationTargetFilterProvider`, registered
+by `init()`) answers these keys:
+
+| Key              | Options                                              | Selects                                                                                                                                                                         |
+| ---------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `'allPixelData'` | —                                                    | Every display set containing pixel values — the ROI tools' **default**. Excludes segmentation representations and the non-pixel modalities (SEG, RTSTRUCT, RTPLAN, SR, PR, KO). |
+| `'modality'`     | `{ modality: 'PT' }` or `{ modality: ['CT', 'PT'] }` | Display sets whose modality matches. Candidates with an unknown display set/modality are excluded.                                                                              |
+| `'id'`           | `{ id: volumeId }`                                   | Display sets referencing the given display set/volume/image id — a substring match, so partial identifiers such as a contained series UID also work.                            |
+| `'first'`        | —                                                    | Just the first candidate display set (the pre-5.x single-target behaviour).                                                                                                     |
+| `'all'`          | —                                                    | Every candidate display set, including segmentation representations.                                                                                                            |
+
+The built-in keys always resolve: if the provider chain returns nothing for
+them (for example after `metaData.removeAllProviders()`), the built-in
+provider is consulted directly. The built-in provider is registered below the
+default priority, so an application provider registered at the default
+priority can override any of these keys.
+
+### The filter function
+
+The resolved filter (or a function set directly as `targetsFilter` — see
+[Custom filters](#custom-filters)) is called once per candidate display set
+of the viewport, in order. Its first parameter is the display set related
+information of the candidate, and its second parameter is the viewport the
+filter is applying to:
 
 ```ts
 type MeasurementTargetsFilter = (
@@ -66,7 +119,7 @@ search continues:
 | `'stop'`              | skipped          | **stop looking**     |
 
 Return `'useAndStop'` or `'stop'` when no further items should be
-considered — for example `targetFilters.first` is simply
+considered — for example the `'first'` key resolves to simply
 `() => 'useAndStop'`, and a "first PT only" filter is
 `(displaySetInfo) => displaySetInfo.modality === 'PT' ? 'useAndStop' : false`.
 
@@ -91,20 +144,17 @@ candidates (a PT-only filter on a CT viewport, or the default pixel-data
 filter when only a SEG is shown), the annotation is still drawn but no
 statistics are computed or displayed for that viewport.
 
-Ready-made filters are available on every tool class via
-`BaseTool.targetFilters`.
-
 ## Examples
 
 All display sets with pixel values — this is the default configuration for
 the ROI tools, made explicit. Candidates with a non-pixel modality
-(`BaseTool.NON_PIXEL_DATA_MODALITIES`: SEG, RTSTRUCT, RTPLAN, SR, PR, KO)
+(`utilities.NON_PIXEL_DATA_MODALITIES`: SEG, RTSTRUCT, RTPLAN, SR, PR, KO)
 are excluded, while candidates with an unknown display set (legacy stacks)
 are included:
 
 ```ts
 toolGroup.addTool(CircleROITool.toolName, {
-  targetsFilter: CircleROITool.targetFilters.allPixelData,
+  targetsFilter: { key: 'allPixelData' },
 });
 ```
 
@@ -112,7 +162,7 @@ CT statistics only — nothing is shown on viewports without a CT:
 
 ```ts
 toolGroup.addTool(CircleROITool.toolName, {
-  targetsFilter: CircleROITool.targetFilters.forModality('CT'),
+  targetsFilter: { key: 'modality', options: { modality: 'CT' } },
 });
 ```
 
@@ -122,7 +172,7 @@ viewports without a PT):
 
 ```ts
 toolGroup.addTool(CircleROITool.toolName, {
-  targetsFilter: CircleROITool.targetFilters.forModality('PT'),
+  targetsFilter: { key: 'modality', options: { modality: 'PT' } },
 });
 ```
 
@@ -131,7 +181,7 @@ those two modalities:
 
 ```ts
 toolGroup.addTool(CircleROITool.toolName, {
-  targetsFilter: CircleROITool.targetFilters.forModality('CT', 'PT'),
+  targetsFilter: { key: 'modality', options: { modality: ['CT', 'PT'] } },
 });
 ```
 
@@ -139,7 +189,7 @@ Just the first target (the pre-5.x single-target behaviour):
 
 ```ts
 toolGroup.addTool(CircleROITool.toolName, {
-  targetsFilter: CircleROITool.targetFilters.first,
+  targetsFilter: { key: 'first' },
 });
 ```
 
@@ -149,13 +199,48 @@ configuration:
 
 ```ts
 toolGroup.addTool(RectangleROITool.toolName, {
-  targetsFilter: RectangleROITool.targetFilters.forId(ptVolumeId),
+  targetsFilter: { key: 'id', options: { id: ptVolumeId } },
 });
 ```
 
-Custom filters are plain functions, so any selection logic is possible —
-including deciding from the exemplar instance, stopping early, or handling
-unknown display sets explicitly:
+The `tmtv` example wires several of these as separately labelled dropdown
+entries (default both, PT SUV only, CT HU only) on a PT/CT fusion layout,
+and the `petCt` example shows the `id` variant.
+
+## Custom filters
+
+Applications add their own target-selection behaviour through the metadata
+providers they already use — register a provider answering the
+`annotationTargetFilter` type for new keys, then name the key in the tool
+configuration:
+
+```ts
+import { metaData } from '@cornerstonejs/core';
+
+metaData.addProvider((type, key, options) => {
+  if (type !== 'annotationTargetFilter') {
+    return;
+  }
+  if (key === 'suvCapable') {
+    // The filter function receives each candidate display set in turn
+    return ({ instance }) => instance?.Units === 'BQML';
+  }
+});
+
+toolGroup.addTool(CircleROITool.toolName, {
+  targetsFilter: { key: 'suvCapable' },
+});
+```
+
+Providers that do not recognise a key return `undefined`, so the chain falls
+through to the next provider (and finally to the built-in keys). Registering
+a provider at the default priority also overrides the built-in keys, which
+sit below it.
+
+For one-off cases a filter function can also be set directly as the
+`targetsFilter` configuration — any selection logic is possible, including
+deciding from the exemplar instance, stopping early, or handling unknown
+display sets explicitly:
 
 ```ts
 toolGroup.addTool(CircleROITool.toolName, {
@@ -178,10 +263,6 @@ toolGroup.addTool(CircleROITool.toolName, {
     displaySetInfo.modality !== displaySetInfo.previous?.modality,
 });
 ```
-
-The `tmtv` example wires several of these as separately labelled dropdown
-entries (default both, PT SUV only, CT HU only) on a PT/CT fusion layout,
-and the `petCt` example shows the `forId` variant.
 
 ## How it behaves
 

--- a/packages/tools/examples/petCt/index.ts
+++ b/packages/tools/examples/petCt/index.ts
@@ -392,12 +392,12 @@ function setUpToolGroups() {
   });
   fusionToolGroup.addTool(RectangleROITool.toolName, {
     // Compute/show statistics for the PT volume of the fusion viewport only,
-    // selected by its volume id.  `targetFilters.forModality('PT')` would
-    // select the same volume by modality instead, and leaving the default
-    // configuration (targetFilters.allPixelData) would compute/show the
-    // statistics of both PT and CT at once.
+    // selected by its volume id.  { key: 'modality', options: { modality:
+    // 'PT' } } would select the same volume by modality instead, and leaving
+    // the default configuration ({ key: 'allPixelData' }) would compute/show
+    // the statistics of both PT and CT at once.
     // (This replaces the deprecated `isPreferredTargetId` configuration.)
-    targetsFilter: RectangleROITool.targetFilters.forId(ptVolumeId),
+    targetsFilter: { key: 'id', options: { id: ptVolumeId } },
   });
 
   // Here is the difference in the toolGroups used, that we need to specify the

--- a/packages/tools/src/init.ts
+++ b/packages/tools/src/init.ts
@@ -1,4 +1,4 @@
-import { eventTarget, Enums } from '@cornerstonejs/core';
+import { eventTarget, Enums, metaData } from '@cornerstonejs/core';
 import { getAnnotationManager } from './stateManagement/annotation/annotationState';
 import { Events as TOOLS_EVENTS } from './enums';
 import { addEnabledElement, removeEnabledElement } from './store';
@@ -21,6 +21,10 @@ import type { Config } from './config';
 import segmentationRemovedListener from './eventListeners/segmentation/segmentationRemovedEventListener';
 import renderingPipelineChangedListener from './eventListeners/segmentation/renderingPipelineChangedListener';
 import { registerBuiltInSegmentationRepresentationDisplays } from './tools/displayTools/registerBuiltInSegmentationRepresentationDisplays';
+import {
+  annotationTargetFilterProvider,
+  ANNOTATION_TARGET_FILTER_PROVIDER_PRIORITY,
+} from './utilities/annotationTargetFilterProvider';
 
 let csToolsInitialized = false;
 
@@ -36,6 +40,13 @@ export function init(defaultConfiguration = {} as Config): void {
   }
 
   registerBuiltInSegmentationRepresentationDisplays();
+  // Resolves the `targetsFilter` tool configuration (annotation measurement
+  // target selection) - registered below the default priority so
+  // application providers can override the built-in keys.
+  metaData.addProvider(
+    annotationTargetFilterProvider,
+    ANNOTATION_TARGET_FILTER_PROVIDER_PRIORITY
+  );
   setConfig(defaultConfiguration);
 
   _addCornerstoneEventListeners();

--- a/packages/tools/src/tools/annotation/CircleROITool.ts
+++ b/packages/tools/src/tools/annotation/CircleROITool.ts
@@ -150,8 +150,9 @@ class CircleROITool extends AnnotationTool {
         simplified: true, // If true, only 2 points are used for the handles, otherwise 5 points are used
         // By default show the statistics of every display set containing
         // pixel values (eg both CT and PT on a fusion viewport), but never
-        // SEG and the like - see BaseTool.targetFilters for alternatives
-        targetsFilter: AnnotationTool.targetFilters.allPixelData,
+        // SEG and the like - see the annotationTargetFilter metadata
+        // provider keys for alternatives
+        targetsFilter: { key: 'allPixelData' },
       },
     }
   ) {

--- a/packages/tools/src/tools/annotation/RectangleROITool.ts
+++ b/packages/tools/src/tools/annotation/RectangleROITool.ts
@@ -124,8 +124,9 @@ class RectangleROITool extends AnnotationTool {
         statsCalculator: BasicStatsCalculator,
         // By default show the statistics of every display set containing
         // pixel values (eg both CT and PT on a fusion viewport), but never
-        // SEG and the like - see BaseTool.targetFilters for alternatives
-        targetsFilter: AnnotationTool.targetFilters.allPixelData,
+        // SEG and the like - see the annotationTargetFilter metadata
+        // provider keys for alternatives
+        targetsFilter: { key: 'allPixelData' },
       },
     }
   ) {

--- a/packages/tools/src/tools/base/BaseTool.ts
+++ b/packages/tools/src/tools/base/BaseTool.ts
@@ -18,6 +18,11 @@ import type {
   MeasurementTargetsFilter,
 } from '../../types';
 
+import {
+  annotationTargetFilterProvider,
+  ANNOTATION_TARGET_FILTER,
+} from '../../utilities/annotationTargetFilterProvider';
+
 const { DefaultHistoryMemo } = csUtils.HistoryMemo;
 
 /**
@@ -121,135 +126,6 @@ abstract class BaseTool {
   }
 
   /**
-   * Modalities whose display sets do not contain measurable pixel values
-   * (segmentations, structured reports etc).  The
-   * `targetFilters.allPixelData` filter excludes candidates with one of
-   * these modalities.
-   */
-  public static readonly NON_PIXEL_DATA_MODALITIES = [
-    'SEG',
-    'RTSTRUCT',
-    'RTPLAN',
-    'SR',
-    'PR',
-    'KO',
-  ];
-
-  /**
-   * Ready made {@link MeasurementTargetsFilter} implementations for the
-   * `targetsFilter` tool configuration option.  The filter decides which of
-   * the display sets shown in a viewport the tool computes and displays
-   * measurement statistics for - on a fusion viewport this allows showing
-   * the statistics of one, several or all of the fused volumes.
-   *
-   * The filter is called once per candidate display set, in viewport order,
-   * receiving the display set related parameters (display set, uid,
-   * exemplar instance, index and the previously chosen candidate) and the
-   * viewport.  It returns, per candidate:
-   * - `true` to include the display set and continue
-   * - `false`/`undefined` to skip it and continue
-   * - `'useAndStop'` to include it and stop looking for further items
-   * - `'stop'` to skip it and stop looking for further items
-   *
-   * The decision should be based on the modality of the display set where
-   * available.  When the display set is unknown (eg a stack viewport using
-   * the legacy set image ids), the candidate has no display set fields and
-   * no modality, and a filter can choose whether to include it based on
-   * that.
-   *
-   * A configured filter's result is authoritative: when it includes no
-   * candidates, no statistics are computed or displayed for the viewport.
-   *
-   * Example configurations:
-   * ```ts
-   * // CT statistics only - shows nothing on viewports without a CT
-   * toolGroup.addTool(CircleROITool.toolName, {
-   *   targetsFilter: CircleROITool.targetFilters.forModality('CT'),
-   * });
-   *
-   * // PT statistics only - shows nothing on viewports without a PT
-   * toolGroup.addTool(CircleROITool.toolName, {
-   *   targetsFilter: CircleROITool.targetFilters.forModality('PT'),
-   * });
-   *
-   * // Every display set containing pixel values (skips SEG etc) - this is
-   * // the default for the ROI tools
-   * toolGroup.addTool(CircleROITool.toolName, {
-   *   targetsFilter: CircleROITool.targetFilters.allPixelData,
-   * });
-   *
-   * // Just the first display set
-   * toolGroup.addTool(CircleROITool.toolName, {
-   *   targetsFilter: CircleROITool.targetFilters.first,
-   * });
-   *
-   * // Custom: the first PT display set only, stopping the search once found
-   * toolGroup.addTool(CircleROITool.toolName, {
-   *   targetsFilter: (displaySetInfo) =>
-   *     displaySetInfo.modality === 'PT' ? 'useAndStop' : false,
-   * });
-   * ```
-   */
-  public static targetFilters = {
-    /**
-     * Includes just the first candidate display set, stopping the search
-     * there.
-     */
-    first: (() => 'useAndStop') as MeasurementTargetsFilter,
-
-    /**
-     * Includes every candidate display set, for example both the CT and the
-     * PT volume on a fusion viewport.
-     */
-    all: (() => true) as MeasurementTargetsFilter,
-
-    /**
-     * Includes every candidate display set containing pixel values:
-     * segmentation representations (candidates carrying a
-     * `representationUID`) and candidates whose modality is one of
-     * {@link BaseTool.NON_PIXEL_DATA_MODALITIES} (eg SEG) are excluded -
-     * even when they are the only thing shown - while candidates whose
-     * display set (and therefore modality) is unknown, such as legacy
-     * stacks, are included.
-     *
-     * This is the default filter for the ROI statistics tools, and is what
-     * excludes segmentations from the measurement targets (the candidate
-     * derivation no longer bakes that exclusion in).
-     */
-    allPixelData: (({ modality, representationUID }) =>
-      !representationUID &&
-      (!modality ||
-        !BaseTool.NON_PIXEL_DATA_MODALITIES.includes(
-          modality
-        ))) as MeasurementTargetsFilter,
-
-    /**
-     * Creates a filter including the display sets whose modality is one of
-     * the given modalities, eg `forModality('PT')` or
-     * `forModality('CT', 'PT')`.  Candidates with an unknown display
-     * set/modality are excluded; include them with a custom filter checking
-     * `!displaySetInfo.imageIds` if needed.
-     */
-    forModality:
-      (...modalities: string[]): MeasurementTargetsFilter =>
-      ({ modality }) =>
-        modalities.includes(modality),
-
-    /**
-     * Creates a filter including the display sets referencing the given
-     * display set, volume or image id.  This is a substring match, so
-     * partial identifiers such as a series UID contained in the id may also
-     * be used.
-     */
-    forId:
-      (id: string): MeasurementTargetsFilter =>
-      ({ displaySetUID, referencedId, targetId }) =>
-        displaySetUID?.includes(id) ||
-        referencedId?.includes(id) ||
-        targetId.includes(id),
-  };
-
-  /**
    * A function generator to test if the target id is the desired one.
    * Used for deciding which set of cached stats is appropriate to display
    * for a given viewport.
@@ -259,8 +135,8 @@ abstract class BaseTool {
    * It is also possible to use series query parameters such as `/series/{seriesUID}/`
    * to generate specific series selections within a stack viewport.
    *
-   * @deprecated Use the `targetsFilter` configuration option with
-   * `BaseTool.targetFilters.forId` instead.
+   * @deprecated Use the `targetsFilter` configuration option instead:
+   * `targetsFilter: { key: 'id', options: { id: desiredVolumeId } }`.
    */
   public static isSpecifiedTargetId(desiredVolumeId: string) {
     // imageId including the target id is a proxy for testing if the
@@ -434,8 +310,9 @@ abstract class BaseTool {
    *
    * This is the primary (first) entry of {@link getMeasurementTargets}, so it
    * honours the `targetsFilter` tool configuration - configuring, for
-   * example, `targetFilters.forModality('PT')` makes the PT volume of a
-   * fusion viewport the target the statistics are stored/read for.
+   * example, `{ key: 'modality', options: { modality: 'PT' } }` makes the PT
+   * volume of a fusion viewport the target the statistics are stored/read
+   * for.
    *
    * @param viewport - viewport to get the targetId for
    * @param data - Optional: The annotation's data object, containing cachedStats.
@@ -454,11 +331,13 @@ abstract class BaseTool {
    * measurement statistics for on the given viewport.
    *
    * The targets are selected by the `targetsFilter` tool configuration
-   * option, called once per candidate display set of the viewport in order
-   * (see {@link BaseTool.targetFilters} for ready made filters).  The filter
-   * receives the display set related parameters - including the previously
-   * chosen candidate - and the viewport, and returns per candidate whether
-   * to include it and whether to stop looking for further items (see
+   * option - usually a `{ key, options }` spec resolved to a filter function
+   * through the `annotationTargetFilter` metadata providers (see
+   * {@link BaseTool.resolveTargetsFilter}) - called once per candidate
+   * display set of the viewport in order.  The filter receives the display
+   * set related parameters - including the previously chosen candidate - and
+   * the viewport, and returns per candidate whether to include it and
+   * whether to stop looking for further items (see
    * {@link MeasurementTargetsFilterResult}).
    *
    * Each returned targetId reuses an existing cachedStats key when
@@ -487,7 +366,7 @@ abstract class BaseTool {
     viewport: Types.IViewport,
     data?: AnnotationData
   ): string[] {
-    const { targetsFilter, isPreferredTargetId } = this.configurationTyped;
+    const { isPreferredTargetId } = this.configurationTyped;
 
     // Legacy option (deprecated) choosing the preferred target from already
     // computed stats.  Checked first so configurations predating
@@ -500,6 +379,7 @@ abstract class BaseTool {
       }
     }
 
+    const targetsFilter = this.resolveTargetsFilter();
     if (targetsFilter) {
       const candidates = this.getMeasurementTargetCandidates(viewport, data);
       const targets: string[] = [];
@@ -527,6 +407,61 @@ abstract class BaseTool {
     throw new Error(
       'getMeasurementTargets: viewport must have a getViewReferenceId method'
     );
+  }
+
+  /** The `targetsFilter` spec keys already warned about as unresolvable. */
+  private static unresolvedFilterKeys = new Set<string>();
+
+  /**
+   * Resolves the `targetsFilter` tool configuration to the
+   * {@link MeasurementTargetsFilter} function to apply.
+   *
+   * The configuration is normally a declarative
+   * {@link MeasurementTargetsFilterSpec} - a provider `key` and its
+   * `options` - resolved through the metadata provider chain as
+   * `metaData.getMetaData('annotationTargetFilter', key, options)`.
+   * Applications provide further target-selection behaviour (or override
+   * the built-in keys) through their existing metadata providers.
+   *
+   * The built-in keys (`'first'`, `'all'`, `'allPixelData'`, `'modality'`,
+   * `'id'` - see `utilities.annotationTargetFilterProvider`, registered by
+   * `init()`) always resolve: when the provider chain returns nothing for a
+   * key (eg after `metaData.removeAllProviders()`), the built-in provider is
+   * consulted directly.
+   *
+   * A filter function set directly on the configuration is returned as is.
+   * When neither resolves the configured key, a warning is logged (once per
+   * key) and undefined is returned, so the viewport's single default target
+   * is used.
+   */
+  protected resolveTargetsFilter(): MeasurementTargetsFilter | undefined {
+    const { targetsFilter } = this.configurationTyped;
+    if (!targetsFilter) {
+      return;
+    }
+    if (typeof targetsFilter === 'function') {
+      return targetsFilter;
+    }
+    const filter =
+      (metaData.getMetaData(
+        ANNOTATION_TARGET_FILTER,
+        targetsFilter.key,
+        targetsFilter.options
+      ) as MeasurementTargetsFilter | undefined) ??
+      annotationTargetFilterProvider(
+        ANNOTATION_TARGET_FILTER,
+        targetsFilter.key,
+        targetsFilter.options
+      );
+    if (!filter && !BaseTool.unresolvedFilterKeys.has(targetsFilter.key)) {
+      BaseTool.unresolvedFilterKeys.add(targetsFilter.key);
+      console.warn(
+        `resolveTargetsFilter: no annotationTargetFilter metadata provider ` +
+          `resolved the targetsFilter key "${targetsFilter.key}" - ` +
+          `using the viewport's default target`
+      );
+    }
+    return filter;
   }
 
   /**

--- a/packages/tools/src/types/IBaseTool.ts
+++ b/packages/tools/src/types/IBaseTool.ts
@@ -84,9 +84,12 @@ export type MeasurementTargetsFilterResult =
   | 'stop';
 
 /**
- * A configurable filter deciding which of the display sets shown in a
- * viewport an annotation tool computes and displays statistics for.  Set it
- * on the tool configuration as `targetsFilter`.
+ * A filter deciding which of the display sets shown in a viewport an
+ * annotation tool computes and displays statistics for.  It is normally
+ * resolved from the `targetsFilter` tool configuration (a
+ * {@link MeasurementTargetsFilterSpec}) through the `annotationTargetFilter`
+ * metadata providers, but can also be set on the configuration directly as a
+ * function.
  *
  * The filter is called once per candidate display set, in viewport order,
  * with the display set related parameters (display set, uid, exemplar
@@ -105,38 +108,53 @@ export type MeasurementTargetsFilterResult =
  * available; candidates whose display set is unknown (eg legacy stack image
  * ids) have no `imageIds`/`instance`, letting the filter choose whether to
  * include them.
- *
- * See `BaseTool.targetFilters` for ready made filters:
- *
- * ```ts
- * // CT only - shows nothing on viewports without a CT
- * toolGroup.addTool(CircleROITool.toolName, {
- *   targetsFilter: CircleROITool.targetFilters.forModality('CT'),
- * });
- * // PT only - shows nothing on viewports without a PT
- * toolGroup.addTool(CircleROITool.toolName, {
- *   targetsFilter: CircleROITool.targetFilters.forModality('PT'),
- * });
- * // Every display set with pixel values (skips SEG etc) - the ROI tools'
- * // default
- * toolGroup.addTool(CircleROITool.toolName, {
- *   targetsFilter: CircleROITool.targetFilters.allPixelData,
- * });
- * // Just the first display set
- * toolGroup.addTool(CircleROITool.toolName, {
- *   targetsFilter: CircleROITool.targetFilters.first,
- * });
- * // Custom: the first PT display set only, stopping the search once found
- * toolGroup.addTool(CircleROITool.toolName, {
- *   targetsFilter: (displaySetInfo) =>
- *     displaySetInfo.modality === 'PT' ? 'useAndStop' : false,
- * });
- * ```
  */
 export type MeasurementTargetsFilter = (
   displaySetInfo: MeasurementTargetCandidate,
   viewport: Types.IViewport
 ) => MeasurementTargetsFilterResult;
+
+/**
+ * A declarative `targetsFilter` tool configuration, resolved to a
+ * {@link MeasurementTargetsFilter} through the metadata provider chain:
+ *
+ * ```ts
+ * const filter = metaData.getMetaData(
+ *   'annotationTargetFilter',
+ *   targetsFilter.key,
+ *   targetsFilter.options
+ * );
+ * ```
+ *
+ * The built-in provider answers the keys `'first'`, `'all'`,
+ * `'allPixelData'`, `'modality'` (options: `{ modality: 'PT' }` or
+ * `{ modality: ['CT', 'PT'] }`) and `'id'` (options: `{ id: volumeId }`,
+ * a substring match) - see `utilities.annotationTargetFilterProvider`.
+ * Applications add further keys (or override the built-in ones) through
+ * their existing metadata providers.
+ *
+ * ```ts
+ * // PT only - shows nothing on viewports without a PT
+ * toolGroup.addTool(CircleROITool.toolName, {
+ *   targetsFilter: { key: 'modality', options: { modality: 'PT' } },
+ * });
+ * // Every display set with pixel values (skips SEG etc) - the ROI tools'
+ * // default
+ * toolGroup.addTool(CircleROITool.toolName, {
+ *   targetsFilter: { key: 'allPixelData' },
+ * });
+ * // Just the first display set
+ * toolGroup.addTool(CircleROITool.toolName, {
+ *   targetsFilter: { key: 'first' },
+ * });
+ * ```
+ */
+export type MeasurementTargetsFilterSpec = {
+  /** The `annotationTargetFilter` metadata provider key, eg `'modality'`. */
+  key: string;
+  /** Options passed to the provider, eg `{ modality: 'PT' }`. */
+  options?: Record<string, unknown>;
+};
 
 /**
  * General tool configuration.  This is intended to be extended
@@ -151,14 +169,17 @@ export interface ToolConfiguration {
   strategyOptions: any;
 
   /**
-   * Filter deciding which display sets shown in the viewport the tool
-   * computes and displays measurement statistics for.  See
-   * {@link MeasurementTargetsFilter} and `BaseTool.targetFilters`.
-   * The ROI statistics tools default this to `targetFilters.allPixelData`
+   * Decides which display sets shown in the viewport the tool computes and
+   * displays measurement statistics for.  Usually a
+   * {@link MeasurementTargetsFilterSpec} naming an `annotationTargetFilter`
+   * metadata provider key and its options, resolved through the metadata
+   * provider chain; a {@link MeasurementTargetsFilter} function may also be
+   * given directly.
+   * The ROI statistics tools default this to `{ key: 'allPixelData' }`
    * (every display set containing pixel values); tools without a default
    * filter use the viewport's single default target.
    */
-  targetsFilter?: MeasurementTargetsFilter;
+  targetsFilter?: MeasurementTargetsFilterSpec | MeasurementTargetsFilter;
 
   /**
    * @returns true if the given targetId is preferred.

--- a/packages/tools/src/types/index.ts
+++ b/packages/tools/src/types/index.ts
@@ -82,6 +82,7 @@ import type {
   MeasurementTargetCandidate,
   MeasurementTargetsFilter,
   MeasurementTargetsFilterResult,
+  MeasurementTargetsFilterSpec,
 } from './IBaseTool';
 import type { RepresentationStyle } from './../stateManagement/segmentation/SegmentationStyle';
 import type { LogicalOperation } from '../utilities/contourSegmentation';
@@ -182,6 +183,7 @@ export type {
   MeasurementTargetCandidate,
   MeasurementTargetsFilter,
   MeasurementTargetsFilterResult,
+  MeasurementTargetsFilterSpec,
   RepresentationStyle,
   Segment,
   SegmentationPublicInput,

--- a/packages/tools/src/utilities/annotationTargetFilterProvider.ts
+++ b/packages/tools/src/utilities/annotationTargetFilterProvider.ts
@@ -1,0 +1,149 @@
+import type { MeasurementTargetsFilter } from '../types';
+
+/**
+ * The metadata type under which measurement target filters are resolved.
+ * The `targetsFilter` tool configuration names a provider `key` and its
+ * `options`, and `BaseTool` resolves the actual filter function through the
+ * metadata provider chain:
+ *
+ * ```ts
+ * const filter = metaData.getMetaData(
+ *   'annotationTargetFilter',
+ *   targetsFilter.key,
+ *   targetsFilter.options
+ * );
+ * ```
+ *
+ * Applications can supply their own target-selection behaviour through their
+ * existing metadata providers - register a provider answering this type for
+ * new keys (or for the built-in keys, at a priority above
+ * {@link ANNOTATION_TARGET_FILTER_PROVIDER_PRIORITY} to override them):
+ *
+ * ```ts
+ * metaData.addProvider((type, key, options) => {
+ *   if (type !== 'annotationTargetFilter') {
+ *     return;
+ *   }
+ *   if (key === 'suvCapable') {
+ *     return ({ instance }) => instance?.Units === 'BQML';
+ *   }
+ * });
+ * ```
+ */
+export const ANNOTATION_TARGET_FILTER = 'annotationTargetFilter';
+
+/**
+ * The priority the built-in {@link annotationTargetFilterProvider} is
+ * registered at - below the default (0), so application providers registered
+ * at the default priority take precedence for the built-in keys.
+ */
+export const ANNOTATION_TARGET_FILTER_PROVIDER_PRIORITY = -10;
+
+/**
+ * Modalities whose display sets do not contain measurable pixel values
+ * (segmentations, structured reports etc).  The `allPixelData` filter
+ * excludes candidates with one of these modalities.
+ */
+export const NON_PIXEL_DATA_MODALITIES = [
+  'SEG',
+  'RTSTRUCT',
+  'RTPLAN',
+  'SR',
+  'PR',
+  'KO',
+];
+
+/**
+ * Includes just the first candidate display set, stopping the search there.
+ */
+const first: MeasurementTargetsFilter = () => 'useAndStop';
+
+/**
+ * Includes every candidate display set, for example both the CT and the PT
+ * volume on a fusion viewport.
+ */
+const all: MeasurementTargetsFilter = () => true;
+
+/**
+ * Includes every candidate display set containing pixel values:
+ * segmentation representations (candidates carrying a `representationUID`)
+ * and candidates whose modality is one of
+ * {@link NON_PIXEL_DATA_MODALITIES} (eg SEG) are excluded - even when they
+ * are the only thing shown - while candidates whose display set (and
+ * therefore modality) is unknown, such as legacy stacks, are included.
+ *
+ * This is the default filter for the ROI statistics tools, and is what
+ * excludes segmentations from the measurement targets (the candidate
+ * derivation no longer bakes that exclusion in).
+ */
+const allPixelData: MeasurementTargetsFilter = ({
+  modality,
+  representationUID,
+}) =>
+  !representationUID &&
+  (!modality || !NON_PIXEL_DATA_MODALITIES.includes(modality));
+
+/**
+ * The built-in `annotationTargetFilter` metadata provider, registered by
+ * `init()` at {@link ANNOTATION_TARGET_FILTER_PROVIDER_PRIORITY}.  It answers
+ * the {@link ANNOTATION_TARGET_FILTER} type for the built-in keys, returning
+ * a {@link MeasurementTargetsFilter} for the `targetsFilter` tool
+ * configuration to apply:
+ *
+ * - `'first'` - just the first candidate display set
+ * - `'all'` - every candidate display set
+ * - `'allPixelData'` - every display set containing pixel values (the ROI
+ *   tools' default); excludes segmentation representations and
+ *   {@link NON_PIXEL_DATA_MODALITIES}
+ * - `'modality'` - display sets whose modality matches
+ *   `options.modality` (a string, eg `'PT'`, or an array, eg
+ *   `['CT', 'PT']`); candidates with an unknown display set/modality are
+ *   excluded
+ * - `'id'` - display sets referencing `options.id` - a substring match
+ *   against the display set uid, backing volume/image id and targetId, so
+ *   partial identifiers such as a contained series UID also work
+ *
+ * Unknown keys (and known keys missing their required options) are left for
+ * other providers, so applications can extend the vocabulary through the
+ * same metadata provider chain.
+ */
+export function annotationTargetFilterProvider(
+  type: string,
+  key: string,
+  filterOptions?: unknown
+): MeasurementTargetsFilter | undefined {
+  if (type !== ANNOTATION_TARGET_FILTER) {
+    return;
+  }
+  const options = filterOptions as Record<string, unknown> | undefined;
+  switch (key) {
+    case 'first':
+      return first;
+    case 'all':
+      return all;
+    case 'allPixelData':
+      return allPixelData;
+    case 'modality': {
+      const requested = options?.modality;
+      const modalities = Array.isArray(requested)
+        ? (requested as string[])
+        : typeof requested === 'string'
+          ? [requested]
+          : undefined;
+      if (!modalities?.length) {
+        return;
+      }
+      return ({ modality }) => modalities.includes(modality);
+    }
+    case 'id': {
+      const id = options?.id;
+      if (typeof id !== 'string' || !id) {
+        return;
+      }
+      return ({ displaySetUID, referencedId, targetId }) =>
+        displaySetUID?.includes(id) ||
+        referencedId?.includes(id) ||
+        targetId.includes(id);
+    }
+  }
+}

--- a/packages/tools/src/utilities/index.ts
+++ b/packages/tools/src/utilities/index.ts
@@ -63,6 +63,7 @@ import getOrCreateImageVolume from './segmentation/getOrCreateImageVolume';
 import * as usFanExtraction from '../tools/annotation/UltrasoundPleuraBLineTool/utils/fanExtraction';
 import { jumpToFocalPoint } from './genericViewportToolHelpers';
 export * from './defaultGetTextLines';
+export * from './annotationTargetFilterProvider';
 
 export {
   math,


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->

### Context

Implements the review suggestion on #2557: the measurement target-selection helpers should not live as static API on the tool classes (`CircleROITool.targetFilters.forModality('PT')` etc.). Instead, target selection is resolved through the existing metadata-provider system. This PR targets the `feat/add-multiple-results` branch so the diff shows only the architecture change.

### Changes & Results

- Removed `BaseTool.targetFilters` and `BaseTool.NON_PIXEL_DATA_MODALITIES` - no tool class carries a copy of the target-selection API anymore.
- The `targetsFilter` tool configuration is now a declarative spec naming a provider key and its options:
  ```ts
  toolGroup.addTool(CircleROITool.toolName, {
    targetsFilter: { key: 'modality', options: { modality: 'PT' } },
  });
  ```
- `BaseTool` resolves the spec through the metadata provider chain:
  ```ts
  const filter = metaData.getMetaData(
    'annotationTargetFilter',
    targetsFilter.key,
    targetsFilter.options
  );
  ```
  Note this uses `getMetaData` rather than `get`: `get(type, ...queries)` treats extra arguments as alternative queries and would drop the options, while `getMetaData(type, query, options)` forwards them to the providers.
- New built-in provider `utilities.annotationTargetFilterProvider`, registered once by `init()`, answering the keys `first`, `all`, `allPixelData` (still the ROI tools' default, now `{ key: 'allPixelData' }`), `modality` (string or array) and `id`. It is registered below the default priority, so an application provider registered at the default priority overrides the built-in keys, and unknown keys fall through the chain - applications add target-selection behavior through their existing metadata providers without a new registry concept.
- Robustness: when the provider chain returns nothing for a key (eg after `metaData.removeAllProviders()`, which the test harness and applications call after init), `BaseTool` consults the built-in provider directly, so the built-in keys always resolve. A key unknown to both warns once and falls back to the viewport's single default target.
- A plain filter function is still accepted as `targetsFilter` for one-off cases; it adds no registry or tool-class API. Easy to drop if provider-only is preferred.
- Updated the `tmtv` and `petCt` examples, exported `MeasurementTargetsFilterSpec`, and rewrote the `measurementTargets` docs page around the provider architecture (built-in key table, custom provider registration, priority/override semantics).

### Testing

- `packages/tools` typecheck and oxlint clean.
- All 634 tools jest tests pass.
- The karma fusion test in `CircleROI_test.js` (from #2557) exercises the provider resolution path end-to-end via the default `{ key: 'allPixelData' }` configuration.
- Manual: run the `tmtv` example; the "Circle ROI (PT SUV only)" / "Rectangle ROI (CT HU only)" dropdown entries behave as on the base branch.

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: macOS 15"
- [x] "Node version: 22.22.2"
- [x] "Browser: Chrome"