### PR TITLE
fix(synchronization): Slice Synchronization Fails for Series with Mismatched FOR

### DIFF
--- a/packages/core/src/utilities/calculateViewportsSpatialRegistration.ts
+++ b/packages/core/src/utilities/calculateViewportsSpatialRegistration.ts
@@ -27,11 +27,11 @@ function calculateViewportsSpatialRegistration(
   viewport1: IStackViewport | IVolumeViewport,
   viewport2: IStackViewport | IVolumeViewport
 ): void {
-  const imageId1 = viewport1.getSliceIndex();
-  const imageId2 = viewport2.getSliceIndex();
+  const imageId1 = viewport1.getImageIds()[0];
+  const imageId2 = viewport2.getImageIds()[0];
 
-  const imagePlaneModule1 = get('imagePlaneModule', imageId1.toString());
-  const imagePlaneModule2 = get('imagePlaneModule', imageId2.toString());
+  const imagePlaneModule1 = get('imagePlaneModule', imageId1);
+  const imagePlaneModule2 = get('imagePlaneModule', imageId2);
 
   if (!imagePlaneModule1 || !imagePlaneModule2) {
     console.log('Viewport spatial registration requires image plane module');


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

When two viewports have different `FrameOfReferenceUID`, scroll synchronization falls back to `calculateViewportsSpatialRegistration()` to align them using `imagePositionPatient`

This fallback was calling `viewport.getSliceIndex()` and passing the returned slice number as the `imageId` to `metaData.get(imagePlaneModule, imageId)`. Since a slice index is not a valid `imageId`, the metadata lookup returned undefined, so the spatial registration was silently skipped, breaking scroll sync whenever viewports belonged to different frames of reference. Sync only appeared to work when `FrameOfReferenceUID` was identical (or empty/undefined on both sides), because that path bypasses the fallback entirely.

The PR is incorporated by [FlyWheel.io](https://flywheel.io/).

Fixes: https://github.com/cornerstonejs/cornerstone3D/issues/2762

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

**File changed:** `calculateViewportsSpatialRegistration.ts`

- Replaced `viewport.getSliceIndex()` with `viewport.getImageIds()[0]` to get the imageId of each viewport.
- Passed this `imageId` directly to `metaData.get('imagePlaneModule', imageId)`, instead of the slice index.

**Result:** `imagePlaneModule` metadata now resolves correctly for both viewports, so the translation between `imagePositionPatient` values is calculated properly, and scroll synchronization works again for viewports with mismatched `FrameOfReferenceUID`.

**Before:**

https://github.com/user-attachments/assets/ad17110b-d296-4a36-b4fc-e7c04d3329b2

**After:**

https://github.com/user-attachments/assets/fb726e7c-63fb-4a91-9378-e6f3bcba4609

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

- Launch the OHIF Viewer using this study link: [OHIF Viewer Dev](https://viewer-dev.ohif.org/viewer?StudyInstanceUIDs=1.3.6.1.4.1.25403.345050719074.3824.20170125095438.5)
- Change the layout to a 2-viewport configuration (1x2 or 2x1).
- Load the following series into each viewport:
- Viewport 1: Body 3.0 CE
- Viewport 2: Body 5.0 Lung I+ CE
- Enable the Image Slice Sync tool.
- Scroll through the images in Viewport 1.
- Verify that Viewport 2 scrolls in sync with Viewport 1, matching the corresponding slice position.

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"--> Windows 11
- [x] "Node version: <!--[e.g. 16.14.0]"--> 22.19.0
- [x] "Browser: 150.0.7871.187
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spatial registration across viewports by using the active image identifiers directly.
  * Increased reliability when calculating image alignment and translation between viewports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->