### PR TITLE
fix/wsi-viewport-preserve-zoom-on-resize

### DIFF
--- a/packages/core/src/RenderingEngine/WSIViewport.ts
+++ b/packages/core/src/RenderingEngine/WSIViewport.ts
@@ -450,6 +450,28 @@ class WSIViewport extends Viewport {
       canvas.width = clientWidth;
       canvas.height = clientHeight;
     }
+    // Preserve fit-relative zoom across container size changes.
+    // Without this, WSIViewport keeps the old OpenLayers resolution, so
+    // exiting full screen (smaller container) leaves the slide zoomed in.
+    const map = this.map;
+    const view = map?.getView?.();
+    if (map && view) {
+      const extent = view.getProjection().getExtent();
+      const oldSize = map.getSize();
+      const oldResolution = view.getResolution();
+      let relativeZoom;
+      if (oldSize && oldResolution) {
+        relativeZoom =
+          view.getResolutionForExtent(extent, oldSize) / oldResolution;
+      }
+      map.updateSize();
+      const newSize = map.getSize();
+      if (relativeZoom && newSize) {
+        view.setResolution(
+          view.getResolutionForExtent(extent, newSize) / relativeZoom
+        );
+      }
+    }
     this.refreshRenderValues();
   };
 


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
fix(WSIViewport): preserve fit-relative zoom on container resize
Problem
When a WSIViewport container changes size (e.g., entering/exiting fullscreen, panel resize), the OpenLayers map was not recalculating its resolution. This caused the slide to appear zoomed in after shrinking the container — the viewport retained the old resolution calculated for the larger container dimensions.

Solution
In the resize handler, after the canvas dimensions are updated, capture the current fit-relative zoom (the ratio of the "fit-to-extent" resolution to the current resolution) before the map knows about the new size. After calling map.updateSize(), restore that same relative zoom level by computing a new resolution for the updated container size.





### Changes & Results
List all the changes that have been done, such as:
WSIViewport.ts
Added zoom preservation logic in the resize handler
Calculates relativeZoom as resolutionForExtent(oldSize) / oldResolution before the resize
Calls map.updateSize() to sync OpenLayers with the new DOM dimensions
Restores zoom by setting resolutionForExtent(newSize) / relativeZoom on the view

What are the effects of this change?
- Before vs After

https://github.com/user-attachments/assets/8a7d1db1-1cf6-489b-9ab7-6703d421ba43



### Testing
Resize the browser window while a WSI is loaded — zoom level should remain consistent
Enter/exit fullscreen — the slide should not jump to a more-zoomed-in state
Zoom in manually, then resize — the relative zoom level should be preserved

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the slide’s zoom level when resizing the viewer, including when entering or exiting full-screen mode.
  * Maintained consistent rendering while adapting the viewport to its new size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->