### PR TITLE
preserve WSI viewport zoom level on resize and fullscreen

### DIFF
--- a/packages/core/src/RenderingEngine/WSIViewport.ts
+++ b/packages/core/src/RenderingEngine/WSIViewport.ts
@@ -70,6 +70,12 @@ class WSIViewport extends Viewport {
     zoom: 1,
   };
 
+  // Fit-relative zoom preserved across resize / full screen (see
+  // resize()). 1 = fit-to-container. _wsiZoomClamped tracks whether the
+  // view clamped the resolution, so the next resize keeps the target.
+  private _wsiZoomTarget = 1;
+  private _wsiZoomClamped = false;
+
   private viewer: WSIViewerLike;
   private annotationRemovedListener: EventListener = (evt: Event) => {
     const { detail } = evt as CustomEvent<{
@@ -443,12 +449,59 @@ class WSIViewport extends Viewport {
 
   public resize = (): void => {
     const canvas = this.canvas;
+    // Previous CSS-pixel size. This method always sets canvas.width/
+    // height to clientWidth/clientHeight (unscaled), so these hold the
+    // prior client size and stay in the same coordinate system as the
+    // new clientWidth/clientHeight below (DPR-independent ratio).
+    const oldWidth = canvas.width;
+    const oldHeight = canvas.height;
     const { clientWidth, clientHeight } = canvas;
 
-    // Set the canvas to be same resolution as the client.
     if (canvas.width !== clientWidth || canvas.height !== clientHeight) {
       canvas.width = clientWidth;
       canvas.height = clientHeight;
+    }
+    // Preserve fit-relative zoom across resize / full screen so the
+    // slide is not left zoomed. Skip re-deriving the target after a
+    // clamp, else a clamped resolution would ratchet the zoom.
+    const map = this.map;
+    const view = map?.getView?.();
+    if (map && view && clientWidth > 0 && clientHeight > 0) {
+      const extent = view.getProjection().getExtent();
+      if (!this._wsiZoomClamped && oldWidth > 0 && oldHeight > 0) {
+        const oldResolution = view.getResolution();
+        const oldFit = view.getResolutionForExtent(extent, [
+          oldWidth,
+          oldHeight,
+        ]);
+        if (
+          isFinite(oldFit) &&
+          isFinite(oldResolution) &&
+          oldResolution > 0
+        ) {
+          this._wsiZoomTarget = oldFit / oldResolution;
+        }
+      }
+      map.updateSize();
+      const newFit = view.getResolutionForExtent(extent, [
+        clientWidth,
+        clientHeight,
+      ]);
+      const target = this._wsiZoomTarget;
+      if (
+        isFinite(newFit) &&
+        newFit > 0 &&
+        isFinite(target) &&
+        target > 0
+      ) {
+        const desired = newFit / target;
+        view.setResolution(desired);
+        // Remember if the view clamped the resolution to its allowed
+        // range, so the next resize keeps the intended target.
+        const actual = view.getResolution();
+        this._wsiZoomClamped =
+          Math.abs(actual - desired) > 1e-6 * Math.max(1, desired);
+      }
     }
     this.refreshRenderValues();
   };


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

Problem
When a WSI (Whole Slide Imaging) viewport container is resized — e.g. toggling full screen, dragging a panel divider, or a responsive layout change — the zoom level resets to fit-to-slide. Users lose their current zoom position and have to re-navigate.



### Changes & Results

Track the user's zoom as a ratio relative to the fit-to-container resolution (_wsiZoomTarget). On resize():

Derive the current fit-relative zoom from the old container size before updating.
Call map.updateSize() to let OpenLayers know about the new dimensions.
Compute the new fit resolution for the updated container and apply the preserved zoom target.
Detect if OpenLayers clamped the resolution to its min/max range (_wsiZoomClamped) so subsequent resizes don't ratchet the target.


### Testing
Resize the browser window while zoomed into a WSI slide — zoom level is preserved.
Toggle full screen — same zoom level maintained.
Zoom to maximum resolution, then resize — clamped state is respected without drift.
<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved zoom levels when resizing the viewport or switching to fullscreen.
  * Prevented unintended zoom drift when the viewport dimensions change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->