### PR TITLE
fix(dicomImageLoader): normalize stored pixel bits

### DIFF
--- a/packages/core/src/types/IImageFrame.ts
+++ b/packages/core/src/types/IImageFrame.ts
@@ -9,6 +9,7 @@ interface ImageFrame {
   columns: number;
   bitsAllocated: number;
   bitsStored: number;
+  highBit?: number;
   pixelRepresentation: number;
   smallestPixelValue: number;
   largestPixelValue: number;

--- a/packages/dicomImageLoader/src/__tests__/normalizeStoredPixelData.spec.ts
+++ b/packages/dicomImageLoader/src/__tests__/normalizeStoredPixelData.spec.ts
@@ -1,0 +1,59 @@
+import type { Types } from '@cornerstonejs/core';
+import normalizeStoredPixelData from '../shared/normalizeStoredPixelData';
+
+function createImageFrame(
+  pixelData: Types.PixelDataTypedArray,
+  overrides: Partial<Types.IImageFrame> = {}
+): Types.IImageFrame {
+  return {
+    bitsAllocated: 16,
+    bitsStored: 14,
+    highBit: 13,
+    pixelRepresentation: 0,
+    pixelData,
+    ...overrides,
+  } as Types.IImageFrame;
+}
+
+describe('normalizeStoredPixelData', () => {
+  it('removes unused upper bits from unsigned pixels', () => {
+    const imageFrame = createImageFrame(new Uint16Array([32768, 41249, 65343]));
+
+    normalizeStoredPixelData(imageFrame);
+
+    expect(imageFrame.pixelData).toEqual(new Uint16Array([0, 8481, 16191]));
+  });
+
+  it('sign extends signed stored pixels', () => {
+    const imageFrame = createImageFrame(
+      new Int16Array([0x3fff, 0x2000, 0x1fff]),
+      { pixelRepresentation: 1 }
+    );
+
+    normalizeStoredPixelData(imageFrame);
+
+    expect(imageFrame.pixelData).toEqual(new Int16Array([-1, -8192, 8191]));
+  });
+
+  it('uses HighBit to extract a shifted stored field', () => {
+    const imageFrame = createImageFrame(new Uint16Array([0xfff8, 0x4000]), {
+      bitsStored: 12,
+      highBit: 14,
+    });
+
+    normalizeStoredPixelData(imageFrame);
+
+    expect(imageFrame.pixelData).toEqual(new Uint16Array([4095, 2048]));
+  });
+
+  it('leaves pixels unchanged when all allocated bits are stored', () => {
+    const imageFrame = createImageFrame(new Uint16Array([0, 41249, 65535]), {
+      bitsStored: 16,
+      highBit: 15,
+    });
+
+    normalizeStoredPixelData(imageFrame);
+
+    expect(imageFrame.pixelData).toEqual(new Uint16Array([0, 41249, 65535]));
+  });
+});

--- a/packages/dicomImageLoader/src/decodeImageFrameWorker.js
+++ b/packages/dicomImageLoader/src/decodeImageFrameWorker.js
@@ -21,6 +21,7 @@ import getPixelDataTypeFromMinMax, {
   validatePixelDataType,
 } from './shared/getPixelDataTypeFromMinMax';
 import isColorImage from './shared/isColorImage';
+import normalizeStoredPixelData from './shared/normalizeStoredPixelData';
 
 const imageUtils = {
   bilinear,
@@ -41,20 +42,7 @@ export function postProcessDecodedPixels(
   start,
   decodeConfig
 ) {
-  const shouldShift =
-    imageFrame.pixelRepresentation !== undefined &&
-    imageFrame.pixelRepresentation === 1;
-
-  const shift =
-    shouldShift && imageFrame.bitsStored !== undefined
-      ? 32 - imageFrame.bitsStored
-      : undefined;
-
-  if (shouldShift && shift !== undefined) {
-    for (let i = 0; i < imageFrame.pixelData.length; i++) {
-      imageFrame.pixelData[i] = (imageFrame.pixelData[i] << shift) >> shift;
-    }
-  }
+  normalizeStoredPixelData(imageFrame);
 
   // Cache the pixelData reference quickly incase we want to set a targetBuffer _and_ scale.
   let pixelDataArray = imageFrame.pixelData;

--- a/packages/dicomImageLoader/src/imageLoader/getImageFrame.ts
+++ b/packages/dicomImageLoader/src/imageLoader/getImageFrame.ts
@@ -16,6 +16,7 @@ function getImageFrame(imageId: string): Types.IImageFrame {
     columns: imagePixelModule.columns,
     bitsAllocated: imagePixelModule.bitsAllocated,
     bitsStored: imagePixelModule.bitsStored,
+    highBit: imagePixelModule.highBit,
     pixelRepresentation: imagePixelModule.pixelRepresentation, // 0 = unsigned,
     smallestPixelValue: imagePixelModule.smallestPixelValue,
     largestPixelValue: imagePixelModule.largestPixelValue,

--- a/packages/dicomImageLoader/src/shared/normalizeStoredPixelData.ts
+++ b/packages/dicomImageLoader/src/shared/normalizeStoredPixelData.ts
@@ -1,0 +1,43 @@
+import type { Types } from '@cornerstonejs/core';
+
+/**
+ * Removes bits outside the stored pixel field and sign extends signed values.
+ */
+export default function normalizeStoredPixelData(
+  imageFrame: Types.IImageFrame
+): void {
+  const {
+    bitsAllocated,
+    bitsStored,
+    highBit = bitsStored - 1,
+    pixelData,
+    pixelRepresentation,
+  } = imageFrame;
+  const lowBit = highBit - bitsStored + 1;
+
+  if (
+    !pixelData ||
+    bitsStored <= 0 ||
+    bitsStored >= 32 ||
+    bitsStored > bitsAllocated ||
+    lowBit < 0 ||
+    highBit >= bitsAllocated ||
+    (bitsStored === bitsAllocated && lowBit === 0)
+  ) {
+    return;
+  }
+
+  const valueRange = 2 ** bitsStored;
+  const mask = valueRange - 1;
+  const signBit = valueRange / 2;
+  const isSigned = pixelRepresentation === 1;
+
+  for (let i = 0; i < pixelData.length; i++) {
+    const storedValue = (pixelData[i] >>> lowBit) & mask;
+    pixelData[i] = storedValue;
+
+    if (isSigned && storedValue >= signBit) {
+      pixelData[i] -= valueRange;
+    }
+  }
+}


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
Mask unsigned pixels to Bits Stored before range calculation. Use High Bit to locate the stored field and preserve signed values. Fix rendering when unused upper bits contain nonzero data.

Fixes #781
<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->
<img width="2322" height="1478" alt="image" src="https://github.com/user-attachments/assets/ae986c37-15d2-4d0a-98d2-39af296747da" />


### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DICOM image pixel decoding for unsigned and signed pixel data.
  * Correctly applies stored-bit ranges and High Bit metadata, improving image values when pixel data uses nonstandard bit layouts.
  * Preserves already-normalized data and safely handles invalid pixel metadata.

* **Enhancements**
  * Image frame metadata now includes High Bit information for more accurate pixel interpretation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->