### PR TITLE
feat(dicomImageLoader): add wasmBasePath option for codec binaries

### DIFF
--- a/packages/dicomImageLoader/src/__tests__/wasmBasePath.spec.ts
+++ b/packages/dicomImageLoader/src/__tests__/wasmBasePath.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * Unit tests for the codec WASM base path resolution.
+ *
+ * The decoders normally locate their binaries with a bare
+ * `@cornerstonejs/codec-...` specifier inside `new URL(..., import.meta.url)`,
+ * which bundlers do not rewrite. `wasmBasePath` lets an application point all
+ * of the codecs at one directory it serves itself. These tests pin down the
+ * joining rules (trailing slash, absolute/relative/full-URL roots) and the
+ * fallback to the decoder's built-in location when no base path is set.
+ */
+
+import {
+  getWasmBasePath,
+  resolveWasmUrl,
+  setWasmBasePath,
+  setWasmBasePathFromConfig,
+} from '../shared/wasmBasePath';
+
+const DEFAULT_URL = 'http://localhost/node_modules/codec/decodewasm';
+const FILE = 'charlswasm_decode.wasm';
+
+describe('wasmBasePath', () => {
+  afterEach(() => {
+    setWasmBasePath(undefined);
+  });
+
+  it('falls back to the decoder default when unset', () => {
+    expect(getWasmBasePath()).toBeUndefined();
+    expect(resolveWasmUrl(FILE, DEFAULT_URL)).toBe(DEFAULT_URL);
+  });
+
+  it('accepts a URL object as the default', () => {
+    const url = new URL(DEFAULT_URL);
+    expect(resolveWasmUrl(FILE, url)).toBe(url.toString());
+  });
+
+  it('appends the file name to an absolute base path', () => {
+    setWasmBasePath('/assets/cs-wasm/');
+    expect(resolveWasmUrl(FILE, DEFAULT_URL)).toBe(
+      `http://localhost/assets/cs-wasm/${FILE}`
+    );
+  });
+
+  it('adds a missing trailing slash', () => {
+    setWasmBasePath('/assets/cs-wasm');
+    expect(resolveWasmUrl(FILE, DEFAULT_URL)).toBe(
+      `http://localhost/assets/cs-wasm/${FILE}`
+    );
+  });
+
+  it('supports a full URL base path', () => {
+    setWasmBasePath('https://cdn.example.com/cs-wasm/');
+    expect(resolveWasmUrl(FILE, DEFAULT_URL)).toBe(
+      `https://cdn.example.com/cs-wasm/${FILE}`
+    );
+  });
+
+  it('resolves a relative base path against the current location', () => {
+    setWasmBasePath('cs-wasm/');
+    // jsdom serves the test at http://localhost/, so a relative root lands
+    // next to it. In the worker this is the worker script's directory, which
+    // is what the default import.meta.url resolution uses too.
+    expect(resolveWasmUrl(FILE, DEFAULT_URL)).toBe(
+      `http://localhost/cs-wasm/${FILE}`
+    );
+  });
+
+  it('uses one root for every codec', () => {
+    setWasmBasePath('/assets/cs-wasm/');
+    const files = [
+      'charlswasm_decode.wasm',
+      'libjpegturbowasm_decode.wasm',
+      'openjpegwasm_decode.wasm',
+      'openjphjs.wasm',
+    ];
+
+    expect(files.map((f) => resolveWasmUrl(f, DEFAULT_URL))).toEqual(
+      files.map((f) => `http://localhost/assets/cs-wasm/${f}`)
+    );
+  });
+
+  it('treats an empty base path as unset', () => {
+    setWasmBasePath('/assets/cs-wasm/');
+    setWasmBasePath('');
+    expect(getWasmBasePath()).toBeUndefined();
+    expect(resolveWasmUrl(FILE, DEFAULT_URL)).toBe(DEFAULT_URL);
+  });
+
+  describe('setWasmBasePathFromConfig', () => {
+    it('takes the path from a decode config', () => {
+      setWasmBasePathFromConfig({ wasmBasePath: '/assets/cs-wasm/' });
+      expect(getWasmBasePath()).toBe('/assets/cs-wasm/');
+    });
+
+    it('leaves the current path alone for a config without one', () => {
+      setWasmBasePath('/assets/cs-wasm/');
+      setWasmBasePathFromConfig({});
+      setWasmBasePathFromConfig(undefined);
+      expect(getWasmBasePath()).toBe('/assets/cs-wasm/');
+    });
+  });
+});

--- a/packages/dicomImageLoader/src/decodeImageFrameWorker.js
+++ b/packages/dicomImageLoader/src/decodeImageFrameWorker.js
@@ -15,6 +15,7 @@ import decodeJPEG2000 from './shared/decoders/decodeJPEG2000';
 import decodeHTJ2K from './shared/decoders/decodeHTJ2K';
 // Note that the scaling is pixel value scaling, which is applying a modality LUT
 import applyModalityLUT from './shared/scaling/scaleArray';
+import { setWasmBasePathFromConfig } from './shared/wasmBasePath';
 import getMinMax from './shared/getMinMax';
 import getPixelDataTypeFromMinMax, {
   validatePixelDataType,
@@ -362,6 +363,10 @@ export async function decodeImageFrame(
   callbackFn
 ) {
   const start = new Date().getTime();
+
+  // Apply the configured WASM base path before any codec initializes, so the
+  // decoders below resolve their binaries from it.
+  setWasmBasePathFromConfig(decodeConfig);
 
   let decodePromise = null;
 

--- a/packages/dicomImageLoader/src/decodeImageFrameWorker.js
+++ b/packages/dicomImageLoader/src/decodeImageFrameWorker.js
@@ -366,6 +366,15 @@ export async function decodeImageFrame(
 
   // Apply the configured WASM base path before any codec initializes, so the
   // decoders below resolve their binaries from it.
+  //
+  // A decodeConfig without wasmBasePath deliberately leaves the current value
+  // in place rather than clearing it - that stickiness is load-bearing. Every
+  // decoder calls its own initialize()/initLibjpegTurbo() with no arguments
+  // from decodeAsync, which passes undefined straight back into this setter; a
+  // reset there would wipe the path between here and the codec's first
+  // locateFile call, putting back the bare-specifier 404 the option fixes.
+  // The value is write-once in effect anyway, since initialize() returns early
+  // once its codec is instantiated.
   setWasmBasePathFromConfig(decodeConfig);
 
   let decodePromise = null;

--- a/packages/dicomImageLoader/src/imageLoader/createImage.ts
+++ b/packages/dicomImageLoader/src/imageLoader/createImage.ts
@@ -86,7 +86,13 @@ async function createImage(
     }
   }
 
-  const { decodeConfig } = getOptions();
+  const { decodeConfig, wasmBasePath } = getOptions();
+  // Forward the WASM base path to the worker, where the decoders resolve their
+  // binaries. The loader-level option wins over one set in decodeConfig.
+  const taskDecodeConfig =
+    wasmBasePath === undefined
+      ? decodeConfig
+      : { ...decodeConfig, wasmBasePath };
 
   // Remove any property of the `imageFrame` that cannot be transferred to the worker,
   // such as promises and functions.
@@ -106,7 +112,7 @@ async function createImage(
     pixelData,
     canvas,
     options,
-    decodeConfig
+    taskDecodeConfig
   );
 
   const isColorImage = isColorImageFn(imageFrame.photometricInterpretation);

--- a/packages/dicomImageLoader/src/shared/decoders/decodeHTJ2K.ts
+++ b/packages/dicomImageLoader/src/shared/decoders/decodeHTJ2K.ts
@@ -11,6 +11,7 @@ const openjphWasm = new URL(
 );
 
 import type { LoaderDecodeOptions } from '../../types';
+import { resolveWasmUrl, setWasmBasePathFromConfig } from '../wasmBasePath';
 
 const local: {
   codec: HTJ2KModule | undefined;
@@ -38,6 +39,7 @@ function calculateSizeAtDecompositionLevel(
 
 export function initialize(decodeConfig?: LoaderDecodeOptions): Promise<void> {
   local.decodeConfig = decodeConfig;
+  setWasmBasePathFromConfig(decodeConfig);
 
   if (local.codec) {
     return Promise.resolve();
@@ -46,7 +48,7 @@ export function initialize(decodeConfig?: LoaderDecodeOptions): Promise<void> {
   const openJphModule = openJphFactory({
     locateFile: (f) => {
       if (f.endsWith('.wasm')) {
-        return openjphWasm.toString();
+        return resolveWasmUrl('openjphjs.wasm', openjphWasm);
       }
 
       return f;

--- a/packages/dicomImageLoader/src/shared/decoders/decodeJPEG2000.ts
+++ b/packages/dicomImageLoader/src/shared/decoders/decodeJPEG2000.ts
@@ -20,6 +20,7 @@ const openjpegWasm = new URL(
 
 import type { Types } from '@cornerstonejs/core';
 import type { WebWorkerDecodeConfig } from '../../types';
+import { resolveWasmUrl, setWasmBasePathFromConfig } from '../wasmBasePath';
 
 const local: {
   codec: OpenJpegModule;
@@ -35,6 +36,7 @@ export function initialize(
   decodeConfig?: WebWorkerDecodeConfig
 ): Promise<void> {
   local.decodeConfig = decodeConfig;
+  setWasmBasePathFromConfig(decodeConfig);
 
   if (local.codec) {
     return Promise.resolve();
@@ -43,7 +45,7 @@ export function initialize(
   const openJpegModule = openJpegFactory({
     locateFile: (f) => {
       if (f.endsWith('.wasm')) {
-        return openjpegWasm.toString();
+        return resolveWasmUrl('openjpegwasm_decode.wasm', openjpegWasm);
       }
 
       return f;

--- a/packages/dicomImageLoader/src/shared/decoders/decodeJPEGBaseline8Bit.ts
+++ b/packages/dicomImageLoader/src/shared/decoders/decodeJPEGBaseline8Bit.ts
@@ -13,6 +13,8 @@ const libjpegTurboWasm = new URL(
   import.meta.url
 );
 import type { Types } from '@cornerstonejs/core';
+import type { LoaderDecodeOptions } from '../../types';
+import { resolveWasmUrl, setWasmBasePathFromConfig } from '../wasmBasePath';
 
 const local: {
   codec: OpenJpegModule;
@@ -22,7 +24,9 @@ const local: {
   decoder: undefined,
 };
 
-function initLibjpegTurbo(): Promise<void> {
+function initLibjpegTurbo(decodeConfig?: LoaderDecodeOptions): Promise<void> {
+  setWasmBasePathFromConfig(decodeConfig);
+
   if (local.codec) {
     return Promise.resolve();
   }
@@ -30,7 +34,7 @@ function initLibjpegTurbo(): Promise<void> {
   const libjpegTurboModule = libjpegTurboFactory({
     locateFile: (f) => {
       if (f.endsWith('.wasm')) {
-        return libjpegTurboWasm.toString();
+        return resolveWasmUrl('libjpegturbowasm_decode.wasm', libjpegTurboWasm);
       }
 
       return f;

--- a/packages/dicomImageLoader/src/shared/decoders/decodeJPEGLS.ts
+++ b/packages/dicomImageLoader/src/shared/decoders/decodeJPEGLS.ts
@@ -13,6 +13,7 @@ const charlsWasm = new URL(
 import type { ByteArray } from 'dicom-parser';
 import type { WebWorkerDecodeConfig } from '../../types';
 import type { Types } from '@cornerstonejs/core';
+import { resolveWasmUrl, setWasmBasePathFromConfig } from '../wasmBasePath';
 
 const local: {
   codec: CharlsModule;
@@ -34,6 +35,7 @@ export function initialize(
   decodeConfig?: WebWorkerDecodeConfig
 ): Promise<void> {
   local.decodeConfig = decodeConfig;
+  setWasmBasePathFromConfig(decodeConfig);
 
   if (local.codec) {
     return Promise.resolve();
@@ -42,7 +44,7 @@ export function initialize(
   const charlsModule = charlsFactory({
     locateFile: (f) => {
       if (f.endsWith('.wasm')) {
-        return charlsWasm.toString();
+        return resolveWasmUrl('charlswasm_decode.wasm', charlsWasm);
       }
 
       return f;

--- a/packages/dicomImageLoader/src/shared/wasmBasePath.ts
+++ b/packages/dicomImageLoader/src/shared/wasmBasePath.ts
@@ -1,0 +1,81 @@
+/**
+ * Resolves the URL of a codec's WASM binary.
+ *
+ * By default each decoder locates its binary with a `new URL(...)` call whose
+ * first argument is a bare `@cornerstonejs/codec-...` specifier. Bundlers do
+ * not rewrite bare specifiers there, so applications that bundle the loader
+ * have to patch the built worker to make the binaries resolvable.
+ *
+ * Setting a single base path avoids that: point it at one directory containing
+ * the codec binaries, and every decoder loads
+ * `<wasmBasePath>/<binary file name>` from it. There is deliberately no
+ * per-codec configuration - one root for all of them.
+ *
+ * The base path is set from the loader option of the same name (see
+ * `LoaderOptions.wasmBasePath`), which reaches the decode web worker through
+ * the per-task decode config.
+ */
+
+/** Base path for all codec WASM binaries, or undefined for the default. */
+let wasmBasePath: string | undefined;
+
+/**
+ * Sets the base path used to resolve every codec's WASM binary. Pass undefined
+ * (or an empty string) to restore the default `import.meta.url` resolution.
+ */
+export function setWasmBasePath(basePath?: string): void {
+  wasmBasePath = basePath || undefined;
+}
+
+/** Returns the configured base path, or undefined when unset. */
+export function getWasmBasePath(): string | undefined {
+  return wasmBasePath;
+}
+
+/**
+ * Sets the base path from a decode config, if it carries one. Configs without
+ * a `wasmBasePath` leave the current value alone, so a decode task cannot
+ * accidentally clear a path set elsewhere.
+ */
+export function setWasmBasePathFromConfig(
+  decodeConfig?: { wasmBasePath?: string } | undefined
+): void {
+  if (decodeConfig?.wasmBasePath !== undefined) {
+    setWasmBasePath(decodeConfig.wasmBasePath);
+  }
+}
+
+/**
+ * Resolves the URL to load a codec's WASM binary from.
+ *
+ * @param fileName - binary's file name, e.g. `charlswasm_decode.wasm`
+ * @param defaultUrl - the decoder's built-in `import.meta.url` based location,
+ *   used when no base path is configured
+ * @returns an absolute URL when one can be resolved, otherwise the joined path
+ */
+export function resolveWasmUrl(
+  fileName: string,
+  defaultUrl: URL | string
+): string {
+  if (!wasmBasePath) {
+    return defaultUrl.toString();
+  }
+
+  const base = wasmBasePath.endsWith('/') ? wasmBasePath : `${wasmBasePath}/`;
+  const path = `${base}${fileName}`;
+
+  // Resolve relative base paths against the current location, which is the
+  // worker script when decoding (matching what import.meta.url would give).
+  // Absolute paths and full URLs are unaffected by this.
+  const href = typeof self !== 'undefined' ? self.location?.href : undefined;
+
+  if (!href) {
+    return path;
+  }
+
+  try {
+    return new URL(path, href).toString();
+  } catch {
+    return path;
+  }
+}

--- a/packages/dicomImageLoader/src/types/LoaderDecodeOptions.ts
+++ b/packages/dicomImageLoader/src/types/LoaderDecodeOptions.ts
@@ -1,3 +1,9 @@
 export interface LoaderDecodeOptions {
-  // whatever
+  /**
+   * Base path the codec WASM binaries are loaded from, e.g. `/assets/cs-wasm/`
+   * or `https://cdn.example.com/cs-wasm/`. Applications normally set
+   * `LoaderOptions.wasmBasePath` instead; that value is forwarded here so it
+   * reaches the decode web worker.
+   */
+  wasmBasePath?: string;
 }

--- a/packages/dicomImageLoader/src/types/LoaderOptions.ts
+++ b/packages/dicomImageLoader/src/types/LoaderOptions.ts
@@ -30,6 +30,23 @@ export interface LoaderOptions {
   onprogress?: (event: ProgressEvent<EventTarget>, params: unknown) => void;
   errorInterceptor?: (error: LoaderXhrRequestError) => void;
   strict?: boolean;
+  /**
+   * Base path all codec WASM binaries are loaded from, e.g. `/assets/cs-wasm/`,
+   * `./cs-wasm/` or `https://cdn.example.com/cs-wasm/`. The directory must
+   * contain the codec binaries under their published file names:
+   * `charlswasm_decode.wasm`, `libjpegturbowasm_decode.wasm`,
+   * `openjpegwasm_decode.wasm` and `openjphjs.wasm`.
+   *
+   * This is a single root for every codec - there is no per-codec path. A
+   * relative path resolves against the decode worker's location.
+   *
+   * When unset, each decoder resolves its binary relative to its own module
+   * with a bare `@cornerstonejs/codec-...` specifier. Bundlers do not rewrite
+   * bare specifiers inside `new URL(...)`, so bundled applications should set
+   * this option and serve the binaries themselves (copying them at build time
+   * out of the `dist` directory of each `@cornerstonejs/codec-...` package).
+   */
+  wasmBasePath?: string;
   decodeConfig?: LoaderDecodeOptions;
   /**
    * When true, registers the legacy wadouri/wadors metadata providers.

--- a/packages/dicomImageLoader/src/types/WebWorkerTypes.ts
+++ b/packages/dicomImageLoader/src/types/WebWorkerTypes.ts
@@ -13,6 +13,11 @@ export interface WebWorkerOptions {
 export interface WebWorkerDecodeConfig {
   initializeCodecsOnStartup: boolean;
   strict?: boolean;
+  /**
+   * Base path the codec WASM binaries are loaded from. Forwarded from
+   * `LoaderOptions.wasmBasePath` with the decode task.
+   */
+  wasmBasePath?: string;
 }
 
 export interface WebWorkerTaskOptions {

--- a/packages/docs/docs/getting-started/vue-angular-react-vite.md
+++ b/packages/docs/docs/getting-started/vue-angular-react-vite.md
@@ -77,7 +77,7 @@ Here are some examples of how to use Cornerstone3D with React, Vue, Angular, and
 
 2. **Required setup:**
    - **Vite config:** Same as Vue: CommonJS plugin for `dicom-parser`, exclude `@cornerstonejs/dicom-image-loader` from `optimizeDeps`, include `dicom-parser`, and `worker: { format: 'es' }`. Optionally use a Cornerstone WASM plugin or `base` for subpath.
-   - **Subpath:** Set `base: '/subpath/'` in `vite.config.ts` (or from env) for build/preview under a subpath; optionally use `setConfiguration({ wasmBasePath })` or a plugin for WASM base path.
+   - **Subpath:** Set `base: '/subpath/'` in `vite.config.ts` (or from env) for build/preview under a subpath; serve the codec binaries yourself and point the loader at them with `init({ wasmBasePath })` (see [Codec WASM location](#codec-wasm-location)).
 
 3. **How to run:**
    - **Dev (root):** `npm run dev` → open http://localhost:5173/
@@ -94,6 +94,47 @@ Here are some examples of how to use Cornerstone3D with React, Vue, Angular, and
 | React (Vite) | `npm install` | `npm run dev` | `npm run build` | `npm run preview`                      |
 
 For subpath, use the `dev:subpath` / `build:subpath` / `preview:subpath` scripts where available (Vue, Angular) or set `base` in Vite config (React/Vue).
+
+---
+
+## Codec WASM location
+
+Each decoder locates its WASM binary with a bare `@cornerstonejs/codec-...` specifier inside `new URL(..., import.meta.url)`. Bundlers do not rewrite bare specifiers there, so in a bundled application the request goes to a path that does not exist — usually answered by the SPA fallback, which surfaces as:
+
+```
+CompileError: WebAssembly.instantiate(): expected magic word 00 61 73 6d, found 3c 21 64 6f
+```
+
+(`3c 21 64 6f` is `<!do` — the decoder received `index.html` instead of a binary.)
+
+Serve the binaries yourself and point the loader at them with `wasmBasePath`:
+
+```js
+import { init as dicomImageLoaderInit } from '@cornerstonejs/dicom-image-loader';
+
+dicomImageLoaderInit({
+  wasmBasePath: '/assets/cs-wasm/',
+});
+```
+
+That is a single root for every codec — there is no per-codec option. The directory must contain the four binaries under their published names, copied at build time out of the `dist` directory of each codec package:
+
+| File                           | Copy from                                 |
+| ------------------------------ | ----------------------------------------- |
+| `charlswasm_decode.wasm`       | `@cornerstonejs/codec-charls`             |
+| `libjpegturbowasm_decode.wasm` | `@cornerstonejs/codec-libjpeg-turbo-8bit` |
+| `openjpegwasm_decode.wasm`     | `@cornerstonejs/codec-openjpeg`           |
+| `openjphjs.wasm`               | `@cornerstonejs/codec-openjph`            |
+
+For a **subpath** deployment, include the base path. Deriving it from the document keeps one build working at any mount point:
+
+```js
+dicomImageLoaderInit({
+  wasmBasePath: new URL('assets/cs-wasm/', document.baseURI).href,
+});
+```
+
+A relative `wasmBasePath` resolves against the decode worker's location, and an absolute path or full URL (e.g. a CDN) is used as given. When the option is unset, the default `import.meta.url` resolution applies, which is what unbundled and script-tag usage relies on.
 
 ---
 

--- a/packages/docs/docs/getting-started/vue-angular-react-vite.md
+++ b/packages/docs/docs/getting-started/vue-angular-react-vite.md
@@ -35,6 +35,7 @@ Here are some examples of how to use Cornerstone3D with React, Vue, Angular, and
 2. **Required setup:**
    - **Vite config:** Use `@originjs/vite-plugin-commonjs` for `dicom-parser`, set `optimizeDeps.exclude: ['@cornerstonejs/dicom-image-loader']`, `optimizeDeps.include: ['dicom-parser']`, and `worker: { format: 'es' }`. See [Vite basic setup](#basic-setup) below.
    - **Subpath:** For running under a subpath (e.g. `/subpath/`), set `base` from `process.env.BASE_PATH` and use scripts like `dev:subpath` / `build:subpath` that set `BASE_PATH=/subpath/`. The Vue template uses `cross-env` for this.
+   - **Codec WASM:** Vite resolves the codec binaries on its own, so nothing is required here. Optionally set `init({ wasmBasePath })` to serve them from a location you choose, e.g. a CDN — see [Codec WASM location](#codec-wasm-location).
 
 3. **How to run:**
    - **Dev (root):** `npm run dev` → open http://localhost:5173/
@@ -54,6 +55,7 @@ Here are some examples of how to use Cornerstone3D with React, Vue, Angular, and
 2. **Required setup:**
    - **Postinstall / prebuild:** The project uses scripts to create Node stubs (`fs`/`path`) for the browser build and to bundle the DICOM image loader worker and copy codec WASM. These run on `npm install` and before `npm run build` (via `prebuild`). The **preview** script runs them before building so the production bundle has the worker and codecs.
    - **Serve:** In development, `@cornerstonejs/dicom-image-loader` is excluded from prebundle so the worker loads correctly.
+   - **Codec WASM:** Required here, unlike the Vite templates — the `application` builder uses esbuild, which does not resolve the codecs' bare specifiers. Point the loader at the copied binaries with `init({ wasmBasePath })`; see [Codec WASM location](#codec-wasm-location).
    - **Assets:** Codec `.wasm` files are copied from `node_modules` into the build via `angular.json` assets; the worker is generated into `public/cs-dicom-loader/` (and that folder is typically gitignored).
 
 3. **How to run:**
@@ -77,7 +79,8 @@ Here are some examples of how to use Cornerstone3D with React, Vue, Angular, and
 
 2. **Required setup:**
    - **Vite config:** Same as Vue: CommonJS plugin for `dicom-parser`, exclude `@cornerstonejs/dicom-image-loader` from `optimizeDeps`, include `dicom-parser`, and `worker: { format: 'es' }`. Optionally use a Cornerstone WASM plugin or `base` for subpath.
-   - **Subpath:** Set `base: '/subpath/'` in `vite.config.ts` (or from env) for build/preview under a subpath; serve the codec binaries yourself and point the loader at them with `init({ wasmBasePath })` (see [Codec WASM location](#codec-wasm-location)).
+   - **Subpath:** Set `base: '/subpath/'` in `vite.config.ts` (or from env) for build/preview under a subpath.
+   - **Codec WASM:** Vite resolves the codec binaries on its own, so nothing is required here. Optionally set `init({ wasmBasePath })` to serve them from a location you choose, e.g. a CDN — see [Codec WASM location](#codec-wasm-location).
 
 3. **How to run:**
    - **Dev (root):** `npm run dev` → open http://localhost:5173/
@@ -99,7 +102,17 @@ For subpath, use the `dev:subpath` / `build:subpath` / `preview:subpath` scripts
 
 ## Codec WASM location
 
-Each decoder locates its WASM binary with a bare `@cornerstonejs/codec-...` specifier inside `new URL(..., import.meta.url)`. Bundlers do not rewrite bare specifiers there, so in a bundled application the request goes to a path that does not exist — usually answered by the SPA fallback, which surfaces as:
+Each decoder locates its WASM binary with a bare `@cornerstonejs/codec-...` specifier inside `new URL(..., import.meta.url)`. Whether that needs any setup from you depends on the bundler:
+
+| Bundler               | Behavior                                                                                                       |
+| --------------------- | -------------------------------------------------------------------------------------------------------------- |
+| webpack 5             | Resolves the specifier through the package `exports` map and emits the binary as an asset. Nothing to do.      |
+| Vite / Rollup (build) | Same: resolves and emits the binary (or inlines it, when under the asset inline limit). Nothing to do.         |
+| esbuild               | Does **not** resolve it. `new URL(...)` is treated as ordinary code, so the bare specifier survives the build. |
+
+Angular's `application` builder is esbuild-based, so Angular applications are the common case that needs configuration. In Vite, keep `@cornerstonejs/dicom-image-loader` out of dev-time dependency optimization (the `optimizeDeps.exclude` above), because prebundling runs esbuild — that is the same limitation seen from the dev server.
+
+When the specifier is not resolved, the request goes to a path that does not exist — usually answered by the SPA fallback, which surfaces as:
 
 ```
 CompileError: WebAssembly.instantiate(): expected magic word 00 61 73 6d, found 3c 21 64 6f
@@ -116,6 +129,8 @@ dicomImageLoaderInit({
   wasmBasePath: '/assets/cs-wasm/',
 });
 ```
+
+Reach for this when your bundler does not resolve the specifiers (esbuild, so Angular), or when you want the binaries served from a location you control — a CDN, or a path that suits a subpath deployment — regardless of bundler.
 
 That is a single root for every codec — there is no per-codec option. The directory must contain the four binaries under their published names, copied at build time out of the `dist` directory of each codec package:
 


### PR DESCRIPTION
Each decoder locates its WASM binary with a bare `@cornerstonejs/codec-...` specifier inside `new URL(..., import.meta.url)`. Bundlers do not rewrite bare specifiers there, so bundled applications get a request for a path that does not exist - typically answered by the SPA fallback, surfacing as:

  CompileError: WebAssembly.instantiate(): expected magic word 00 61 73 6d,
  found 3c 21 64 6f            (3c 21 64 6f is "<!do")

The only fix available to consumers today is to post-process the built worker and rewrite those specifiers, which every bundler-based integration has to reinvent and which breaks silently whenever the decoders change.

Add a single `wasmBasePath` loader option instead:

  dicomImageLoaderInit({ wasmBasePath: '/assets/cs-wasm/' })

One root for all four codecs - deliberately no per-codec paths. The directory holds the binaries under their published file names. A relative path resolves against the decode worker's location; absolute paths and full URLs (e.g. a CDN) are used as given. When unset, the existing import.meta.url resolution applies, so unbundled and script-tag usage is unaffected.

The value reaches the decoders through the per-task decode config, and is applied before any codec initializes.

Also documents the option and replaces the docs reference to `setConfiguration({ wasmBasePath })`, which was never implemented.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable `wasmBasePath` to control where codec decoder WASM binaries are loaded from.
  * Forwarded the setting through the decode flow so it applies consistently across supported JPEG, JPEG-LS, and HTJ2K decoders.

* **Bug Fixes**
  * Improved WASM URL/base-path resolution to better handle unset values, absolute/relative paths, and missing trailing slashes.

* **Documentation**
  * Updated framework setup guidance (Vue/React/Vite and Angular) with clearer codec WASM hosting and `wasmBasePath` configuration.

* **Tests**
  * Added unit tests covering default behavior and multiple resolution scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->