### PR TITLE
fix(examples): import addButtonToToolbar in calibrationTools example

### DIFF
--- a/packages/tools/examples/calibrationTools/index.ts
+++ b/packages/tools/examples/calibrationTools/index.ts
@@ -8,6 +8,7 @@ import {
   initDemo,
   createImageIdsAndCacheMetaData,
   setTitleAndDescription,
+  addButtonToToolbar,
   addDropdownToToolbar,
   viewportId,
   renderingEngineId,


### PR DESCRIPTION
The calibrationTools example called addButtonToToolbar() for the three rotation buttons but never imported it, so the module threw a ReferenceError during evaluation. Because the throw happened at module scope, run() never executed and initDemo() never ran -- which in turn left the DICOM image loaders unregistered, so clicking the already rendered "Local file" button failed with "No image loader found for scheme dicomfile".

Adding the missing import fixes both symptoms.

Fixes #1320 

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing


### 1. Example loads (direct regression check)

- [ ] Open the example. DevTools console shows **no** `ReferenceError` and **no** `pageerror`.
- [ ] A CT image renders in the viewport.
- [ ] The toolbar has **7** controls: `Local file` button, tool dropdown, calibration dropdown, aspect dropdown, and the three buttons `Rotate Random`, `Rotate Absolute 0`, `Rotate Delta 30`.

The three rotate buttons are the ones that disappeared under the bug — if you see 4 controls instead of 7, the fix isn't in the build you're looking at.

Two console errors from dcmjs (`Invalid vr type xs - using US`, `Invalid vr type ox - using OW`) are pre-existing and unrelated. Ignore them.

### 2. Calibration changes measurements (DICOMweb stack)

- [ ] With `Length` selected, drag a horizontal line across the image. Note the value — call it the baseline, in `mm`.
- [ ] Step the calibration dropdown through the options below. Each one updates the **existing** annotation immediately; no redraw required.

| Dropdown option | Expected unit | Expected value |
| --- | --- | --- |
| `Default` | `mm` | baseline |
| `User Calibration 0.5` | `mm User` | 4× the `ERMF 2` value |
| `ERMF 2` | `mm ERMF` | 1× (the smallest) |
| `Error 1` | `mm Error` | 2× the `ERMF 2` value |
| `px units` | `px` | number unchanged, unit switches |

The absolute numbers depend on the image's `PixelSpacing`, so the stable check is the **4 : 2 : 1 ratio** between `User Calibration 0.5`, `Error 1`, and `ERMF 2`, plus the unit suffix changing on each. Reference run against the default CT series (`PixelSpacing` 0.9765625):

```
baseline              195.3124 mm
User Calibration 0.5  400.0000 mm User
ERMF 2                100.0000 mm ERMF
Error 1               200.0000 mm Error
px units              195.3124 px
Default               195.3124 mm     <- reverts cleanly
```

- [ ] Selecting `Default` at the end returns the measurement to the baseline value and `mm` unit.


### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Examples**
  - Updated the calibration tools example to include the toolbar button helper.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->