### PR TITLE
fix(core): re-apply invert after colormap when scrolling a stack

### DIFF
--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -995,6 +995,15 @@ class StackViewport extends Viewport {
 
     if (typeof colormap !== 'undefined') {
       this.setColormap(colormap);
+      // setColormap rebuilds the RGB transfer function in its default,
+      // non-inverted state, so `this.invert` no longer reflects the actor's
+      // actual LUT. Clear the tracked flag so the setInvertColor below actually
+      // re-applies the inversion instead of being skipped by its no-op guard
+      // (setInvertColorGPU only flips the TF when the requested value differs
+      // from this.invert). Without this, invert is lost when scrolling after a
+      // reset: reset applies a colormap, which is then re-applied on every
+      // scroll and clobbers the inversion.
+      this.invert = false;
     }
 
     this.setInterpolationType(interpolationType);

--- a/packages/core/test/stackViewport_gpu_render_test.js
+++ b/packages/core/test/stackViewport_gpu_render_test.js
@@ -26,7 +26,8 @@ const { cache, RenderingEngine, utilities, imageLoader, metaData, Enums } =
   cornerstone3D;
 
 const { Events, ViewportType, InterpolationType } = Enums;
-const { calibratedPixelSpacingMetadataProvider } = utilities;
+const { calibratedPixelSpacingMetadataProvider, transferFunctionUtils } =
+  utilities;
 
 const { fakeImageLoader, fakeMetaDataProvider, compareImages } = testUtils;
 
@@ -913,6 +914,55 @@ describe('renderingCore -- Stack', () => {
 
           done();
         })
+        .catch(done.fail);
+    });
+
+    it('Should preserve inversion when scrolling after resetProperties', function (done) {
+      testUtils.createViewports(renderingEngine, {
+        viewportId,
+        orientation: Enums.OrientationAxis.AXIAL,
+      });
+
+      const imageInfo = {
+        loader: 'fakeImageLoader',
+        name: 'imageURI',
+        rows: 64,
+        columns: 64,
+        barStart: 20,
+        barWidth: 5,
+        xSpacing: 1,
+        ySpacing: 1,
+        sliceIndex: 0,
+      };
+      const imageId1 = testUtils.encodeImageIdInfo(imageInfo);
+      const imageId2 = testUtils.encodeImageIdInfo({
+        ...imageInfo,
+        sliceIndex: 1,
+      });
+
+      const vp = renderingEngine.getViewport(viewportId);
+      const getTransferFunctionColors = () => {
+        const actor = vp.getDefaultActor().actor;
+        const transferFunction = actor.getProperty().getRGBTransferFunction(0);
+
+        return transferFunctionUtils
+          .getTransferFunctionNodes(transferFunction)
+          .map(([, red, green, blue]) => [red, green, blue]);
+      };
+
+      vp.setStack([imageId1, imageId2], 0)
+        .then(() => {
+          vp.resetProperties();
+          vp.setProperties({ invert: true });
+
+          const invertedColors = getTransferFunctionColors();
+
+          return vp.setImageIdIndex(1).then(() => {
+            expect(vp.getProperties().invert).toBe(true);
+            expect(getTransferFunctionColors()).toEqual(invertedColors);
+          });
+        })
+        .then(done)
         .catch(done.fail);
     });
 


### PR DESCRIPTION
## Context

Regression report: [OHIF/Viewers#6153](https://github.com/OHIF/Viewers/issues/6153) — *"After a reset, Invert is lost when scrolling between slices."*

Repro: open a stack study → Invert → Reset → Invert again (the current slice inverts) → scroll to another slice → **the invert is gone**.

## Root cause

Bisected to #2679, which added `setColormap(colormap)` (and VOILUTFunction/sharpening/smoothing) to `StackViewport._setPropertiesFromCache()` — the method that runs on every stack scroll.

- `_resetProperties()` calls `setColormap(matchedColormap)`, so **after a Reset `this.colormap` is defined** (before any reset it is `undefined`).
- Every subsequent scroll then calls `setColormap(this.colormap)` inside `_setPropertiesFromCache`, which **rebuilds the RGB transfer function in its default, non-inverted state**.
- The `setInvertColor(invert)` that follows is a **no-op**: `setInvertColorGPU` only flips the transfer function when the requested value differs from `this.invert` (`(!this.invert && invert) || (this.invert && !invert)`), and `this.invert` still holds the carried-over `true`. So the freshly rebuilt TF stays non-inverted and the inversion is silently dropped.

This is exactly why the loss appears **only after a reset** (that's what makes the colormap defined), and only did so after #2679 added the colormap re-application on scroll.

## Fix

In `_setPropertiesFromCache`, clear `this.invert` right after `setColormap(...)` so the tracked flag matches the rebuilt (non-inverted) transfer function. The subsequent `setInvertColor(invert)` — called with the desired value captured before the mutation — then actually re-applies the inversion instead of being skipped by the no-op guard. #2679's colormap preservation is retained.

## Testing

- Manual: Invert → Reset → Invert → scroll — inversion now persists across slices.
- Regression checks: Reset still restores defaults; a colormap set by the user still persists across scrolling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where image inversion could be lost when restoring cached viewport settings, ensuring inversion is correctly reapplied after colormap/transfer function restoration.
  * Added a regression test to confirm inversion remains enabled (and transfer-function colors stay consistent) when switching slices after `resetProperties()`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->