### PR TITLE
fix(tools): keep existing spline contour when drawing another contour

### DIFF
--- a/packages/tools/src/tools/annotation/SplineContourSegmentationTool.ts
+++ b/packages/tools/src/tools/annotation/SplineContourSegmentationTool.ts
@@ -3,6 +3,7 @@ import type { PublicToolProps } from '../../types';
 import SplineROITool from './SplineROITool';
 import { Events } from '../../enums';
 import { convertContourSegmentationAnnotation } from '../../utilities/contourSegmentation';
+import { getAnnotation } from '../../stateManagement/annotation/annotationState';
 
 class SplineContourSegmentationTool extends SplineROITool {
   static toolName = 'SplineContourSegmentationTool';
@@ -51,6 +52,20 @@ class SplineContourSegmentationTool extends SplineROITool {
     ) {
       return;
     }
+
+    // applyContourStroke already removes the source stroke and rebuilds the
+    // segment as PlanarFreehandContourSegmentationTool annotations. Converting
+    // the removed source again would add a second, same-geometry freehand
+    // contour. Under Clipper's EvenOdd fill rule those duplicates cancel out
+    // when the next stroke is applied, which makes the original spline vanish.
+    // Skip if the source annotation is no longer in the annotation state.
+    if (
+      !annotation?.annotationUID ||
+      !getAnnotation(annotation.annotationUID)
+    ) {
+      return;
+    }
+
     convertContourSegmentationAnnotation(annotation);
   }
 }


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

This PR fixes an issue in OHIF https://github.com/OHIF/Viewers/issues/6167

When the user draws a Spline contour, the contour disappears from the viewport as soon as another contour is drawn.

### Root cause 
- When `simplifiedSpline` is enabled, finishing a spline ran `applyContourStroke` (which already rebuilds the contour as freehand) and then `convertContourSegmentationAnnotation` again on the removed source annotation.
- That created a second identical freehand contour; on the next stroke, Clipper EvenOdd canceled the duplicates so the original spline disappeared.


<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

`SplineContourSegmentationTool.ts`: Skip the simplified-spline convert when the source annotation is no longer in state (the normal case after `applyContourStroke`).

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

1. Open a study in Segmentation mode
2. Select Contour panel and clicks on Add segmentation
3. Draw a contour using the Spline Contour tool.
4. Draw another spline contour in the same slice 
5. Confirm the first spline contour stays displayed

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: macOS 10.15.4
- [x] Node version: v24.18.0
- [x] Browser: Chrome 83.0.4103.116

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale or removed contour annotations from being converted after a cut or merge operation.
  * Improved stability by safely ignoring annotations that are no longer available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->