### PR TITLE
fix(Stretch): Image aspect ratio resets to fit viewport when changing layout after calling setAspectRatio with isFitViewportAfterStretch disabled

### DIFF
--- a/packages/core/src/RenderingEngine/Viewport.ts
+++ b/packages/core/src/RenderingEngine/Viewport.ts
@@ -1266,7 +1266,7 @@ class Viewport {
       viewUp: viewUpToSet,
       clippingRange: clippingRangeToUse,
       aspectRatio: targetAspectRatio,
-      isFitViewportAfterStretch: false,
+      isFitViewportAfterStretch: previousCamera.isFitViewportAfterStretch,
     });
 
     const modifiedCamera = this.getCamera();
@@ -1504,6 +1504,16 @@ class Viewport {
   }
 
   /**
+   * Returns whether to change aspect ratio in anamorphic or not
+   *
+   * @returns change aspect ratio in anamorphic or not
+   */
+  public getIsFitViewportAfterStretch(): boolean {
+    const { isFitViewportAfterStretch } = this.getCamera();
+    return isFitViewportAfterStretch ?? false;
+  }
+
+  /**
    * Because the focalPoint is always in the centre of the viewport,
    * we must do planar computations if the frame (image "slice") is to be preserved.
    * 1. Calculate the intersection of the view plane with the imageData
@@ -1601,6 +1611,7 @@ class Viewport {
       viewAngle: vtkCamera.getViewAngle(),
       flipHorizontal: this.flipHorizontal,
       flipVertical: this.flipVertical,
+      isFitViewportAfterStretch: vtkCamera.getIsFitViewportAfterStretch(),
       aspectRatio: vtkCamera.getAspectRatio(),
     };
   }
@@ -1783,6 +1794,7 @@ class Viewport {
 
     if (aspectRatio) {
       this.setAspectRatioForVTKCamera(aspectRatio, isFitViewportAfterStretch);
+      vtkCamera.setIsFitViewportAfterStretch(isFitViewportAfterStretch);
     }
 
     // update clipping range only if focal point changed of a new actor is added
@@ -2254,7 +2266,7 @@ class Viewport {
       this.setDisplayArea(displayArea);
     }
     this.setZoom(zoom);
-    this.setAspectRatio(aspectRatio);
+    this.setAspectRatio(aspectRatio, this.getIsFitViewportAfterStretch());
     if (pan) {
       const [aspectX, aspectY] = aspectRatio;
       this.setPan([pan[0] * zoom * aspectX, pan[1] * zoom * aspectY] as Point2);

--- a/packages/core/src/RenderingEngine/Viewport.ts
+++ b/packages/core/src/RenderingEngine/Viewport.ts
@@ -1730,7 +1730,7 @@ class Viewport {
       flipVertical,
       clippingRange,
       aspectRatio,
-      isFitViewportAfterStretch,
+      isFitViewportAfterStretch: providedIsFitViewportAfterStretch,
     } = cameraInterface;
 
     // Note: Flip camera should be two separate calls since
@@ -1791,6 +1791,12 @@ class Viewport {
     if (clippingRange !== undefined) {
       vtkCamera.setClippingRange(clippingRange);
     }
+
+    const isFitViewportAfterStretch =
+      providedIsFitViewportAfterStretch ??
+      previousCamera.isFitViewportAfterStretch ??
+      true;
+    updatedCamera.isFitViewportAfterStretch = isFitViewportAfterStretch;
 
     if (aspectRatio) {
       this.setAspectRatioForVTKCamera(aspectRatio, isFitViewportAfterStretch);
@@ -2213,6 +2219,7 @@ class Viewport {
     }
     const currentAspectRatio = this.getAspectRatio();
     target.aspectRatio = currentAspectRatio;
+    target.isFitViewportAfterStretch = this.getIsFitViewportAfterStretch();
     if (pan) {
       const currentPan = this.getPan();
       const [aspectX, aspectY] = currentAspectRatio;
@@ -2261,12 +2268,13 @@ class Viewport {
       rotation,
       flipHorizontal = this.flipHorizontal,
       flipVertical = this.flipVertical,
+      isFitViewportAfterStretch = this.getIsFitViewportAfterStretch(),
     } = viewPres;
     if (displayArea !== this.getDisplayArea()) {
       this.setDisplayArea(displayArea);
     }
     this.setZoom(zoom);
-    this.setAspectRatio(aspectRatio, this.getIsFitViewportAfterStretch());
+    this.setAspectRatio(aspectRatio, isFitViewportAfterStretch);
     if (pan) {
       const [aspectX, aspectY] = aspectRatio;
       this.setPan([pan[0] * zoom * aspectX, pan[1] * zoom * aspectY] as Point2);

--- a/packages/core/src/RenderingEngine/vtkClasses/extendedVtkCamera.ts
+++ b/packages/core/src/RenderingEngine/vtkClasses/extendedVtkCamera.ts
@@ -26,6 +26,7 @@ interface ICameraInitialValues {
   physicalViewUp?: number[];
   physicalViewNorth?: number[];
   aspectRatio?: number[];
+  isFitViewportAfterStretch?: boolean;
 }
 
 declare module '@kitware/vtk.js/Rendering/Core/Camera' {
@@ -44,6 +45,18 @@ declare module '@kitware/vtk.js/Rendering/Core/Camera' {
      * @param aspectRatio - [scaleX, scaleY] stretch factors applied along the canvas X and Y axes
      */
     setAspectRatio(aspectRatio: [x: number, y: number]): boolean;
+
+    /**
+     *  Returns whether fit to viewport after stretch or not
+     *  @defaultValue true
+     */
+    getIsFitViewportAfterStretch(): boolean;
+
+    /**
+     * Set whether fit to viewport after stretch or not
+     * @param isFitViewportAfterStretch - Whether fit to viewport after stretch or not
+     */
+    setIsFitViewportAfterStretch(isFitViewportAfterStretch: boolean): void;
   }
 }
 
@@ -85,6 +98,14 @@ function extendedVtkCamera(publicAPI, model) {
 
   publicAPI.setAspectRatio = (aspectRatio) => {
     model.aspectRatio = aspectRatio;
+  };
+
+  publicAPI.getIsFitViewportAfterStretch = () => {
+    return model.isFitViewportAfterStretch;
+  };
+
+  publicAPI.setIsFitViewportAfterStretch = (isFitViewportAfterStretch) => {
+    model.isFitViewportAfterStretch = isFitViewportAfterStretch;
   };
 }
 

--- a/packages/core/src/RenderingEngine/vtkClasses/vtkSlabCamera.ts
+++ b/packages/core/src/RenderingEngine/vtkClasses/vtkSlabCamera.ts
@@ -759,6 +759,18 @@ export interface vtkSlabCamera extends vtkObject {
    * @param aspectRatio - aspectRatio of the viewport in x and y axis
    */
   setAspectRatio(aspectRatio: [x: number, y: number]): boolean;
+
+  /**
+   *  Returns whether fit to viewport after stretch or not
+   *  @defaultValue true
+   */
+  getIsFitViewportAfterStretch(): boolean;
+
+  /**
+   * Set whether fit to viewport after stretch or not
+   * @param isFitViewportAfterStretch - Whether fit to viewport after stretch or not
+   */
+  setIsFitViewportAfterStretch(isFitViewportAfterStretch: boolean): void;
 }
 
 const DEFAULT_VALUES = {

--- a/packages/core/src/types/IViewport.ts
+++ b/packages/core/src/types/IViewport.ts
@@ -349,6 +349,11 @@ export interface ViewPresentation {
    * The aspect ratio is how the viewport image is stretched and the default is [1,1].
    */
   aspectRatio?: Point2;
+
+  /**
+   * Whether to fit the viewport after stretching the aspect ratio.
+   */
+  isFitViewportAfterStretch?: boolean;
 }
 
 /**


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

`Viewport.setAspectRatio(aspectRatio, isFitViewportAfterStretch)` stretches the camera to a custom aspect ratio. When `isFitViewportAfterStretch` is false, the function must keep that stretched ratio, and the function must not fit the image back to the viewport borders. But earlier, no code saved the `isFitViewportAfterStretch` flag. `setAspectRatioForVTKCamera` used the flag one time for the calculation, and then the code discarded the flag. The VTK camera object had no memory of this flag.

Because of this, `resetCamera()` did not know that fit-after-stretch was disabled. `resetCamera()` used a fixed value `false` for `isFitViewportAfterStretch` when `resetCamera()` created the camera again. Also, `setViewPresentation()`, which restores the state of the layout, called `setAspectRatio()` without the second argument, and the default value set the behaviour back to fit-to-viewport. So, the custom aspect ratio went back to the fit-viewport behaviour at each change of the layout.

The PR is incorporated by [FlyWheel.io](https://flywheel.io/).

Fixes: https://github.com/cornerstonejs/cornerstone3D/issues/2830

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

#### The first implementation

The first implementation saved the flag on the camera.

**File changed:**
1. `extendedVtkCamera.ts`
  - Added `getIsFitViewportAfterStretch()` and `setIsFitViewportAfterStretch()` to the custom VTK camera interface and implementation. The flag was saved directly on the camera model itself as `model.isFitViewportAfterStretch`.
2. `vtkSlabCamera.ts`
  - Added matching `getIsFitViewportAfterStretch()` and `setIsFitViewportAfterStretch()` type declarations to the `vtkSlabCamera` interface.
3. `RenderingEngine/Viewport.ts`
  - Added `getIsFitViewportAfterStretch()` on `Viewport`, which reads the flag from `getCamera()` (defaults to `false` if not set).
  - `getCameraNoRotation()` included `isFitViewportAfterStretch: vtkCamera.getIsFitViewportAfterStretch()` in the returned camera state, so the flag stayed available through `getCamera()`.
  - `setCamera()` called `vtkCamera.setIsFitViewportAfterStretch(isFitViewportAfterStretch)` whenever the aspect ratio was applied, and saved the flag on the VTK camera.
  - `resetCamera()` used `previousCamera.isFitViewportAfterStretch` instead of the fixed value `false` when it created the camera again, and kept the stretch mode that was active before.
  - `setViewPresentation()` called `this.setAspectRatio(aspectRatio, this.getIsFitViewportAfterStretch())` instead of skipping the second argument, so the restore of the layout also respected the saved flag.

#### The issues with the first implementation

`isFitViewportAfterStretch` is not a property of a camera. The flag selects between two calculations during one transition from an old aspect ratio to a new aspect ratio. A camera holds an aspect ratio and a `parallelScale`. A camera does not hold the method that gave the camera those two values.

That one decision gave four problems:

- `DEFAULT_VALUES` in `extendedVtkCamera.ts` had no entry for the flag, and `macro.setGet` had no entry for the flag. A camera that no code configured therefore returned `undefined`.
- The code read that same `undefined` as `false` in `getIsFitViewportAfterStretch()`, and as `true` in `setCamera`, in `setAspectRatio` and in `setAspectRatioForVTKCamera`.
- The CPU path did not make a round trip of the flag. `getCameraCPU()` did not return the flag, and `setCameraCPU()` did not store the flag. `getIsFitViewportAfterStretch()` therefore always returned `false` for a CPU stack viewport.
- A `setCamera()` call that had no `aspectRatio` lost the flag, because the code wrote the flag to the VTK camera inside the `if (aspectRatio)` block only.

The first implementation also kept a second effect of the setter. The fit branch of `setAspectRatioForVTKCamera` multiplied the camera `parallelScale` by a fit factor, and the branch multiplied `initialCamera.parallelScale` and `fitToCanvasCamera.parallelScale` by the same factor. Those two values are the baselines of `getZoom()` and `setZoom()`. A setter for the aspect ratio therefore changed the meaning of every zoom value that came after the setter. PR #2443 added that calculation, and `resetCamera` already owns those baselines.

#### The current implementation

No code stores the flag. `setAspectRatio` only stretches the image, and `resetCamera` does the fit.

**Files changed:**
1. `RenderingEngine/Viewport.ts`
  - `resetCamera` calculates `parallelScale` from the stretched width of the image. The calculation uses `targetAspectRatio`, and `resetCamera({ resetZoom: true })` therefore fits a stretched image.
  - `setAspectRatio(value, storeAsInitialCamera)` only sets the aspect ratio. The function does not change `parallelScale`, `initialCamera` or `fitToCanvasCamera`.
  - `setCamera` gives the aspect ratio to the VTK camera, and `setCamera` does nothing else with the aspect ratio.
  - `setViewPresentation` sets the aspect ratio first, and sets the zoom second.
  - `setAspectRatioForVTKCamera` and `getIsFitViewportAfterStretch` are removed.
2. `RenderingEngine/StackViewport.ts`
  - `setAspectRatioForViewport` only sets the aspect ratio.
  - The new function `getFitParallelScaleCPU` holds the fit calculation of the CPU path.
  - `resetCameraCPU` uses that calculation, and `resetCameraCPU` accepts the option `resetAspectRatio`.
3. `extendedVtkCamera.ts` and `vtkSlabCamera.ts`
  - `getIsFitViewportAfterStretch()` and `setIsFitViewportAfterStretch()` are removed.
4. `types/ICamera.ts` and `types/IViewport.ts`
  - `isFitViewportAfterStretch` is removed from `ICamera` and from `ViewPresentation`.
5. `examples/axisBasedImageStretching` and `examples/calibrationTools`
  - The examples call `resetCamera` after `setAspectRatio` when a fit is necessary.

**Breaking change:** the second argument of `setAspectRatio` was `isFitViewportAfterStretch`, and the second argument is now `storeAsInitialCamera`. A caller that gave `true` for a fit must now call `resetCamera` after `setAspectRatio`.

**Result:**
`setAspectRatio` stretches the image, and `setAspectRatio` keeps the zoom. `resetCamera({ resetZoom: true })` fits the stretched image. A view presentation records the stretch and the zoom as two independent values, and a restore of the presentation writes both values without a new fit calculation. The image therefore keeps the stretch across a reset of the camera and across a change of the layout, and the image no longer goes back to the fit-viewport behaviour.

**Before**

https://github.com/user-attachments/assets/eacd05c8-ac6c-4b52-9e85-d18a98a7e617

**After**

https://github.com/user-attachments/assets/41437432-ebf0-45c2-9f77-5097b3ec9f15

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

These steps use the example `packages/tools/examples/axisBasedImageStretching` of this repository. A link with the OHIF viewer is not necessary, and a new function is not necessary.

1. Run `yarn dev` in the root of the repository.
2. Open the example `axisBasedImageStretching` in the browser.
3. Clear the checkbox `Fit to Viewport after stretch`. The checkbox controls the call of `resetCamera` after `viewport.setAspectRatio()`.
4. Select the value `2:1` in the aspect ratio dropdown. The image gets the stretch, and the image keeps the zoom.
5. Select a value in the `Rotation` dropdown. The `Rotation` dropdown calls `viewport.setViewPresentation()`, and a change of the layout calls the same function.
6. Verify that the image keeps the stretch of step 4 and the zoom of step 4.
7. Set the checkbox `Fit to Viewport after stretch`. Select a different aspect ratio, and then select a different rotation. Verify that the image fits the borders of the viewport.

To test the CPU rendering path, add `?useCpu=true` to the URL of the example. Repeat step 3 and step 4, and then scroll the stack. Each scroll of the stack reads the view presentation and writes the view presentation back. Verify that the image keeps the stretch of step 4.

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"--> Windows 11
- [x] "Node version: <!--[e.g. 16.14.0]"--> 22.19.0
- [x] "Browser: 150.0.7871.187
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved image fitting when applying non-uniform aspect-ratio stretching.
  - Reset Zoom now accounts for horizontal and vertical stretch differences to fit the image correctly within the viewport.
  - Applying an aspect-ratio change preserves the current zoom level instead of automatically refitting the image.
  - Saved view presentations now apply their recorded zoom after aspect-ratio adjustments, ensuring the expected zoom is restored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->