### PR TITLE
fix(dicomImageLoader): ignore windowing/VOI tags when decoding color images

### DIFF
--- a/packages/dicomImageLoader/src/imageLoader/createImage.ts
+++ b/packages/dicomImageLoader/src/imageLoader/createImage.ts
@@ -33,14 +33,6 @@ async function createImage(
   // in cs3d
   const useRGBA = options.useRGBA;
 
-  // always preScale the pixel array unless it is asked not to
-  options.preScale = {
-    enabled:
-      options.preScale && options.preScale.enabled !== undefined
-        ? options.preScale.enabled
-        : true,
-  };
-
   if (!pixelData?.length) {
     return Promise.reject(new Error('The pixel data is missing'));
   }
@@ -49,6 +41,18 @@ async function createImage(
   const canvas = document.createElement('canvas');
   const imageFrame = getImageFrame(imageId);
   imageFrame.decodeLevel = options.decodeLevel;
+
+  const isColorImage = isColorImageFn(imageFrame.photometricInterpretation);
+
+  // always preScale the pixel array unless it is asked not to, or if the image
+  // is not grayscale (DICOM PS3.3 C.11.2.1.2.2).
+  options.preScale = {
+    enabled:
+      !isColorImage &&
+      (options.preScale && options.preScale.enabled !== undefined
+        ? options.preScale.enabled
+        : true),
+  };
 
   options.allowFloatRendering = canRenderFloatTextures();
 
@@ -114,8 +118,6 @@ async function createImage(
     options,
     taskDecodeConfig
   );
-
-  const isColorImage = isColorImageFn(imageFrame.photometricInterpretation);
 
   return new Promise<DICOMLoaderIImage | Types.IImageFrame>(
     (resolve, reject) => {
@@ -390,12 +392,9 @@ async function createImage(
           columns: imageFrame.columns,
           height: imageFrame.rows,
           preScale: imageFrame.preScale,
-          intercept: modalityLutModule.rescaleIntercept
-            ? modalityLutModule.rescaleIntercept
-            : 0,
-          slope: modalityLutModule.rescaleSlope
-            ? modalityLutModule.rescaleSlope
-            : 1,
+          // Ignore rescale/intercept if the image is not monochrome (DICOM PS3.3 C.11.2.1.2.2)
+          intercept: isColorImage ? 0 : modalityLutModule.rescaleIntercept || 0,
+          slope: isColorImage ? 1 : modalityLutModule.rescaleSlope || 1,
           invert: imageFrame.photometricInterpretation === 'MONOCHROME1',
           minPixelValue: imageFrame.smallestPixelValue,
           maxPixelValue: imageFrame.largestPixelValue,
@@ -411,11 +410,15 @@ async function createImage(
           windowWidth: voiLutModule.windowWidth
             ? voiLutModule.windowWidth[0]
             : undefined,
+          // Ignore the VOI descriptors if the image is not monochrome (DICOM
+          // PS3.3 C.11.2.1.2.2). StackViewport reads voiLUTSequence off the
+          // image to derive the initial VOI range, so a stale grayscale LUT
+          // would put it nowhere near the [0, 255] range of the color samples.
           voiLUTFunction:
-            (voiLutModule.voiLUTFunction?.length &&
+            !isColorImage ? ((voiLutModule.voiLUTFunction?.length &&
               voiLutModule.voiLUTFunction[0]) ||
             voiLutModule.voiLutFunction ||
-            undefined,
+            undefined) : undefined,
           decodeTimeInMS: imageFrame.decodeTimeInMS,
           floatPixelData: undefined,
           imageFrame,
@@ -477,8 +480,10 @@ async function createImage(
           };
         }
 
-        // Modality LUT
+        // Modality LUT, skipped for non-monochrome images for the same reason
+        // the rescale slope/intercept is skipped above.
         if (
+          !isColorImage &&
           modalityLutModule.modalityLUTSequence &&
           modalityLutModule.modalityLUTSequence.length > 0 &&
           isModalityLUTForDisplay(sopCommonModule.sopClassUID)
@@ -486,8 +491,9 @@ async function createImage(
           image.modalityLUT = modalityLutModule.modalityLUTSequence[0];
         }
 
-        // VOI LUT
+        // VOI LUT, also skipped for non-monochrome images.
         if (
+          !isColorImage &&
           voiLutModule.voiLUTSequence &&
           voiLutModule.voiLUTSequence.length > 0
         ) {


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

Section PS3.3 C.11.2.1.2.2 of the DICOM standard states:

The Window Center (0028,1050), Window Width (0028,1051) and VOI LUT Function (0028,1056) shall be used only for Images with Photometric Interpretation (0028,0004) Values of MONOCHROME1 and MONOCHROME2. They have no meaning for other Images.

Having those tags is still legal, they should just be ignored when rendering the image.

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

Fix the DICOM image loader to ignore rescale/interecept tags + disable prescaling for non-monochrome images. "non-monochrome" is approximated as "isColorImageFn returns false", let me know if you'd rather match explicitly on the photometric interpretation values.

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

With the test file attached

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- OS: macOS 26.6.1
- NodeJS: 22.22.2
- Browser: Firefox 153.0.3

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of color images during image loading.
  * Disabled inappropriate pre-scaling for color images to preserve accurate display.
  * Ensured color images use identity intensity values while monochrome images retain their modality-based scaling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->