### PR TITLE
fix(dicomImageLoader): update CSP-safe codecs

### DIFF
--- a/packages/dicomImageLoader/package.json
+++ b/packages/dicomImageLoader/package.json
@@ -111,10 +111,10 @@
     "prepublishOnly": "pnpm run build:loader"
   },
   "dependencies": {
-    "@cornerstonejs/codec-charls": "1.2.3",
-    "@cornerstonejs/codec-libjpeg-turbo-8bit": "1.2.2",
-    "@cornerstonejs/codec-openjpeg": "1.3.0",
-    "@cornerstonejs/codec-openjph": "2.4.7",
+    "@cornerstonejs/codec-charls": "1.2.5",
+    "@cornerstonejs/codec-libjpeg-turbo-8bit": "1.2.4",
+    "@cornerstonejs/codec-openjpeg": "1.3.2",
+    "@cornerstonejs/codec-openjph": "2.4.9",
     "comlink": "4.4.2",
     "dicom-parser": "1.8.21",
     "jpeg-lossless-decoder-js": "2.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -486,17 +486,17 @@ importers:
   packages/dicomImageLoader:
     dependencies:
       '@cornerstonejs/codec-charls':
-        specifier: 1.2.3
-        version: 1.2.3
+        specifier: 1.2.5
+        version: 1.2.5
       '@cornerstonejs/codec-libjpeg-turbo-8bit':
-        specifier: 1.2.2
-        version: 1.2.2
+        specifier: 1.2.4
+        version: 1.2.4
       '@cornerstonejs/codec-openjpeg':
-        specifier: 1.3.0
-        version: 1.3.0
+        specifier: 1.3.2
+        version: 1.3.2
       '@cornerstonejs/codec-openjph':
-        specifier: 2.4.7
-        version: 2.4.7
+        specifier: 2.4.9
+        version: 2.4.9
       comlink:
         specifier: 4.4.2
         version: 4.4.2
@@ -2070,10 +2070,24 @@ packages:
       }
     engines: { node: '>=0.14' }
 
+  '@cornerstonejs/codec-charls@1.2.5':
+    resolution:
+      {
+        integrity: sha512-BoENE2cXfzQ2RMxPfMMJxyv7E78iErTCB8b8lod/qv3dsYfCmSOUQKiRsuOZJM24JrjCFnyzbkxhAnF8gAKQnQ==,
+      }
+    engines: { node: '>=0.14' }
+
   '@cornerstonejs/codec-libjpeg-turbo-8bit@1.2.2':
     resolution:
       {
         integrity: sha512-aAUMK2958YNpOb/7G6e2/aG7hExTiFTASlMt/v90XA0pRHdWiNg5ny4S5SAju0FbIw4zcMnR0qfY+yW3VG2ivg==,
+      }
+    engines: { node: '>=0.14' }
+
+  '@cornerstonejs/codec-libjpeg-turbo-8bit@1.2.4':
+    resolution:
+      {
+        integrity: sha512-k5e2/EjE9gV7dkg2x3CzId6mp6P7tTya/AmnLzbN3fZTW6skTMrOTJfqowgGQBzX7styLdcsnjlqwEVqeqaaHQ==,
       }
     engines: { node: '>=0.14' }
 
@@ -2084,10 +2098,24 @@ packages:
       }
     engines: { node: '>=0.14' }
 
+  '@cornerstonejs/codec-openjpeg@1.3.2':
+    resolution:
+      {
+        integrity: sha512-IsvhGRZ/3LzoNQFyAsKKzPw/S769b9JrKhpufU8uEEalOBn+D1OLetzZ48pvpbwxR4J7ZFrnK0FBIYtl8Hdt9Q==,
+      }
+    engines: { node: '>=0.14' }
+
   '@cornerstonejs/codec-openjph@2.4.7':
     resolution:
       {
         integrity: sha512-qvP4q4JDib7mi9r7LqKOwqz7YZ8gjtDX4ZCezeYf8+eb7MBXCz5uXAMeVF3yz9Axw4XiIMdB/pqXkm8tqCl13w==,
+      }
+    engines: { node: '>=0.14' }
+
+  '@cornerstonejs/codec-openjph@2.4.9':
+    resolution:
+      {
+        integrity: sha512-iUGvF8r4SMHFrHGjwhNsTlHDPm+fIcGw3fUYm4vzhsf2J6VR9DqHtynXwUVOCBMSG9YTyWkcsD4db++0kMffMw==,
       }
     engines: { node: '>=0.14' }
 
@@ -21364,11 +21392,19 @@ snapshots:
 
   '@cornerstonejs/codec-charls@1.2.3': {}
 
+  '@cornerstonejs/codec-charls@1.2.5': {}
+
   '@cornerstonejs/codec-libjpeg-turbo-8bit@1.2.2': {}
+
+  '@cornerstonejs/codec-libjpeg-turbo-8bit@1.2.4': {}
 
   '@cornerstonejs/codec-openjpeg@1.3.0': {}
 
+  '@cornerstonejs/codec-openjpeg@1.3.2': {}
+
   '@cornerstonejs/codec-openjph@2.4.7': {}
+
+  '@cornerstonejs/codec-openjph@2.4.9': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -104,4 +104,8 @@ allowBuilds:
   unrs-resolver: false
 
 minimumReleaseAgeExclude:
+  - '@cornerstonejs/codec-charls@1.2.5'
+  - '@cornerstonejs/codec-libjpeg-turbo-8bit@1.2.4'
+  - '@cornerstonejs/codec-openjpeg@1.3.2'
+  - '@cornerstonejs/codec-openjph@2.4.9'
   - ip-address@10.5.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -91,7 +91,8 @@ auditConfig:
     # docs build time on repo-committed images — never on untrusted input.
     - GHSA-w3rx-r6r6-pgpr
     - GHSA-5p2g-fcmc-qvqq
-
+    # extract-zip is a transitive dependency of puppeteer and is only used in dev
+    - GHSA-jmr9-qjv8-65gv
 allowBuilds:
   '@swc/core': true
   canvas: true


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->

### Context

The DICOM image loader's WebAssembly codecs were generated with Emscripten Embind output that used dynamic `Function` construction. Applications enforcing a production Content Security Policy without `unsafe-eval` could therefore fail when a decoder initialized.

The codec packages now generate CSP-safe Embind adapters upstream in cornerstonejs/codecs#85. This PR consumes those published artifacts in Cornerstone3D.

### Changes & Results

- Update `@cornerstonejs/codec-charls` from `1.2.3` to `1.2.5`.
- Update `@cornerstonejs/codec-libjpeg-turbo-8bit` from `1.2.2` to `1.2.4`.
- Update `@cornerstonejs/codec-openjpeg` from `1.3.0` to `1.3.2`.
- Update `@cornerstonejs/codec-openjph` from `2.4.7` to `2.4.9`.
- Add exact-version `minimumReleaseAgeExclude` entries so CI can install these newly published, explicitly reviewed packages without weakening the age policy for any future version.

The installed codec JavaScript no longer contains `eval`, direct or constructed `Function`, or the Emscripten `newFunc(Function, ...)` pattern.

### Testing

- `pnpm install --frozen-lockfile`
- `pnpm --filter @cornerstonejs/dicom-image-loader... run build`
- `pnpm exec jest packages/dicomImageLoader/src/__tests__/wasmBasePath.spec.ts --runInBand` (10 tests passed)
- Scanned all installed codec `dist/*.js` files for CSP-unsafe dynamic-code patterns.

The legacy `build:umd:bundle` target has the same existing `url` polyfill and `812.bundle.min.js` parser failures on this branch and untouched `main`; the dependency update does not introduce those failures.

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the semantic-release format and guidelines.

#### Code

- [x] No application code changed; dependency pins and the lockfile document the update.

#### Public Documentation Updates

- [x] No public API was added or removed, so documentation changes are not required.

#### Tested Environment

- [x] OS: macOS
- [x] Node version: 24.18.0
- [x] Browser: Not applicable; dependency, build, and generated-artifact validation only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated DICOM image codec components to newer versions.
  * Improved compatibility and reliability when decoding supported image formats.
  * Refined release configuration to support smoother delivery of codec updates.

* **Bug Fixes**
  * Addressed issues that could affect image decoding across supported DICOM formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->