### PR TITLE
fix(wsi): stop mouse events leaking from overview map to tools

### DIFF
--- a/packages/core/src/RenderingEngine/WSIViewport.ts
+++ b/packages/core/src/RenderingEngine/WSIViewport.ts
@@ -612,6 +612,16 @@ class WSIViewport extends Viewport {
       bindings: {},
     });
 
+    // Block interactions over the overview map from reaching tool handlers
+    // on the viewport element. getOverlayContainerStopEvent()
+    // returns OL's internal reference, available before render() is called.
+    const controlContainer = viewer.getMap().getOverlayContainerStopEvent();
+    ['pointerdown', 'mousedown', 'dblclick', 'wheel'].forEach((eventType) => {
+      controlContainer.addEventListener(eventType, (event) => {
+        event.stopPropagation();
+      });
+    });
+
     // Render viewer instance in the "viewport" HTML element
     viewer.render({ container: this.microscopyElement });
 


### PR DESCRIPTION
### Context

When a WSI viewport is loaded, `@cornerstonejs/tools` attaches raw DOM listeners (`mousedown`, `dblclick`, `pointerdown`) to the viewport element. The `VolumeImageViewer` from `dicom-microscopy-viewer` renders an OpenLayers overview map (minimap) inside that same element. Because the minimap is a child of the viewport element, mouse events on it bubble up and fire CS3D tool handlers (e.g. pan, annotations). This is unwanted behaviour, interaction within the minimap should stay within that container.

### Changes & Results

In `WSIViewport.setWSI()`, immediately after constructing the `VolumeImageViewer`, attach `stopPropagation` listeners on the OL overlay container using the public API `map.getOverlayContainerStopEvent()`. This element is created synchronously in the OL `Map` constructor, so it is available before `viewer.render()` is called.

**Before:** Clicking on the WSI minimap triggers CS3D tool handlers.  
**After:** Interactions with the minimap are contained within the overview map and do not reach the tool handlers.

### Testing

1. Open a WSI image, with the overview minimap visible. 
2. Make sure the minimap overlaps the image within the viewport. Resize the viewport/browser if needed.
3. Click and drag inside the minimap with the panning tool - the main viewport should not pan.
4. Place a point annotation within the minimap - no annotation should be created.
5. Interactions on the main viewport outside the minimap should work as normal.

### Checklist

#### PR

- [X] My Pull Request title is descriptive, accurate and follows the semantic-release format and guidelines.

#### Code

- [X] My code has been well-documented (function documentation, inline comments, etc.)

#### Public Documentation Updates

- [X] The documentation page has been updated as necessary for any public API additions or removals.

#### Tested Environment

- [X] "OS: Windows 11"
- [X] "Node version: 24.16.0"
- [X] "Browser: Chrome 151.0.7922.108"
