### PR TITLE
fix(core): keep the camera finite for single-slice volumes

### DIFF
--- a/packages/core/src/utilities/snapFocalPointToSlice.ts
+++ b/packages/core/src/utilities/snapFocalPointToSlice.ts
@@ -26,6 +26,24 @@ export default function snapFocalPointToSlice(
 ): { newFocalPoint: Point3; newPosition: Point3 } {
   const { min, max, current } = sliceRange;
 
+  // A single-slice volume collapses the range to zero, which makes the fraction
+  // below 0 / 0 = NaN. That NaN reaches newFocalPoint and newPosition, and a camera
+  // whose focal point and position are both NaN has no direction of projection at
+  // all: vtk.js falls back to its default axial direction while the view up stays on
+  // the acquisition plane, leaving a basis that spans no plane and renders nothing.
+  // There is no slice to snap to in that case, so leave the camera alone.
+  // getVolumeViewportScrollInfo guards the same degenerate range.
+  if (
+    max - min === 0 ||
+    !Number.isFinite(spacingInNormalDirection) ||
+    spacingInNormalDirection === 0
+  ) {
+    return {
+      newFocalPoint: [...focalPoint] as Point3,
+      newPosition: [...position] as Point3,
+    };
+  }
+
   // Get the current offset off the camera position so we can add it on at the end.
   const posDiffFromFocalPoint = vec3.create();
 

--- a/packages/core/src/utilities/snapFocalPointToSlice.ts
+++ b/packages/core/src/utilities/snapFocalPointToSlice.ts
@@ -26,18 +26,32 @@ export default function snapFocalPointToSlice(
 ): { newFocalPoint: Point3; newPosition: Point3 } {
   const { min, max, current } = sliceRange;
 
+  // How many steps there are in this direction. Computed before the guard below
+  // because the guard tests it.
+  const steps = Math.round((max - min) / spacingInNormalDirection);
+
   // A single-slice volume collapses the range to zero, which makes the fraction
   // below 0 / 0 = NaN. That NaN reaches newFocalPoint and newPosition, and a camera
   // whose focal point and position are both NaN has no direction of projection at
   // all: vtk.js falls back to its default axial direction while the view up stays on
   // the acquisition plane, leaving a basis that spans no plane and renders nothing.
   // There is no slice to snap to in that case, so leave the camera alone.
-  // getVolumeViewportScrollInfo guards the same degenerate range.
-  if (
-    max - min === 0 ||
-    !Number.isFinite(spacingInNormalDirection) ||
-    spacingInNormalDirection === 0
-  ) {
+  //
+  // The test is on `steps` rather than only on the raw range because getSliceRange
+  // measures that range by rotating the volume's corners until the normal points at
+  // +X and taking min/max of the X components. The rotation is the identity only for
+  // an axis-aligned positive normal; for an antiparallel or oblique one its
+  // off-diagonal terms are ~1e-16, so the coplanar corners of a one-slice volume come
+  // out differing in the last bits and the range is something like 3e-14 rather than
+  // 0. `steps` rounds both shapes of it to 0.
+  //
+  // `!(spacingInNormalDirection > 0)` folds together zero, negative, NaN and
+  // undefined spacing, which produce the same NaN by a different route. It is needed
+  // in its own right, since `steps` is NaN when spacing is and `NaN <= 0` is false.
+  //
+  // getVolumeViewportScrollInfo and getPlanarVolumeSliceNavigationState guard the
+  // same degenerate range; all three agree on what "can't scroll" means.
+  if (steps <= 0 || max - min === 0 || !(spacingInNormalDirection > 0)) {
     return {
       newFocalPoint: [...focalPoint] as Point3,
       newPosition: [...position] as Point3,
@@ -48,9 +62,6 @@ export default function snapFocalPointToSlice(
   const posDiffFromFocalPoint = vec3.create();
 
   vec3.sub(posDiffFromFocalPoint, position as vec3, focalPoint as vec3);
-
-  // Now we can see how many steps there are in this direction
-  const steps = Math.round((max - min) / spacingInNormalDirection);
 
   // Find out current frameIndex
   const fraction = (current - min) / (max - min);

--- a/packages/core/test/snapFocalPointToSlice.jest.js
+++ b/packages/core/test/snapFocalPointToSlice.jest.js
@@ -45,11 +45,29 @@ describe('snapFocalPointToSlice', () => {
   // vtk.js falls back to its default axial direction while the view up stays on the
   // acquisition plane - a basis that spans no plane, which renders nothing and logs
   // "WebGL: INVALID_VALUE: uniformMatrix3fv: no array".
+  //
+  // getSliceRange does not measure that range along the normal directly - it rotates
+  // the volume's eight corners until the normal points at +X and takes min/max of the
+  // X components. That rotation is the identity only for an axis-aligned positive
+  // normal; for an antiparallel normal like [0, 0, -1], or any oblique one, its
+  // off-diagonal terms are ~1e-16 and the four coplanar corners come out differing in
+  // the last bits. A single-slice volume then reports a range of ~1e-14 rather than 0,
+  // so the guard has to be on the step count, not on an exact zero range.
   describe('with a degenerate slice range', () => {
     it.each([
       ['a single-slice volume', { min: 5, max: 5, current: 5 }, 1],
+      // The residue a non-identity rotation leaves on a one-slice volume.
+      [
+        'a single slice under a rotated normal',
+        { min: 5, max: 5 + 3e-14, current: 5 },
+        1,
+      ],
+      // Spacing wider than the range rounds to zero steps just the same.
+      ['spacing wider than the range', { min: 0, max: 0.4, current: 0 }, 1],
       ['zero spacing', { min: 0, max: 10, current: 0 }, 0],
+      ['negative spacing', { min: 0, max: 10, current: 0 }, -1],
       ['non-finite spacing', { min: 0, max: 10, current: 0 }, NaN],
+      ['undefined spacing', { min: 0, max: 10, current: 0 }, undefined],
     ])('returns the camera unchanged for %s', (_label, sliceRange, spacing) => {
       const { newFocalPoint, newPosition } = snapFocalPointToSlice(
         focalPoint,

--- a/packages/core/test/snapFocalPointToSlice.jest.js
+++ b/packages/core/test/snapFocalPointToSlice.jest.js
@@ -1,0 +1,96 @@
+import snapFocalPointToSlice from '../src/utilities/snapFocalPointToSlice';
+
+describe('snapFocalPointToSlice', () => {
+  const focalPoint = [0, 0, 0];
+  const position = [0, 0, 100];
+  const viewPlaneNormal = [0, 0, 1];
+
+  describe('with a scrollable volume', () => {
+    const sliceRange = { min: 0, max: 10, current: 0 };
+
+    it('dollies the focal point and position by the requested number of frames', () => {
+      const { newFocalPoint, newPosition } = snapFocalPointToSlice(
+        focalPoint,
+        position,
+        sliceRange,
+        viewPlaneNormal,
+        1,
+        2
+      );
+
+      expect(newFocalPoint).toEqual([0, 0, 2]);
+      // The camera keeps its original offset from the focal point.
+      expect(newPosition).toEqual([0, 0, 102]);
+    });
+
+    it('leaves the camera where it is for a zero delta', () => {
+      const { newFocalPoint, newPosition } = snapFocalPointToSlice(
+        focalPoint,
+        position,
+        sliceRange,
+        viewPlaneNormal,
+        1,
+        0
+      );
+
+      expect(newFocalPoint).toEqual([0, 0, 0]);
+      expect(newPosition).toEqual([0, 0, 100]);
+    });
+  });
+
+  // A single-image series produces a volume one slice thick, so the slice range
+  // collapses to min === max === current. Without a guard, `(current - min) /
+  // (max - min)` is 0 / 0 = NaN, and the NaN reaches both returned points. A camera
+  // whose focal point and position are both NaN has no direction of projection, so
+  // vtk.js falls back to its default axial direction while the view up stays on the
+  // acquisition plane - a basis that spans no plane, which renders nothing and logs
+  // "WebGL: INVALID_VALUE: uniformMatrix3fv: no array".
+  describe('with a degenerate slice range', () => {
+    it.each([
+      ['a single-slice volume', { min: 5, max: 5, current: 5 }, 1],
+      ['zero spacing', { min: 0, max: 10, current: 0 }, 0],
+      ['non-finite spacing', { min: 0, max: 10, current: 0 }, NaN],
+    ])('returns the camera unchanged for %s', (_label, sliceRange, spacing) => {
+      const { newFocalPoint, newPosition } = snapFocalPointToSlice(
+        focalPoint,
+        position,
+        sliceRange,
+        viewPlaneNormal,
+        spacing,
+        0
+      );
+
+      expect(newFocalPoint).toEqual(focalPoint);
+      expect(newPosition).toEqual(position);
+    });
+
+    it('never returns NaN components, whatever delta is asked for', () => {
+      const { newFocalPoint, newPosition } = snapFocalPointToSlice(
+        focalPoint,
+        position,
+        { min: 5, max: 5, current: 5 },
+        viewPlaneNormal,
+        1,
+        3
+      );
+
+      [...newFocalPoint, ...newPosition].forEach((component) => {
+        expect(Number.isFinite(component)).toBe(true);
+      });
+    });
+
+    it('returns copies so the caller cannot mutate the camera it passed in', () => {
+      const { newFocalPoint, newPosition } = snapFocalPointToSlice(
+        focalPoint,
+        position,
+        { min: 5, max: 5, current: 5 },
+        viewPlaneNormal,
+        1,
+        0
+      );
+
+      expect(newFocalPoint).not.toBe(focalPoint);
+      expect(newPosition).not.toBe(position);
+    });
+  });
+});


### PR DESCRIPTION
## Context

A viewport showing a single-image series (a scout / topogram) goes black as soon as a second actor is mounted onto it — in our case a segmentation labelmap — and logs:

```
WebGL: INVALID_VALUE: uniformMatrix3fv: no array
```

The slice indicator also reads an out-of-range index, e.g. `536/512`, because the slice count is being measured along the wrong axis.

## Root cause

`snapFocalPointToSlice` locates the current frame with

```js
const fraction = (current - min) / (max - min);
```

A volume one slice thick collapses the slice range to `min === max === current`, so this is `0 / 0` → `NaN`. The clamps below it do not catch it, because `NaN > steps` and `NaN < 0` are both false, so the NaN reaches every component of `newFocalPoint` and `newPosition`.

`setViewReference` hands those straight to `setCamera`, which only sets focal point and position — but vtk.js derives the view plane normal from `position − focalPoint`. With both NaN there is no direction of projection, so the camera falls back to the default axial direction. The view up is never touched and stays on the acquisition plane, leaving a normal and an up that are **parallel**: a basis that spans no plane, hence the unbuildable view matrix and the blank viewport.

## How it is reached

`Viewport.addActors` snapshots the view reference, resets the camera, then replays the reference:

```js
const prevViewRef = this.getViewReference();
this.resetCamera();
this.setViewReference(prevViewRef);      // ← reorients the camera to NaN
this.setViewPresentation(prevViewPresentation);
```

The replayed reference names the plane the viewport is *already* on, so this should be a no-op for orientation. On a single-slice volume it silently moves the camera off the acquisition plane instead. Mounting any second actor is enough to trigger it.

Instrumented trace of the moment it breaks, on a sagittal scout:

```
[cs-camera] addActors:captured   normal=[1,0,0] viewUp=[0,0,1]
[cs-camera] setCamera plane [1,0,0] -> [0,0,-1] | BECAME DEGENERATE
    normal=[0,0,-1] viewUp=[0,0,1]  *** DEGENERATE ***
  setCamera        @ BaseVolumeViewport
  setViewReference @ BaseVolumeViewport
  addActors        @ Viewport
```

## The fix

There is no slice to snap to when the range is degenerate, so return the camera unchanged rather than computing `0 / 0`. `getVolumeViewportScrollInfo` already guards the same zero range for the scroll-step calculation; this is the sibling case that was missed.

Also guards zero and non-finite `spacingInNormalDirection`, which produce the same NaN by a different route.

## Tests

`packages/core/test/snapFocalPointToSlice.jest.js` — 7 cases. Verified that the four degenerate-range cases fail against `main` and pass with the fix, while the two normal scrolling cases are unaffected either way.

Found and verified against a real study in an OHIF-based viewer (contributed by U. Calgary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focal-point snapping when scrolling is unavailable, ranges are degenerate, or spacing values are invalid.
  * Prevented non-finite coordinates and preserved valid camera and focal-point positions in these cases.

* **Tests**
  * Added coverage for normal scrolling, zero movement, invalid spacing, degenerate ranges, finite results, and safe result copying.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->