### PR TITLE
feat(core): improve WSI overview map interactions

### DIFF
--- a/packages/core/src/RenderingEngine/GenericViewport/WSI/DicomMicroscopyRenderPath.ts
+++ b/packages/core/src/RenderingEngine/GenericViewport/WSI/DicomMicroscopyRenderPath.ts
@@ -1,6 +1,9 @@
 import { Events as EVENTS, ViewportType } from '../../../enums';
 import triggerEvent from '../../../utilities/triggerEvent';
-import { getDicomMicroscopyViewer } from '../../../utilities/WSIUtilities';
+import {
+  configureWSIOverviewMap,
+  getDicomMicroscopyViewer,
+} from '../../../utilities/WSIUtilities';
 import type {
   DataAddOptions,
   LoadedData,
@@ -52,6 +55,7 @@ export class DicomMicroscopyRenderPath
     viewer.deactivateDragPanInteraction();
 
     const map = viewer.getMap();
+    const overviewMapInteraction = configureWSIOverviewMap(map);
     const postrenderHandler = () => {
       triggerEvent(ctx.element, EVENTS.IMAGE_RENDERED, {
         element: ctx.element,
@@ -101,6 +105,7 @@ export class DicomMicroscopyRenderPath
         map.render?.();
       },
       removeData: () => {
+        overviewMapInteraction.cleanup();
         this.removeData(rendering);
       },
     };

--- a/packages/core/src/RenderingEngine/WSIViewport.ts
+++ b/packages/core/src/RenderingEngine/WSIViewport.ts
@@ -22,12 +22,14 @@ import imageIdToURI from '../utilities/imageIdToURI';
 import { getGenericViewportWSIDisplaySet } from './GenericViewport/genericViewportDisplaySetAccess';
 import {
   addWSIMiniNavigationOverlayCss,
+  configureWSIOverviewMap,
   type WSIClientLike,
   getDicomMicroscopyViewer,
   loadWSIData,
   type WSIImageDataMetadata,
   type WSIMapLike,
   type WSIMapViewLike,
+  type WSIOverviewMapInteraction,
   type WSITransformUtilitiesLike,
   type WSIViewerLike,
 } from '../utilities/WSIUtilities';
@@ -60,6 +62,8 @@ class WSIViewport extends Viewport {
 
   protected map: WSIMapLike;
   private imageURISet: Set<string> = new Set();
+  // Owns overview-map state and listeners across WSI replacements.
+  private overviewMapInteraction?: WSIOverviewMapInteraction;
 
   private internalCamera = {
     rotation: 0,
@@ -195,6 +199,8 @@ class WSIViewport extends Viewport {
   }
 
   private elementDisabledHandler() {
+    this.overviewMapInteraction?.cleanup();
+    this.overviewMapInteraction = undefined;
     this.removeEventListeners();
     this.viewer?.cleanup();
     this.viewer = null;
@@ -587,6 +593,14 @@ class WSIViewport extends Viewport {
     // Setting WSI data directly resets any display-set bookkeeping; the
     // setDisplaySets override re-records after calling this.
     this.clearDisplaySets();
+    // Preserve the overview state and stop an active drag before replacing
+    // the map. viewer.cleanup() also terminates shared DICOM workers.
+    const overviewMapCollapsed = this.overviewMapInteraction?.getCollapsed();
+
+    this.overviewMapInteraction?.cleanup();
+    this.overviewMapInteraction = undefined;
+    this.map?.un(EVENT_POSTRENDER, this.postrender);
+    this.map?.setTarget?.(null);
     this.microscopyElement.style.background = 'black';
     this.microscopyElement.innerText = 'Loading';
     this.imageIds = imageIds;
@@ -618,6 +632,10 @@ class WSIViewport extends Viewport {
     viewer.deactivateDragPanInteraction();
     this.viewer = viewer;
     this.map = viewer.getMap();
+    this.overviewMapInteraction = configureWSIOverviewMap(
+      this.map,
+      overviewMapCollapsed
+    );
     this.map.on(EVENT_POSTRENDER, this.postrender);
     this.resize();
     this.microscopyElement.innerText = '';

--- a/packages/core/src/utilities/WSIUtilities.ts
+++ b/packages/core/src/utilities/WSIUtilities.ts
@@ -54,13 +54,35 @@ export interface WSIMapViewLike {
   setZoom(zoom: number): void;
 }
 
+export interface WSIOverviewMapLike {
+  getEventCoordinate(event: Event): [number, number];
+}
+
+export interface WSIMapControlLike {
+  element?: HTMLElement;
+  getCollapsed?(): boolean;
+  getOverviewMap?(): WSIOverviewMapLike;
+  setCollapsed?(collapsed: boolean): void;
+}
+
 export interface WSIMapLike {
+  getControls?(): {
+    getArray(): WSIMapControlLike[];
+  };
+  getOverlayContainerStopEvent?(): HTMLElement;
+  getOwnerDocument?(): Document;
   getView(): WSIMapViewLike;
   getViewport(): HTMLElement;
   on(eventName: string, handler: () => void): void;
   render(): void;
+  setTarget?(target: HTMLElement | null): void;
   un(eventName: string, handler: () => void): void;
   updateSize?(): void;
+}
+
+export interface WSIOverviewMapInteraction {
+  cleanup(): void;
+  getCollapsed(): boolean | undefined;
 }
 
 export interface WSIViewerLike {
@@ -126,6 +148,84 @@ export async function getDicomMicroscopyViewer(): Promise<DicomMicroscopyViewerL
   return peerImport(
     'dicom-microscopy-viewer'
   ) as Promise<DicomMicroscopyViewerLike>;
+}
+
+/**
+ * Restores overview-map state, isolates its events from viewport tools, and
+ * owns drag listeners without importing OpenLayers types from the peer viewer.
+ */
+export function configureWSIOverviewMap(
+  map: WSIMapLike,
+  collapsed?: boolean
+): WSIOverviewMapInteraction {
+  const controlContainer = map.getOverlayContainerStopEvent?.();
+  const blockedEventTypes = ['pointerdown', 'mousedown', 'dblclick', 'wheel'];
+  const stopPropagation = (event: Event) => event.stopPropagation();
+
+  blockedEventTypes.forEach((eventType) => {
+    controlContainer?.addEventListener(eventType, stopPropagation);
+  });
+
+  const overviewMapControl = map
+    .getControls?.()
+    .getArray()
+    .find((control) => control.getOverviewMap);
+
+  if (collapsed !== undefined) {
+    overviewMapControl?.setCollapsed?.(collapsed);
+  }
+
+  const overviewMap = overviewMapControl?.getOverviewMap?.();
+  const overviewMapElement = overviewMapControl?.element?.querySelector(
+    '.ol-overviewmap-map'
+  );
+  const magnificationBox = overviewMapControl?.element?.querySelector(
+    '.ol-overviewmap-box'
+  );
+  let stopPanning: (() => void) | undefined;
+
+  const startPanning = (event: Event) => {
+    if (
+      event.target !== magnificationBox ||
+      !overviewMap ||
+      !map.getOwnerDocument
+    ) {
+      return;
+    }
+
+    stopPanning?.();
+
+    const ownerDocument = map.getOwnerDocument();
+    const panViewport = (pointerEvent: Event) => {
+      map.getView().setCenter(overviewMap.getEventCoordinate(pointerEvent));
+    };
+    const stopCurrentPan = () => {
+      ownerDocument.removeEventListener('pointermove', panViewport);
+      ownerDocument.removeEventListener('pointerup', stopCurrentPan);
+      ownerDocument.removeEventListener('pointercancel', stopCurrentPan);
+      stopPanning = undefined;
+    };
+
+    stopPanning = stopCurrentPan;
+    ownerDocument.addEventListener('pointermove', panViewport);
+    ownerDocument.addEventListener('pointerup', stopCurrentPan, { once: true });
+    ownerDocument.addEventListener('pointercancel', stopCurrentPan, {
+      once: true,
+    });
+  };
+
+  overviewMapElement?.addEventListener('pointerdown', startPanning);
+
+  return {
+    cleanup: () => {
+      stopPanning?.();
+      overviewMapElement?.removeEventListener('pointerdown', startPanning);
+      blockedEventTypes.forEach((eventType) => {
+        controlContainer?.removeEventListener(eventType, stopPropagation);
+      });
+    },
+    getCollapsed: () => overviewMapControl?.getCollapsed?.(),
+  };
 }
 
 export function addWSIMiniNavigationOverlayCss() {

--- a/packages/core/test/wsiOverviewMapInteractions.jest.js
+++ b/packages/core/test/wsiOverviewMapInteractions.jest.js
@@ -1,0 +1,72 @@
+import { configureWSIOverviewMap } from '../src/utilities/WSIUtilities';
+
+describe('configureWSIOverviewMap', () => {
+  it('restores state, isolates control events, pans while dragging, and cleans up listeners', () => {
+    const parent = document.createElement('div');
+    const controlContainer = document.createElement('div');
+    const controlElement = document.createElement('div');
+    const overviewMapElement = document.createElement('div');
+    const magnificationBox = document.createElement('div');
+    const parentPointerDown = jest.fn();
+    const setCenter = jest.fn();
+    const getEventCoordinate = jest.fn(() => [12, 34]);
+    let collapsed = false;
+
+    overviewMapElement.className = 'ol-overviewmap-map';
+    magnificationBox.className = 'ol-overviewmap-box';
+    overviewMapElement.appendChild(magnificationBox);
+    controlElement.appendChild(overviewMapElement);
+    controlContainer.appendChild(controlElement);
+    parent.appendChild(controlContainer);
+    parent.addEventListener('pointerdown', parentPointerDown);
+
+    const interaction = configureWSIOverviewMap(
+      {
+        getControls: () => ({
+          getArray: () => [
+            {
+              element: controlElement,
+              getCollapsed: () => collapsed,
+              getOverviewMap: () => ({ getEventCoordinate }),
+              setCollapsed: (value) => {
+                collapsed = value;
+              },
+            },
+          ],
+        }),
+        getOverlayContainerStopEvent: () => controlContainer,
+        getOwnerDocument: () => document,
+        getView: () => ({ setCenter }),
+      },
+      true
+    );
+
+    expect(interaction.getCollapsed()).toBe(true);
+
+    magnificationBox.dispatchEvent(
+      new MouseEvent('pointerdown', { bubbles: true })
+    );
+    document.dispatchEvent(new MouseEvent('pointermove'));
+
+    expect(parentPointerDown).not.toHaveBeenCalled();
+    expect(getEventCoordinate).toHaveBeenCalledTimes(1);
+    expect(setCenter).toHaveBeenCalledWith([12, 34]);
+
+    document.dispatchEvent(new MouseEvent('pointerup'));
+    document.dispatchEvent(new MouseEvent('pointermove'));
+
+    expect(setCenter).toHaveBeenCalledTimes(1);
+
+    magnificationBox.dispatchEvent(
+      new MouseEvent('pointerdown', { bubbles: true })
+    );
+    interaction.cleanup();
+    document.dispatchEvent(new MouseEvent('pointermove'));
+    controlContainer.dispatchEvent(
+      new MouseEvent('pointerdown', { bubbles: true })
+    );
+
+    expect(setCenter).toHaveBeenCalledTimes(1);
+    expect(parentPointerDown).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->

### Context

Whole-slide microscopy viewports already render an overview map, but its controls can pass pointer and wheel events to viewport tools. The magnification box also cannot pan the main slide. Replacing WSI data in the legacy viewport loses the collapsed state and can leave document drag listeners attached.

This keeps the overview-map change separate from #2870, which covers right-drag region zoom.

### Changes & Results

- Configure overview-map interactions for both legacy and GenericViewport WSI paths.
- Stop overview control pointer, double-click, and wheel events from reaching viewport tools.
- Pan the main WSI map while the overview magnification box is dragged.
- Remove document drag listeners when the drag ends or the viewport data is replaced or disabled.
- Preserve the overview map's collapsed state when the legacy `WSIViewport` replaces its data.

Before, overview interactions could activate viewport tools, dragging the magnification box did not pan the slide, and WSI replacement could leave stale listeners.

After, overview interactions remain within the control, drag-to-pan works, and the interaction state follows the WSI lifecycle.

### Testing

Automated checks:

- `corepack pnpm exec jest --selectProjects core packages/core/test/wsiOverviewMapInteractions.jest.js --runInBand`: 34 suites passed, 552 tests passed, 2 skipped.
- `pnpm run build`: passed for the workspace.
- `pnpm run lint`: passed with no warnings or errors.
- `pnpm run test:ci`: passed in Chrome Headless.
- Husky pre-commit lint and format checks passed.

Manual verification steps:

1. Load a whole-slide image in a legacy or GenericViewport WSI viewport.
2. Use the overview control and confirm its pointer, double-click, and wheel events do not activate viewport tools.
3. Drag the overview magnification box and confirm the main slide pans to the selected position.
4. In the legacy viewport, collapse the overview map, replace the WSI data, and confirm it remains collapsed.

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

- [x] The documentation page has been updated as necessary for any public API
  additions or removals. No documentation change is needed because this changes existing overview-map behavior without adding a user-facing option.

#### Tested Environment

- [x] "OS: Windows 11 Enterprise"
- [x] "Node version: 24.15.0"
- [x] "Browser: Chrome Headless 101.0.4950.0"
