### PR TITLE
fix(ai): resolve the ONNX wasm directory against the app, not the route

### DIFF
--- a/packages/ai/src/ONNXSegmentationController.ts
+++ b/packages/ai/src/ONNXSegmentationController.ts
@@ -14,6 +14,7 @@ import {
   LabelmapBaseTool,
 } from '@cornerstonejs/tools';
 import { Events as aiEvents } from './enums';
+import getOrtWasmPaths from './utils/getOrtWasmPaths';
 
 const { strategies } = cstSegmentation;
 const { fillInsideCircle } = strategies;
@@ -1641,7 +1642,13 @@ export default class ONNXSegmentationController {
     }
     config.threads = parseInt(String(config.threads));
     config.local = parseInt(config.local);
-    ort.env.wasm.wasmPaths = 'ort/';
+    // Leave a location the application configured alone — it may be serving
+    // the binaries from a CDN or a versioned path. Otherwise resolve the
+    // copy of `onnxruntime-web/dist` against the application rather than
+    // against the current route. See `getOrtWasmPaths`.
+    if (!ort.env.wasm.wasmPaths) {
+      ort.env.wasm.wasmPaths = getOrtWasmPaths();
+    }
     ort.env.wasm.numThreads = config.threads;
     ort.env.wasm.proxy = config.provider == 'wasm';
 

--- a/packages/ai/src/utils/getOrtWasmPaths.ts
+++ b/packages/ai/src/utils/getOrtWasmPaths.ts
@@ -44,6 +44,19 @@ function getBundlePublicPath(): string | undefined {
 }
 
 /**
+ * The base a bundler anchors its emitted asset URLs to. This is the definition
+ * webpack and rspack generate for `__webpack_require__.b`, which is what
+ * `new URL(<specifier>, import.meta.url)` compiles down to — so the runtime
+ * binaries end up resolved against the same base as the codec wasm.
+ */
+function getDocumentBase(): string | undefined {
+  return (
+    (typeof document !== 'undefined' && document.baseURI) ||
+    globalThis.location?.href
+  );
+}
+
+/**
  * Absolute URL prefix for the ONNX Runtime wasm binaries.
  *
  * @param directory - directory holding `onnxruntime-web/dist`, relative to the
@@ -54,17 +67,17 @@ function getBundlePublicPath(): string | undefined {
 export default function getOrtWasmPaths(
   directory = DEFAULT_ORT_WASM_DIRECTORY
 ): string {
-  const base = getBundlePublicPath() ?? globalThis.document?.baseURI;
-  const documentHref = globalThis.location?.href;
+  const documentBase = getDocumentBase();
+  const base = getBundlePublicPath() ?? documentBase;
 
-  if (!base || !documentHref) {
+  if (!base || !documentBase) {
     return directory;
   }
 
   try {
-    // The public path is often origin-relative (`/pacs/`), so anchor it to the
-    // document before the directory is resolved against it.
-    return new URL(directory, new URL(base, documentHref)).href;
+    // The public path is rarely a full URL (`/pacs/`, or `auto` in a worker),
+    // so anchor it before the directory is resolved against it.
+    return new URL(directory, new URL(base, documentBase)).href;
   } catch {
     return directory;
   }

--- a/packages/ai/src/utils/getOrtWasmPaths.ts
+++ b/packages/ai/src/utils/getOrtWasmPaths.ts
@@ -1,0 +1,71 @@
+/**
+ * ONNX Runtime fetches its WebAssembly binaries from the prefix held in
+ * `ort.env.wasm.wasmPaths` and feeds whatever comes back straight to
+ * `WebAssembly.instantiateStreaming`.
+ *
+ * Every other wasm binary in this repository is located with
+ * `new URL(<specifier>, import.meta.url)` — the bundler resolves the file,
+ * emits it, and hands back an absolute URL that does not depend on the page
+ * the user is currently on. `onnxruntime-web@1.17` cannot be addressed that
+ * way: its `exports` map publishes only the JavaScript entry points, so
+ * `new URL('onnxruntime-web/dist/ort-wasm-simd.jsep.wasm', import.meta.url)`
+ * fails to resolve. Applications copy `onnxruntime-web/dist` next to their
+ * bundle instead — the example runner copies it to `<example>/ort`
+ * (`utils/ExampleRunner/template-config.js`) — and point the runtime there.
+ *
+ * Pointing at it with a bare `'ort/'` is the part that breaks. A
+ * document-relative prefix resolves against the current *route*, not against
+ * the application, so it only finds the copy when the page sits exactly one
+ * segment deep — which is why it works for the examples and for
+ * `viewer.ohif.org/segmentation`. A viewer served from `/viewer/dicomweb`
+ * requests `/viewer/ort/ort-wasm-*.wasm`, receives the SPA fallback's
+ * `index.html`, and ONNX dies with `expected magic word 00 61 73 6d, found
+ * 3c 21 64 6f` followed by "no available backend found".
+ *
+ * So resolve the prefix against the base the bundler already uses for the
+ * assets it emits, which is the directory the copy lives in.
+ */
+
+/** Directory applications copy `onnxruntime-web/dist` into. */
+export const DEFAULT_ORT_WASM_DIRECTORY = 'ort/';
+
+/**
+ * webpack and rspack replace this identifier with the bundle's runtime public
+ * path (`output.publicPath` / `assetPrefix`, or the script's own directory
+ * when that is `'auto'`). It is declared rather than imported because other
+ * bundlers leave it undefined — the `typeof` guard below covers them.
+ */
+declare const __webpack_public_path__: string | undefined;
+
+function getBundlePublicPath(): string | undefined {
+  return typeof __webpack_public_path__ === 'string' && __webpack_public_path__
+    ? __webpack_public_path__
+    : undefined;
+}
+
+/**
+ * Absolute URL prefix for the ONNX Runtime wasm binaries.
+ *
+ * @param directory - directory holding `onnxruntime-web/dist`, relative to the
+ *   application. Defaults to `ort/`.
+ * @returns the prefix as an absolute URL, or `directory` unchanged when there
+ *   is nothing to resolve it against (a non-browser context).
+ */
+export default function getOrtWasmPaths(
+  directory = DEFAULT_ORT_WASM_DIRECTORY
+): string {
+  const base = getBundlePublicPath() ?? globalThis.document?.baseURI;
+  const documentHref = globalThis.location?.href;
+
+  if (!base || !documentHref) {
+    return directory;
+  }
+
+  try {
+    // The public path is often origin-relative (`/pacs/`), so anchor it to the
+    // document before the directory is resolved against it.
+    return new URL(directory, new URL(base, documentHref)).href;
+  } catch {
+    return directory;
+  }
+}


### PR DESCRIPTION
### Context

`ONNXSegmentationController.getConfig()` points ONNX Runtime at its WebAssembly binaries with

```ts
ort.env.wasm.wasmPaths = 'ort/';
```

That prefix is *document-relative*. The browser resolves it against the current route rather than against the application, so it only lands on the copy of `onnxruntime-web/dist` when the page sits exactly one segment deep — which is why it works for the examples and for `viewer.ohif.org/segmentation`.

### Problem

A viewer served from a deeper route (`/viewer/dicomweb`, `<PUBLIC_URL>viewer/<dataSource>`, …) requests `<route>/ort/ort-wasm-*.wasm`. Nothing is served there: the SPA fallback answers with `index.html`, and compiling that as WebAssembly dies with

```
expected magic word 00 61 73 6d, found 3c 21 64 6f   // "<!do"
```

ONNX then reports `no available backend found`, the SAM controller never finishes loading, and the next viewport render throws on the labelmap it never got. Downstream (OHIF/Manta) this reaches the user as a generic "Something went wrong" on the labelmap assist tool, and every consumer whose viewer is not at a single-segment route has to patch it in application code.

The second half of the problem is that the assignment runs from **every** `ONNXSegmentationController` construction, so an application that sets `ort.env.wasm.wasmPaths` itself (a CDN, a versioned path) has its value clobbered — patching it from the app requires trapping the write with an accessor rather than simply assigning.

### Change

* New `packages/ai/src/utils/getOrtWasmPaths.ts` resolves the prefix to an absolute URL against the base the bundler already uses for the assets it emits — webpack/rspack's public path (`__webpack_public_path__`), falling back to `document.baseURI`, and to the bare `'ort/'` outside a browser.
* `getConfig()` only sets `wasmPaths` when the application has not already set it.

### Why not `new URL(..., import.meta.url)`

Every other wasm binary here is located the way the codecs and workers do it — `new URL('@cornerstonejs/codec-charls/decodewasm', import.meta.url)` — letting the bundler resolve, emit and hash the file. That is not available for ONNX at `onnxruntime-web@1.17`: its `exports` map publishes only the JavaScript entry points, so

```
"./dist/ort-wasm-simd.jsep.wasm" is not exported ... from package onnxruntime-web
```

Applications therefore copy `onnxruntime-web/dist` next to their bundle (this repo's `utils/ExampleRunner/template-config.js` copies it to `<example>/ort`) and point the runtime at the copy. Anchoring that copy to the bundle's public path is the closest equivalent, and it is the same base the emitted asset URLs carry. When `onnxruntime-web` is eventually bumped to ≥ 1.21, its `*.bundle.min.mjs` builds resolve their own `.wasm` through `import.meta.url` and this whole assignment can be deleted.

### Impact

| context | before | after |
| --- | --- | --- |
| examples (`publicPath: 'auto'`, ort copied to `<example>/ort`) | `<example>/ort/` | `<example>/ort/` — unchanged |
| viewer at a one-segment route | `<root>/ort/` | `<root>/ort/` — unchanged |
| viewer at a deeper route | `<route>/ort/` — **404 / index.html** | `<root>/ort/` |
| app-configured `wasmPaths` | overwritten | respected |

No new work at load time: one URL resolution, once, inside `getConfig()`. No change to what is fetched or when.

### Testing

* Resolution verified across the deployment shapes above (root public path + deep route, `PUBLIC_URL=/pacs/` + deep route, `publicPath: 'auto'` as the example runner uses, no bundler with and without a `<base>` tag, and a non-browser context).
* Examples resolve to the identical URL they do today, since the example runner leaves `publicPath` at `'auto'` and copies `onnxruntime-web/dist` beside the bundle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading of ONNX Runtime WebAssembly resources across different deployment and bundling configurations.
  * Preserves existing custom resource paths while automatically resolving paths when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->