### PR TITLE
fix(core): render volume viewports without float-linear filtering

### DIFF
--- a/packages/core/src/RenderingEngine/vtkClasses/canUseFloatOpacityTexture.js
+++ b/packages/core/src/RenderingEngine/vtkClasses/canUseFloatOpacityTexture.js
@@ -1,0 +1,18 @@
+/**
+ * Returns whether the current WebGL context can linearly sample a float
+ * opacity texture.
+ *
+ * WebGL2 includes float textures, but linear filtering of those textures is
+ * still gated by OES_texture_float_linear. In WebGL1, both extensions are
+ * required.
+ */
+export default function canUseFloatOpacityTexture(openGLRenderWindow, context) {
+  const supportsFloatTextures =
+    openGLRenderWindow.getWebgl2() ||
+    Boolean(context.getExtension('OES_texture_float'));
+  const supportsFloatLinearFiltering = Boolean(
+    context.getExtension('OES_texture_float_linear')
+  );
+
+  return supportsFloatTextures && supportsFloatLinearFiltering;
+}

--- a/packages/core/src/RenderingEngine/vtkClasses/vtkStreamingOpenGLVolumeMapper.js
+++ b/packages/core/src/RenderingEngine/vtkClasses/vtkStreamingOpenGLVolumeMapper.js
@@ -8,6 +8,7 @@ import { getTransferFunctionsHash } from '@kitware/vtk.js/Rendering/OpenGL/Rende
 import { Representation } from '@kitware/vtk.js/Rendering/Core/Property/Constants';
 import { BlendMode } from '@kitware/vtk.js/Rendering/Core/VolumeMapper/Constants';
 import { getCanUseNorm16Texture } from '../../init';
+import canUseFloatOpacityTexture from './canUseFloatOpacityTexture';
 
 /**
  * vtkStreamingOpenGLVolumeMapper - A derived class of the core vtkOpenGLVolumeMapper class.
@@ -211,11 +212,7 @@ function vtkStreamingOpenGLVolumeMapper(publicAPI, model) {
       // for this table. Errors in low values of opacity accumulate to
       // visible artifacts. High values of opacity quickly terminate without
       // artifacts.
-      if (
-        model._openGLRenderWindow.getWebgl2() ||
-        (model.context.getExtension('OES_texture_float') &&
-          model.context.getExtension('OES_texture_float_linear'))
-      ) {
+      if (canUseFloatOpacityTexture(model._openGLRenderWindow, model.context)) {
         newOpacityTexture.create2DFromRaw({
           width: oWidth,
           height: 2 * numIComps,

--- a/packages/core/test/canUseFloatOpacityTexture.jest.js
+++ b/packages/core/test/canUseFloatOpacityTexture.jest.js
@@ -1,0 +1,48 @@
+import canUseFloatOpacityTexture from '../src/RenderingEngine/vtkClasses/canUseFloatOpacityTexture';
+
+function createContext(supportedExtensions) {
+  return {
+    getExtension: jest.fn((name) =>
+      supportedExtensions.includes(name) ? {} : null
+    ),
+  };
+}
+
+function createRenderWindow(webgl2) {
+  return {
+    getWebgl2: jest.fn(() => webgl2),
+  };
+}
+
+describe('canUseFloatOpacityTexture', () => {
+  it('rejects a WebGL2 float texture without float-linear filtering', () => {
+    const renderWindow = createRenderWindow(true);
+    const context = createContext([]);
+
+    expect(canUseFloatOpacityTexture(renderWindow, context)).toBe(false);
+  });
+
+  it('accepts a WebGL2 float texture with float-linear filtering', () => {
+    const renderWindow = createRenderWindow(true);
+    const context = createContext(['OES_texture_float_linear']);
+
+    expect(canUseFloatOpacityTexture(renderWindow, context)).toBe(true);
+  });
+
+  it('accepts WebGL1 only when both float extensions are available', () => {
+    const renderWindow = createRenderWindow(false);
+    const context = createContext([
+      'OES_texture_float',
+      'OES_texture_float_linear',
+    ]);
+
+    expect(canUseFloatOpacityTexture(renderWindow, context)).toBe(true);
+  });
+
+  it('rejects WebGL1 when either float extension is unavailable', () => {
+    const renderWindow = createRenderWindow(false);
+    const context = createContext(['OES_texture_float_linear']);
+
+    expect(canUseFloatOpacityTexture(renderWindow, context)).toBe(false);
+  });
+});


### PR DESCRIPTION
fixes https://github.com/cornerstonejs/cornerstone3D/issues/2653
fixes https://github.com/cornerstonejs/cornerstone3D/issues/2640

## Summary

- require float-linear filtering support before using a float opacity transfer-function texture
- preserve the high-precision float path on supported desktop browsers
- fall back to the existing byte opacity table on unsupported WebGL contexts
- add focused WebGL1 and WebGL2 regression coverage

## Root cause

WebGL2 includes float textures, but linear filtering for those textures still requires `OES_texture_float_linear`. The existing capability check treated every WebGL2 context as float-linear capable. On iOS Safari, vtk.js therefore created a float opacity lookup texture with linear filtering even though the extension was unavailable, causing CT volume viewports to render black.

This change separates float texture support from float-linear filtering support. The CT scalar volume remains an `Int16Array` and continues to use the GPU `SHORT` scalar texture path.

## User impact

CT volume viewports now render on iOS Safari. Desktop browsers that support float-linear filtering continue to use the same float opacity texture path.

## Validation

- `./node_modules/.bin/jest --selectProjects core --runInBand packages/core/test/canUseFloatOpacityTexture.jest.js` — 4 tests passed
- Prettier check passed for all changed files
- oxlint passed with no warnings or errors
- desktop Chromium, genuine CT via `volumeAPI`: `Int16Array` scalar data, `SHORT` scalar texture, `FLOAT` opacity texture, visible pixels, no GL error or context loss
- iPhone 17 Pro simulator, iOS 26.1 Safari, genuine CT via `volumeAPI`: `Int16Array` scalar data, `SHORT` scalar texture, `UNSIGNED_BYTE` opacity texture, visible pixels, no GL error or context loss

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved volume rendering compatibility by selecting floating-point opacity textures only when the graphics environment supports both float textures and linear filtering.
  * Prevented unsupported texture configurations in WebGL 1 and WebGL 2 environments.

* **Tests**
  * Added coverage for supported and unsupported WebGL capability combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->