### PR TITLE
chore(dependencies): remove unused uuid dependency from dicomImageLoader

### DIFF
--- a/packages/dicomImageLoader/.webpack/webpack-base.js
+++ b/packages/dicomImageLoader/.webpack/webpack-base.js
@@ -30,7 +30,6 @@ module.exports = {
   devtool: 'source-map',
   externals: [
     '@cornerstonejs/core',
-    'uuid',
     {
       'dicom-parser': {
         commonjs: 'dicom-parser',

--- a/packages/dicomImageLoader/package.json
+++ b/packages/dicomImageLoader/package.json
@@ -118,8 +118,7 @@
     "comlink": "4.4.2",
     "dicom-parser": "1.8.21",
     "jpeg-lossless-decoder-js": "2.1.2",
-    "pako": "2.1.0",
-    "uuid": "9.0.1"
+    "pako": "2.1.0"
   },
   "devDependencies": {
     "@cornerstonejs/core": "5.6.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -506,9 +506,6 @@ importers:
       pako:
         specifier: 2.1.0
         version: 2.1.0
-      uuid:
-        specifier: 9.0.1
-        version: 9.0.1
     devDependencies:
       '@cornerstonejs/core':
         specifier: 5.6.12


### PR DESCRIPTION
### Context

`uuid` is listed in `packages/dicomImageLoader`'s `dependencies` (and in the UMD build's webpack `externals`), but it is never imported anywhere in `src` or `test`. A monorepo-wide search confirms no other package relies on it either — `@cornerstonejs/core` has its own `uuidv4()` implementation based on `crypto.randomUUID()` and does not use this package.

### Changes & Results

- Removed `uuid` from `packages/dicomImageLoader/package.json` dependencies
- Removed `'uuid'` from `packages/dicomImageLoader/.webpack/webpack-base.js` externals
- Updated `pnpm-lock.yaml` accordingly (minimal diff, other `uuid@*` transitive resolutions used by unrelated packages are untouched)

### Testing

- `pnpm install --frozen-lockfile` — passes
- `pnpm run build` (full monorepo, including `dicomImageLoader`'s `build:loader`) — passes
- `pnpm run test:unit` (Jest) — 113/113 suites, 1816/1820 tests passed
- `pnpm run test:ci` (Karma, includes wadouri/wadors coverage) — 0 failures, 232 assertions passed

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments, etc.)

#### Public Documentation Updates

- [x] Not applicable — no public API change.

#### Tested Environment

- [x] "OS: macOS 15 (Darwin 24.6.0)"
- [x] "Node version: 24.14.1"
- [x] "Browser: Chrome Headless (karma test:ci)"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused runtime dependency, with no expected changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->