### PR TITLE
fix(core): expose getCompleteScalarDataArray on dynamic volume voxel manager

### DIFF
--- a/packages/core/src/utilities/VoxelManager.ts
+++ b/packages/core/src/utilities/VoxelManager.ts
@@ -1471,6 +1471,14 @@ export default class VoxelManager<T> {
       return voxelGroups[activeDimensionGroup].getCompleteScalarDataArray();
     };
 
+    // Expose the generic scalar-data accessor so consumers that operate on a plain
+    // volume voxel manager (e.g. segmentation statistics) work on dynamic volumes,
+    // returning the currently active dimension group's scalar data.
+    // @ts-ignore
+    voxelManager.getCompleteScalarDataArray = () => {
+      return voxelGroups[activeDimensionGroup].getCompleteScalarDataArray();
+    };
+
     // @ts-ignore
     voxelManager.getCurrentTimePoint = () => {
       console.warn(


### PR DESCRIPTION
The dynamic (4D) volume voxel manager only exposed per-dimension-group scalar accessors, so consumers that call the generic getCompleteScalarDataArray() on a reference volume - such as segmentation statistics (getStatistics -> calculateVolumeStatistics) - threw for segmentations on dynamic volumes. Delegate it to the active dimension group's scalar data.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added access to complete scalar voxel data through dynamically managed volume data.
  * Ensures the active dimension group’s full scalar data can be retrieved consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->