### PR TITLE
fix(core): remove IMAGE_CACHE_IMAGE_ADDED listener when streaming image load settles

### DIFF
--- a/packages/core/src/cache/classes/BaseStreamingImageVolume.ts
+++ b/packages/core/src/cache/classes/BaseStreamingImageVolume.ts
@@ -426,16 +426,20 @@ export class BaseStreamingImageVolume
       return;
     }
 
+    const cleanupImageCacheListener = () => {
+      eventTarget.removeEventListener(
+        Events.IMAGE_CACHE_IMAGE_ADDED,
+        handleImageCacheAdded
+      );
+    };
+
     // Todo: check if this needs more work for when we have progressive loading
     const handleImageCacheAdded = (event) => {
       const { image } = event.detail;
       if (image.imageId === imageId) {
         this.vtkOpenGLTexture.setUpdatedFrame(imageIdIndex);
         // Remove the event listener after it's been triggered
-        eventTarget.removeEventListener(
-          Events.IMAGE_CACHE_IMAGE_ADDED,
-          handleImageCacheAdded
-        );
+        cleanupImageCacheListener();
       }
     };
 
@@ -444,18 +448,35 @@ export class BaseStreamingImageVolume
       handleImageCacheAdded
     );
 
-    const uncompressedIterator = ProgressiveIterator.as(
-      loadAndCacheImage(imageId, options)
-    );
+    try {
+      const uncompressedIterator = ProgressiveIterator.as(
+        loadAndCacheImage(imageId, options)
+      );
 
-    return uncompressedIterator.forEach(
-      (image) => {
-        // scalarData is the volume container we are progressively loading into
-        // image is the pixelData decoded from workers in cornerstoneDICOMImageLoader
-        this.successCallback(imageId, image);
-      },
-      this.errorCallback.bind(this, imageIdIndex, imageId)
-    );
+      const result = uncompressedIterator.forEach(
+        (image) => {
+          // scalarData is the volume container we are progressively loading into
+          // image is the pixelData decoded from workers in cornerstoneDICOMImageLoader
+          this.successCallback(imageId, image);
+        },
+        this.errorCallback.bind(this, imageIdIndex, imageId)
+      );
+
+      // The listener is only needed while this request is in flight. Most
+      // streaming loads never insert the image into the image cache, so
+      // without settle-time cleanup every call leaks one listener on the
+      // global eventTarget, and each closure retains the volume instance,
+      // keeping decached volumes from being garbage collected.
+      Promise.resolve(result).then(
+        cleanupImageCacheListener,
+        cleanupImageCacheListener
+      );
+
+      return result;
+    } catch (error) {
+      cleanupImageCacheListener();
+      throw error;
+    }
   }
 
   protected getImageIdsRequests(imageIds: string[], priorityDefault: number) {

--- a/packages/core/test/BaseStreamingImageVolume_listenerCleanup.jest.js
+++ b/packages/core/test/BaseStreamingImageVolume_listenerCleanup.jest.js
@@ -1,0 +1,106 @@
+jest.mock('../src/loaders/imageLoader', () => ({
+  __esModule: true,
+  ...jest.requireActual('../src/loaders/imageLoader'),
+  loadAndCacheImage: jest.fn(),
+}));
+
+import BaseStreamingImageVolume from '../src/cache/classes/BaseStreamingImageVolume';
+import eventTarget from '../src/eventTarget';
+import { Events } from '../src/enums';
+import triggerEvent from '../src/utilities/triggerEvent';
+import { loadAndCacheImage } from '../src/loaders/imageLoader';
+
+const IMAGE_ID = 'streaming-test:image-1';
+
+function createVolume() {
+  // callLoadImage only touches these members, so a bare prototype instance
+  // avoids the heavyweight ImageVolume constructor requirements.
+  const volume = Object.create(BaseStreamingImageVolume.prototype);
+  volume.cachedFrames = [];
+  volume.vtkOpenGLTexture = { setUpdatedFrame: jest.fn() };
+  volume.successCallback = jest.fn();
+  volume.errorCallback = jest.fn();
+  return volume;
+}
+
+function dispatchImageCacheAdded(imageId) {
+  triggerEvent(eventTarget, Events.IMAGE_CACHE_IMAGE_ADDED, {
+    image: { imageId },
+  });
+}
+
+async function flushMicrotasks() {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('BaseStreamingImageVolume.callLoadImage listener cleanup', () => {
+  beforeEach(() => {
+    eventTarget.reset();
+    jest.clearAllMocks();
+  });
+
+  it('removes the IMAGE_CACHE_IMAGE_ADDED listener once the load resolves', async () => {
+    const volume = createVolume();
+    const image = { imageId: IMAGE_ID };
+    loadAndCacheImage.mockReturnValue(Promise.resolve(image));
+
+    await volume.callLoadImage(IMAGE_ID, 0, {});
+    await flushMicrotasks();
+
+    dispatchImageCacheAdded(IMAGE_ID);
+
+    expect(volume.successCallback).toHaveBeenCalledWith(IMAGE_ID, image);
+    expect(volume.vtkOpenGLTexture.setUpdatedFrame).not.toHaveBeenCalled();
+  });
+
+  it('removes the IMAGE_CACHE_IMAGE_ADDED listener when the load rejects', async () => {
+    const volume = createVolume();
+    loadAndCacheImage.mockReturnValue(
+      Promise.reject(new Error('network failure'))
+    );
+
+    await volume.callLoadImage(IMAGE_ID, 0, {}).catch(() => undefined);
+    await flushMicrotasks();
+
+    dispatchImageCacheAdded(IMAGE_ID);
+
+    expect(volume.errorCallback).toHaveBeenCalled();
+    expect(volume.vtkOpenGLTexture.setUpdatedFrame).not.toHaveBeenCalled();
+  });
+
+  it('still updates the texture frame for cache adds while the load is in flight', async () => {
+    const volume = createVolume();
+    let resolveLoad;
+    loadAndCacheImage.mockReturnValue(
+      new Promise((resolve) => {
+        resolveLoad = resolve;
+      })
+    );
+
+    const loadPromise = volume.callLoadImage(IMAGE_ID, 3, {});
+
+    dispatchImageCacheAdded(IMAGE_ID);
+    expect(volume.vtkOpenGLTexture.setUpdatedFrame).toHaveBeenCalledTimes(1);
+    expect(volume.vtkOpenGLTexture.setUpdatedFrame).toHaveBeenCalledWith(3);
+
+    resolveLoad({ imageId: IMAGE_ID });
+    await loadPromise;
+  });
+
+  it('ignores cache adds for other imageIds and still cleans up on settle', async () => {
+    const volume = createVolume();
+    const image = { imageId: IMAGE_ID };
+    loadAndCacheImage.mockReturnValue(Promise.resolve(image));
+
+    const loadPromise = volume.callLoadImage(IMAGE_ID, 0, {});
+
+    dispatchImageCacheAdded('streaming-test:other-image');
+    expect(volume.vtkOpenGLTexture.setUpdatedFrame).not.toHaveBeenCalled();
+
+    await loadPromise;
+    await flushMicrotasks();
+
+    dispatchImageCacheAdded(IMAGE_ID);
+    expect(volume.vtkOpenGLTexture.setUpdatedFrame).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
`BaseStreamingImageVolume.callLoadImage` registers an `IMAGE_CACHE_IMAGE_ADDED`
listener on the global `eventTarget` so the VTK texture frame gets updated when
the loaded image lands in the image cache. The listener is only removed inside
the handler itself, i.e. when an image with a matching `imageId` actually
arrives.

However, streaming volume loads typically bypass the image cache entirely
(`transferPixelData: true` — see the comment above `callLoadImage`), so for the
common path the event never fires and the listener is never removed:

- one listener leaks per frame request — a few CBCT/MR volumes with hundreds of
  slices each accumulate thousands of listeners on the global `eventTarget`;
- each leaked closure captures `this`, so decached volumes are retained and can
  never be garbage collected, which turns into a significant memory leak in
  long-running viewers that swap volumes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image-loading event listener cleanup after successful loads and errors.
  * Prevented cache events from updating image frames after loading has completed.
  * Preserved real-time frame updates during active image loading while ignoring unrelated images.

* **Tests**
  * Added coverage for successful loads, rejected loads, pending loads, and event filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->