### PR TITLE
fix(adapters): do not drop segmentation slices when merging sparse segment data

### DIFF
--- a/packages/adapters/src/adapters/Cornerstone3D/Segmentation/compactMergeSegData.ts
+++ b/packages/adapters/src/adapters/Cornerstone3D/Segmentation/compactMergeSegData.ts
@@ -46,20 +46,34 @@ export const compactMergeSegmentDataWithoutInformationLoss = ({
       continue;
     }
 
-    largerArray.forEach((_, currentImageIndex) => {
+    // Iterate the index RANGE rather than one array's populated entries.
+    //
+    // getSegmentData() builds its result as a SPARSE array — segmentData[i] is assigned
+    // only for images that actually hold voxels — and Array.prototype.forEach SKIPS HOLES.
+    // Iterating `largerArray` therefore visited only the indices where that array had an
+    // element. When the existing layer is the longer one, `largerArray` IS the existing
+    // layer, so every image where only the INCOMING segment had data was never visited,
+    // and was silently dropped.
+    const mergeLength = Math.max(
+      currentTestedArray.length,
+      newSegmentData.length
+    );
+
+    for (
+      let currentImageIndex = 0;
+      currentImageIndex < mergeLength;
+      currentImageIndex++
+    ) {
       const originalImagePixelData = currentTestedArray[currentImageIndex];
       const newImagePixelData = newSegmentData[currentImageIndex];
 
-      if (
-        (!originalImagePixelData && !newImagePixelData) ||
-        !newImagePixelData
-      ) {
-        return;
+      if (!newImagePixelData) {
+        continue;
       }
 
       if (!originalImagePixelData) {
         currentTestedArray[currentImageIndex] = newImagePixelData;
-        return;
+        continue;
       }
 
       const mergedPixelData = originalImagePixelData.map(
@@ -70,7 +84,7 @@ export const compactMergeSegmentDataWithoutInformationLoss = ({
       );
 
       currentTestedArray[currentImageIndex] = mergedPixelData;
-    });
+    }
     return;
   }
 

--- a/packages/adapters/test/compactMergeSegData.jest.js
+++ b/packages/adapters/test/compactMergeSegData.jest.js
@@ -161,4 +161,37 @@ describe('compactMergeSegmentDataWithoutInformationLoss', () => {
       ],
     ]);
   });
+
+  // getSegmentData() assigns only the indices that hold voxels, so its result is a SPARSE
+  // array (real holes), not a dense one containing `undefined`. That distinction matters:
+  // Array.prototype.forEach visits an `undefined` ELEMENT but skips a HOLE. Every test above
+  // uses dense arrays, so none of them exercise this.
+  it('should keep new data at indices the existing layer does not span (sparse arrays)', () => {
+    // Existing layer holds images 3..4 — length 5, holes at 0..2.
+    const existingLayer = [];
+    existingLayer[3] = [1, 0];
+    existingLayer[4] = [1, 0];
+
+    // New segment holds images 1..3 — length 4, so the EXISTING layer is the longer one
+    // and becomes `largerArray`. Indices 1 and 2 are outside the existing layer's
+    // populated set and used to be dropped.
+    const newSegmentData = [];
+    newSegmentData[1] = [0, 2];
+    newSegmentData[2] = [0, 2];
+    newSegmentData[3] = [0, 2];
+
+    const arrayOfSegmentData = [existingLayer];
+
+    compactMergeSegmentDataWithoutInformationLoss({
+      arrayOfSegmentData,
+      newSegmentData,
+    });
+
+    // Merged into the single existing layer, keeping every image from both.
+    expect(arrayOfSegmentData).toHaveLength(1);
+    expect(arrayOfSegmentData[0][1]).toEqual([0, 2]);
+    expect(arrayOfSegmentData[0][2]).toEqual([0, 2]);
+    expect(arrayOfSegmentData[0][3]).toEqual([1, 2]);
+    expect(arrayOfSegmentData[0][4]).toEqual([1, 0]);
+  });
 });


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->

### Context

Fixes #2846.

`getSegmentData()` in `labelmapImagesFromBuffer.ts` builds its result as a **sparse** array — `segmentData[i]` is assigned only for images that actually hold voxels:

```js
if (hasWrittenSegmentationData) {
  segmentData[currentLabelMapImageIndex] = segmentationDataForImageId;
}
```

`compactMergeSegmentDataWithoutInformationLoss` then merged two of those arrays with `largerArray.forEach(...)`. **`Array.prototype.forEach` skips holes**, so the merge only visited indices where `largerArray` had an element. When the existing layer is the longer of the two, `largerArray` **is** that layer — and every image where only the *incoming* segment had data was never visited, and was silently discarded.

It surfaces when two segments do **not** collide in-plane (so they merge into one layer instead of being pushed as separate layers) **and** the incoming segment extends beyond the existing layer's populated index range.

Observed on a 694-slice CT: segment A spanned images `[375..525]` (length 526), segment B spanned `[241..453]` (length 454). B merged into A's layer, `largerArray` became A, and B came back as only `[375..453]` — **213 slices reduced to 79**. Reloading a saved DICOM-SEG returned a truncated mask, and re-exporting wrote the truncation back, so the loss compounded on every save/reload cycle. Nothing raised an error.

A detail that makes this recognisable: the survivor is always `A.start..B.end`, regardless of how far B extends below `A.start`. Masks of 134 and 213 slices both collapsed to exactly 79, which is what made the symptom look so strange from the outside.

### Changes & Results

- `compactMergeSegData.ts`: iterate the index **range** (`Math.max` of both lengths) instead of one array's populated entries.
- `checkHasOverlapping` iterates the same way but is **correct** and is deliberately left unchanged: an overlap requires both arrays to be populated at the same index, so a hole can never be an overlap.
- Added a regression test.

**Before / after** (the new test case):

```
FAIL  should keep new data at indices the existing layer does not span (sparse arrays)
      expected [0,2], got undefined
```
```
PASS  should keep new data at indices the existing layer does not span (sparse arrays)
```

Downstream verification in our application (OHIF-based): reloading the affected DICOM-SEG and re-exporting is now **byte-identical** to the original — 1428/1428 frames, 13/13 segments, zero differing pixels, compared per (segment label + referenced source SOP instance). Before the fix the same round trip returned 79 of 213 slices for the affected segment.

### Testing

```
cd packages/adapters && yarn test -- compactMergeSegData
```

Nine cases: the eight existing ones plus the new sparse-array case. The new case fails on `main` and passes with this change; the existing eight are unaffected either way.

Worth noting why this was not already covered: every existing case uses **dense** arrays. `[undefined, [0, 1]]` holds an `undefined` *element*, which `forEach` **does** visit — that is materially different from a hole, which it skips. The new test builds sparse arrays the way `getSegmentData()` actually does.

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

- [x] The documentation page has been updated as necessary for any public API
  additions or removals. <!-- no public API change -->

#### Tested Environment

- [x] "OS: Ubuntu 22.04 (Linux 5.15)"
- [x] "Node version: 24.2.0"
- [x] "Browser: Chrome 13x (downstream verification in an OHIF 3.x viewer)"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved segmentation data merging when image data contains gaps or sparse entries.
  * Preserved newly received voxel data while continuing to merge overlapping image data correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->