### PR TITLE
feat(core): add WSI right-drag zoom

### DIFF
--- a/packages/core/src/RenderingEngine/GenericViewport/WSI/DicomMicroscopyRenderPath.ts
+++ b/packages/core/src/RenderingEngine/GenericViewport/WSI/DicomMicroscopyRenderPath.ts
@@ -1,6 +1,12 @@
 import { Events as EVENTS, ViewportType } from '../../../enums';
+import clamp from '../../../utilities/clamp';
 import triggerEvent from '../../../utilities/triggerEvent';
-import { getDicomMicroscopyViewer } from '../../../utilities/WSIUtilities';
+import {
+  getDicomMicroscopyViewer,
+  type WSIInteractionHandler,
+  type WSIMapLike,
+  type WSIViewerLike,
+} from '../../../utilities/WSIUtilities';
 import type {
   DataAddOptions,
   LoadedData,
@@ -52,6 +58,9 @@ export class DicomMicroscopyRenderPath
     viewer.deactivateDragPanInteraction();
 
     const map = viewer.getMap();
+
+    this.configureDragZoom(viewer, map);
+
     const postrenderHandler = () => {
       triggerEvent(ctx.element, EVENTS.IMAGE_RENDERED, {
         element: ctx.element,
@@ -142,6 +151,76 @@ export class DicomMicroscopyRenderPath
 
   private getFrameOfReferenceUID(payload: WSIPayload): string | undefined {
     return payload.frameOfReferenceUID ?? undefined;
+  }
+
+  private configureDragZoom(viewer: WSIViewerLike, map: WSIMapLike): void {
+    const interactions = map.getInteractions?.();
+
+    if (
+      !interactions ||
+      !map.getPixelFromCoordinate ||
+      !viewer.activateDragZoomInteraction ||
+      !viewer.deactivateDragZoomInteraction
+    ) {
+      return;
+    }
+
+    const existingInteractions = new Set(interactions.getArray());
+
+    // The viewer API does not return the created interaction, so identify it
+    // by comparing the map's interactions before and after activation.
+    viewer.activateDragZoomInteraction({
+      bindings: { mouseButtons: ['right'] },
+    });
+
+    const addedInteractions = interactions
+      .getArray()
+      .filter((interaction) => !existingInteractions.has(interaction));
+    const dragZoomInteraction = addedInteractions[0];
+    const handleDownEvent = dragZoomInteraction?.handleDownEvent;
+    const handleDragEvent = dragZoomInteraction?.handleDragEvent;
+    const handleUpEvent = dragZoomInteraction?.handleUpEvent;
+
+    if (
+      addedInteractions.length !== 1 ||
+      !handleDownEvent ||
+      !handleDragEvent ||
+      !handleUpEvent
+    ) {
+      viewer.deactivateDragZoomInteraction();
+      console.warn(
+        'Unable to constrain microscopy drag zoom; drag zoom was disabled'
+      );
+      return;
+    }
+
+    const imageExtent = map.getView().getProjection().getExtent();
+    const constrainToImageExtent =
+      (handler: WSIInteractionHandler): WSIInteractionHandler =>
+      (event) => {
+        const originalCoordinate = event.coordinate;
+        const originalPixel = event.pixel;
+
+        event.coordinate = [
+          clamp(originalCoordinate[0], imageExtent[0], imageExtent[2]),
+          clamp(originalCoordinate[1], imageExtent[1], imageExtent[3]),
+        ];
+        event.pixel = map.getPixelFromCoordinate(event.coordinate);
+
+        // Other map interactions receive the same event object.
+        try {
+          return handler.call(dragZoomInteraction, event);
+        } finally {
+          event.coordinate = originalCoordinate;
+          event.pixel = originalPixel;
+        }
+      };
+
+    dragZoomInteraction.handleDownEvent =
+      constrainToImageExtent(handleDownEvent);
+    dragZoomInteraction.handleDragEvent =
+      constrainToImageExtent(handleDragEvent);
+    dragZoomInteraction.handleUpEvent = constrainToImageExtent(handleUpEvent);
   }
 
   private removeData(rendering: WSIRendering): void {

--- a/packages/core/src/utilities/WSIUtilities.ts
+++ b/packages/core/src/utilities/WSIUtilities.ts
@@ -54,7 +54,26 @@ export interface WSIMapViewLike {
   setZoom(zoom: number): void;
 }
 
+export interface WSIMapBrowserEventLike {
+  coordinate: [number, number];
+  pixel: [number, number];
+}
+
+export type WSIInteractionHandler = (
+  event: WSIMapBrowserEventLike
+) => boolean | void;
+
+export interface WSIInteractionLike {
+  handleDownEvent?: WSIInteractionHandler;
+  handleDragEvent?: WSIInteractionHandler;
+  handleUpEvent?: WSIInteractionHandler;
+}
+
 export interface WSIMapLike {
+  getInteractions?(): {
+    getArray(): WSIInteractionLike[];
+  };
+  getPixelFromCoordinate?(coordinate: [number, number]): [number, number];
   getView(): WSIMapViewLike;
   getViewport(): HTMLElement;
   on(eventName: string, handler: () => void): void;
@@ -64,8 +83,12 @@ export interface WSIMapLike {
 }
 
 export interface WSIViewerLike {
+  activateDragZoomInteraction?(options: {
+    bindings: { mouseButtons: string[] };
+  }): void;
   cleanup?(): void;
   deactivateDragPanInteraction(): void;
+  deactivateDragZoomInteraction?(): void;
   getAffine(): unknown;
   getMap(): WSIMapLike;
   render(args: { container: HTMLElement }): void;

--- a/packages/core/test/dicomMicroscopyRenderPath.jest.js
+++ b/packages/core/test/dicomMicroscopyRenderPath.jest.js
@@ -1,0 +1,93 @@
+import { DicomMicroscopyRenderPath } from '../src/RenderingEngine/GenericViewport/WSI/DicomMicroscopyRenderPath';
+import { getDicomMicroscopyViewer } from '../src/utilities/WSIUtilities';
+
+jest.mock('../src/utilities/WSIUtilities', () => ({
+  ...jest.requireActual('../src/utilities/WSIUtilities'),
+  getDicomMicroscopyViewer: jest.fn(),
+}));
+
+describe('DicomMicroscopyRenderPath', () => {
+  it('enables right-drag zoom and constrains its coordinates to the slide extent', async () => {
+    const existingInteraction = {};
+    const receivedCoordinates = [];
+    const dragZoomInteraction = {
+      handleDownEvent(event) {
+        receivedCoordinates.push(event.coordinate);
+        return true;
+      },
+      handleDragEvent(event) {
+        receivedCoordinates.push(event.coordinate);
+      },
+      handleUpEvent(event) {
+        receivedCoordinates.push(event.coordinate);
+        return false;
+      },
+    };
+    let dragZoomActive = false;
+    const map = {
+      getInteractions: () => ({
+        getArray: () =>
+          dragZoomActive
+            ? [existingInteraction, dragZoomInteraction]
+            : [existingInteraction],
+      }),
+      getPixelFromCoordinate: jest.fn(([x, y]) => [x * 2, y * 2]),
+      getView: () => ({
+        getProjection: () => ({ getExtent: () => [0, 10, 100, 80] }),
+      }),
+      on: jest.fn(),
+    };
+    const viewer = {
+      activateDragZoomInteraction: jest.fn(() => {
+        dragZoomActive = true;
+      }),
+      deactivateDragPanInteraction: jest.fn(),
+      deactivateDragZoomInteraction: jest.fn(),
+      getMap: () => map,
+      render: jest.fn(),
+    };
+
+    getDicomMicroscopyViewer.mockResolvedValue({
+      viewer: {
+        VolumeImageViewer: jest.fn(() => viewer),
+      },
+    });
+
+    const element = document.createElement('div');
+    const renderPath = new DicomMicroscopyRenderPath();
+
+    await renderPath.addData(
+      {
+        element,
+        renderingEngineId: 'rendering-engine',
+        viewportId: 'viewport',
+      },
+      {
+        id: 'wsi',
+        type: 'wsi',
+        client: {},
+        volumeImages: [],
+      },
+      {}
+    );
+
+    expect(viewer.activateDragZoomInteraction).toHaveBeenCalledWith({
+      bindings: { mouseButtons: ['right'] },
+    });
+    expect(viewer.deactivateDragZoomInteraction).not.toHaveBeenCalled();
+
+    const event = { coordinate: [-20, 120], pixel: [-40, 240] };
+
+    dragZoomInteraction.handleDownEvent(event);
+    dragZoomInteraction.handleDragEvent(event);
+    dragZoomInteraction.handleUpEvent(event);
+
+    expect(receivedCoordinates).toEqual([
+      [0, 80],
+      [0, 80],
+      [0, 80],
+    ]);
+    expect(map.getPixelFromCoordinate).toHaveBeenCalledTimes(3);
+    expect(event).toEqual({ coordinate: [-20, 120], pixel: [-40, 240] });
+  });
+});


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->

### Context

Whole-slide microscopy viewports do not currently expose the existing DICOM Microscopy Viewer drag-zoom interaction. Applications that need region zoom therefore have to patch the built Cornerstone package.

This change enables region zoom in the source WSI render path while keeping the selection inside the slide extent.

### Changes & Results

- Activate drag zoom for the right mouse button after the microscopy viewer renders.
- Clamp the drag interaction's coordinates and pixels to the slide projection extent, then restore the shared map event for other interactions.
- Disable drag zoom if the peer viewer no longer adds one identifiable interaction with the expected handlers.
- Keep the new peer-library capabilities optional in the public WSI compatibility types.
- Add a regression test covering activation, extent clamping, pixel recalculation, and event restoration.

Before: right-dragging did not zoom a selected WSI region.

After: right-dragging shows the existing OpenLayers selection box and fits the selected in-slide region.

No dependency or user-facing configuration changes are included.

### Testing

Automated checks:

- `pnpm exec jest --selectProjects core packages/core/test/dicomMicroscopyRenderPath.jest.js --runInBand` - 34 suites passed, 552 tests passed, 2 skipped.
- `pnpm run build` - passed for the workspace.
- `pnpm run test:ci` - passed in Chrome Headless.
- The repository pre-commit lint and formatting hook passed.

Manual verification steps:

1. Load a WSI dataset in a generic whole-slide viewport.
2. Right-drag across an area of the slide and confirm the selection box appears and the viewport fits that area.
3. Right-drag beyond a slide edge and confirm the selected region stays within the slide extent.
4. Confirm left-drag panning and wheel zoom retain their existing behavior.

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

- [x] The documentation page has been updated as necessary for any public API
  additions or removals. No public documentation change is needed because this
  configures existing viewer behavior and adds no user-facing API.

#### Tested Environment

- [x] "OS: Microsoft Windows 11 Enterprise"
- [x] "Node version: 24.15.0"
- [x] "Browser: Chrome Headless 101.0.4950.0"



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added right-button drag zoom for whole-slide image viewing.
  * Drag interactions are constrained to the image boundaries for more predictable navigation.
  * Improved compatibility with viewers that provide optional map and interaction capabilities.

* **Bug Fixes**
  * Prevented drag handling from modifying the original event coordinates.
  * Safely disables drag zoom when the viewer setup is incomplete or ambiguous.

* **Tests**
  * Added coverage for drag-zoom activation, boundary clamping, and event preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->