### PR TITLE
fix(tools): preserve continuous measurement coordinates

### DIFF
--- a/packages/tools/src/tools/annotation/RectangleROITool.ts
+++ b/packages/tools/src/tools/annotation/RectangleROITool.ts
@@ -53,7 +53,7 @@ import { isViewportPreScaled } from '../../utilities/viewport/isViewportPreScale
 import { BasicStatsCalculator } from '../../utilities/math/basic';
 import { getStyleProperty } from '../../stateManagement/annotation/config/helpers';
 
-const { transformWorldToIndex } = csUtils;
+const { transformWorldToIndex, transformWorldToIndexContinuous } = csUtils;
 
 /**
  * RectangleROIAnnotation let you draw annotations that measures the statistics
@@ -841,11 +841,11 @@ class RectangleROITool extends AnnotationTool {
 
       const { dimensions, imageData, metadata, voxelManager } = image;
 
-      const indexHandles = worldHandles.map((worldHandle) =>
-        transformWorldToIndex(imageData, worldHandle)
+      const continuousIndexHandles = worldHandles.map((worldHandle) =>
+        transformWorldToIndexContinuous(imageData, worldHandle)
       );
-      const pos1Index = indexHandles[0].map(Math.floor);
-      const pos2Index = indexHandles[3].map(Math.floor);
+      const pos1Index = transformWorldToIndex(imageData, worldHandles[0]);
+      const pos2Index = transformWorldToIndex(imageData, worldHandles[3]);
 
       // Check if one of the indexes are inside the volume, this then gives us
       // Some area to do stats over.
@@ -874,12 +874,12 @@ class RectangleROITool extends AnnotationTool {
         const calibrate = getCalibratedLengthUnitsAndScale(image, handles);
 
         const width = RectangleROITool.calculateLengthInIndex(calibrate, [
-          indexHandles[0],
-          indexHandles[1],
+          continuousIndexHandles[0],
+          continuousIndexHandles[1],
         ]);
         const height = RectangleROITool.calculateLengthInIndex(calibrate, [
-          indexHandles[0],
-          indexHandles[2],
+          continuousIndexHandles[0],
+          continuousIndexHandles[2],
         ]);
         const area = Math.abs(width * height);
         const { areaUnit } = calibrate;

--- a/packages/tools/src/tools/annotation/UltrasoundDirectionalTool.ts
+++ b/packages/tools/src/tools/annotation/UltrasoundDirectionalTool.ts
@@ -47,7 +47,7 @@ import type {
 import type { StyleSpecifier } from '../../types/AnnotationStyle';
 import { getCalibratedProbeUnitsAndValue } from '../../utilities/getCalibratedUnits';
 import { lineSegment } from '../../utilities/math';
-const { transformWorldToIndex } = csUtils;
+const { transformWorldToIndexContinuous } = csUtils;
 
 /**
  * The `UltrasoundDirectionalTool` class is a tool for creating directional ultrasound annotations.
@@ -767,8 +767,8 @@ class UltrasoundDirectionalTool extends AnnotationTool {
       const worldPos1 = data.handles.points[0];
       const worldPos2 = data.handles.points[1];
 
-      const imageIndex1 = transformWorldToIndex(imageData, worldPos1);
-      const imageIndex2 = transformWorldToIndex(imageData, worldPos2);
+      const imageIndex1 = transformWorldToIndexContinuous(imageData, worldPos1);
+      const imageIndex2 = transformWorldToIndexContinuous(imageData, worldPos2);
 
       const { values: values1, units: units1 } =
         getCalibratedProbeUnitsAndValue(image, [imageIndex1]);

--- a/packages/tools/test/RectangleROIArea.jest.js
+++ b/packages/tools/test/RectangleROIArea.jest.js
@@ -1,0 +1,63 @@
+import RectangleROITool from '../src/tools/annotation/RectangleROITool';
+
+describe('Rectangle ROI area', () => {
+  it('uses continuous indices for physical area', () => {
+    const tool = new RectangleROITool();
+    const targetId = 'imageId:test';
+    const forEach = jest.fn();
+    const image = {
+      dimensions: [100, 100, 1],
+      hasPixelSpacing: true,
+      imageData: {
+        worldToIndex: ([x, y, z]) => [x / 5, y / 5, z],
+      },
+      metadata: { Modality: 'CT' },
+      spacing: [5, 5, 1],
+      voxelManager: { forEach },
+    };
+    const annotation = {
+      data: {
+        cachedStats: { [targetId]: {} },
+        handles: {
+          points: [
+            [2, 2, 0],
+            [29, 2, 0],
+            [2, 18, 0],
+            [29, 18, 0],
+          ],
+        },
+      },
+      invalidated: false,
+      metadata: {},
+    };
+    const viewport = {
+      element: document.createElement('div'),
+    };
+
+    tool.getTargetImageData = () => image;
+    tool.configuration.statsCalculator = {
+      getStatistics: () => ({ array: [] }),
+      statsCallback: jest.fn(),
+    };
+
+    tool._calculateCachedStats(
+      annotation,
+      [0, 0, 1],
+      [0, 1, 0],
+      {},
+      { viewport }
+    );
+
+    expect(annotation.data.cachedStats[targetId].area).toBeCloseTo(27 * 16);
+    expect(forEach).toHaveBeenCalledWith(
+      tool.configuration.statsCalculator.statsCallback,
+      expect.objectContaining({
+        boundsIJK: [
+          [0, 6],
+          [0, 4],
+          [0, 0],
+        ],
+      })
+    );
+  });
+});

--- a/packages/tools/test/UltrasoundDirectionalTool.jest.js
+++ b/packages/tools/test/UltrasoundDirectionalTool.jest.js
@@ -1,0 +1,59 @@
+import UltrasoundDirectionalTool from '../src/tools/annotation/UltrasoundDirectionalTool';
+
+describe('Ultrasound Directional measurements', () => {
+  it('uses continuous indices for calibrated endpoint values', () => {
+    const tool = new UltrasoundDirectionalTool();
+    const targetId = 'imageId:test';
+    const image = {
+      calibration: {
+        sequenceOfUltrasoundRegions: [
+          {
+            regionDataType: 1,
+            regionLocationMinX0: 0,
+            regionLocationMaxX1: 100,
+            regionLocationMinY0: 0,
+            regionLocationMaxY1: 100,
+            physicalUnitsXDirection: 4,
+            physicalUnitsYDirection: 7,
+            physicalDeltaX: 2,
+            physicalDeltaY: 3,
+          },
+        ],
+      },
+      imageData: {
+        worldToIndex: ([x, y, z]) => [x, y, z],
+      },
+    };
+    const annotation = {
+      data: {
+        cachedStats: { [targetId]: {} },
+        handles: {
+          points: [
+            [0.2, 0.3, 0],
+            [10.7, 4.8, 0],
+          ],
+        },
+      },
+      invalidated: false,
+    };
+    const viewport = {
+      element: document.createElement('div'),
+      worldToCanvas: ([x, y]) => [x, y],
+    };
+
+    tool.getTargetImageData = () => image;
+
+    tool._calculateCachedStats(annotation, {}, { viewport });
+
+    const { xValues, yValues, isHorizontal, units, isUnitless } =
+      annotation.data.cachedStats[targetId];
+
+    expect(xValues[0]).toBeCloseTo(0.4);
+    expect(xValues[1]).toBeCloseTo(21.4);
+    expect(yValues[0]).toBeCloseTo(0.9);
+    expect(yValues[1]).toBeCloseTo(14.4);
+    expect(isHorizontal).toBe(true);
+    expect(units).toEqual(['seconds', 'cm/sec']);
+    expect(isUnitless).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- calculate Rectangle ROI physical width and height from continuous image indices
- calculate Ultrasound Directional calibrated endpoints from continuous image indices
- retain rounded image indices where tools intentionally sample voxels or define discrete bounds
- add regression coverage for fractional Rectangle ROI and calibrated ultrasound coordinates

## Why

Some measurement paths converted world handles to rounded voxel indices before calculating their reported values. This quantized Rectangle ROI area differently on volumes with different pixel spacing and quantized Ultrasound Directional measurements to whole pixels.

## Impact

- a shared Rectangle ROI reports consistent physical area across aligned volumes
- calibrated US and ECG directional measurements preserve subpixel endpoint positions
- intensity statistics and discrete tools continue to use integer voxel coordinates

## Validation

- `pnpm test:unit:no-coverage packages/tools/test/RectangleROIArea.jest.js packages/tools/test/UltrasoundDirectionalTool.jest.js --runInBand`
- `pnpm build:esm`
- commit hooks: oxlint and Prettier
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rectangular ROI area calculations by preserving fractional image coordinates, resulting in more accurate physical measurements.
  * Improved ultrasound directional measurements by using more precise coordinate conversions for calibrated values.

* **Tests**
  * Added coverage validating accurate ROI area calculations.
  * Added coverage for calibrated ultrasound measurements, direction classification, units, and endpoint values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->