### PR TITLE
feat(core): improve WSI overview map fitting and interactions

### DIFF
--- a/packages/core/src/RenderingEngine/GenericViewport/WSI/DicomMicroscopyRenderPath.ts
+++ b/packages/core/src/RenderingEngine/GenericViewport/WSI/DicomMicroscopyRenderPath.ts
@@ -1,6 +1,9 @@
 import { Events as EVENTS, ViewportType } from '../../../enums';
 import triggerEvent from '../../../utilities/triggerEvent';
-import { getDicomMicroscopyViewer } from '../../../utilities/WSIUtilities';
+import {
+  configureWSIOverviewMap,
+  getDicomMicroscopyViewer,
+} from '../../../utilities/WSIUtilities';
 import type {
   DataAddOptions,
   LoadedData,
@@ -52,6 +55,7 @@ export class DicomMicroscopyRenderPath
     viewer.deactivateDragPanInteraction();
 
     const map = viewer.getMap();
+    const overviewMapInteraction = configureWSIOverviewMap(map);
     const postrenderHandler = () => {
       triggerEvent(ctx.element, EVENTS.IMAGE_RENDERED, {
         element: ctx.element,
@@ -101,6 +105,7 @@ export class DicomMicroscopyRenderPath
         map.render?.();
       },
       removeData: () => {
+        overviewMapInteraction.cleanup();
         this.removeData(rendering);
       },
     };

--- a/packages/core/src/RenderingEngine/WSIViewport.ts
+++ b/packages/core/src/RenderingEngine/WSIViewport.ts
@@ -22,12 +22,14 @@ import imageIdToURI from '../utilities/imageIdToURI';
 import { getGenericViewportWSIDisplaySet } from './GenericViewport/genericViewportDisplaySetAccess';
 import {
   addWSIMiniNavigationOverlayCss,
+  configureWSIOverviewMap,
   type WSIClientLike,
   getDicomMicroscopyViewer,
   loadWSIData,
   type WSIImageDataMetadata,
   type WSIMapLike,
   type WSIMapViewLike,
+  type WSIOverviewMapInteraction,
   type WSITransformUtilitiesLike,
   type WSIViewerLike,
 } from '../utilities/WSIUtilities';
@@ -60,6 +62,8 @@ class WSIViewport extends Viewport {
 
   protected map: WSIMapLike;
   private imageURISet: Set<string> = new Set();
+  // Owns overview-map state and listeners across WSI replacements.
+  private overviewMapInteraction?: WSIOverviewMapInteraction;
 
   private internalCamera = {
     rotation: 0,
@@ -195,6 +199,8 @@ class WSIViewport extends Viewport {
   }
 
   private elementDisabledHandler() {
+    this.overviewMapInteraction?.cleanup();
+    this.overviewMapInteraction = undefined;
     this.removeEventListeners();
     this.viewer?.cleanup();
     this.viewer = null;
@@ -587,6 +593,14 @@ class WSIViewport extends Viewport {
     // Setting WSI data directly resets any display-set bookkeeping; the
     // setDisplaySets override re-records after calling this.
     this.clearDisplaySets();
+    // Preserve the overview state and stop an active drag before replacing
+    // the map. viewer.cleanup() also terminates shared DICOM workers.
+    const overviewMapCollapsed = this.overviewMapInteraction?.getCollapsed();
+
+    this.overviewMapInteraction?.cleanup();
+    this.overviewMapInteraction = undefined;
+    this.map?.un(EVENT_POSTRENDER, this.postrender);
+    this.map?.setTarget?.(null);
     this.microscopyElement.style.background = 'black';
     this.microscopyElement.innerText = 'Loading';
     this.imageIds = imageIds;
@@ -618,6 +632,10 @@ class WSIViewport extends Viewport {
     viewer.deactivateDragPanInteraction();
     this.viewer = viewer;
     this.map = viewer.getMap();
+    this.overviewMapInteraction = configureWSIOverviewMap(
+      this.map,
+      overviewMapCollapsed
+    );
     this.map.on(EVENT_POSTRENDER, this.postrender);
     this.resize();
     this.microscopyElement.innerText = '';

--- a/packages/core/src/utilities/WSIUtilities.ts
+++ b/packages/core/src/utilities/WSIUtilities.ts
@@ -54,13 +54,35 @@ export interface WSIMapViewLike {
   setZoom(zoom: number): void;
 }
 
+export interface WSIOverviewMapLike {
+  getEventCoordinate(event: Event): [number, number];
+}
+
+export interface WSIMapControlLike {
+  element?: HTMLElement;
+  getCollapsed?(): boolean;
+  getOverviewMap?(): WSIOverviewMapLike;
+  setCollapsed?(collapsed: boolean): void;
+}
+
 export interface WSIMapLike {
+  getControls?(): {
+    getArray(): WSIMapControlLike[];
+  };
+  getOverlayContainerStopEvent?(): HTMLElement;
+  getOwnerDocument?(): Document;
   getView(): WSIMapViewLike;
   getViewport(): HTMLElement;
   on(eventName: string, handler: () => void): void;
   render(): void;
+  setTarget?(target: HTMLElement | null): void;
   un(eventName: string, handler: () => void): void;
   updateSize?(): void;
+}
+
+export interface WSIOverviewMapInteraction {
+  cleanup(): void;
+  getCollapsed(): boolean | undefined;
 }
 
 export interface WSIViewerLike {
@@ -126,6 +148,84 @@ export async function getDicomMicroscopyViewer(): Promise<DicomMicroscopyViewerL
   return peerImport(
     'dicom-microscopy-viewer'
   ) as Promise<DicomMicroscopyViewerLike>;
+}
+
+/**
+ * Restores overview-map state, isolates its events from viewport tools, and
+ * owns drag listeners without importing OpenLayers types from the peer viewer.
+ */
+export function configureWSIOverviewMap(
+  map: WSIMapLike,
+  collapsed?: boolean
+): WSIOverviewMapInteraction {
+  const controlContainer = map.getOverlayContainerStopEvent?.();
+  const blockedEventTypes = ['pointerdown', 'mousedown', 'dblclick', 'wheel'];
+  const stopPropagation = (event: Event) => event.stopPropagation();
+
+  blockedEventTypes.forEach((eventType) => {
+    controlContainer?.addEventListener(eventType, stopPropagation);
+  });
+
+  const overviewMapControl = map
+    .getControls?.()
+    .getArray()
+    .find((control) => control.getOverviewMap);
+
+  if (collapsed !== undefined) {
+    overviewMapControl?.setCollapsed?.(collapsed);
+  }
+
+  const overviewMap = overviewMapControl?.getOverviewMap?.();
+  const overviewMapElement = overviewMapControl?.element?.querySelector(
+    '.ol-overviewmap-map'
+  );
+  const magnificationBox = overviewMapControl?.element?.querySelector(
+    '.ol-overviewmap-box'
+  );
+  let stopPanning: (() => void) | undefined;
+
+  const startPanning = (event: Event) => {
+    if (
+      event.target !== magnificationBox ||
+      !overviewMap ||
+      !map.getOwnerDocument
+    ) {
+      return;
+    }
+
+    stopPanning?.();
+
+    const ownerDocument = map.getOwnerDocument();
+    const panViewport = (pointerEvent: Event) => {
+      map.getView().setCenter(overviewMap.getEventCoordinate(pointerEvent));
+    };
+    const stopCurrentPan = () => {
+      ownerDocument.removeEventListener('pointermove', panViewport);
+      ownerDocument.removeEventListener('pointerup', stopCurrentPan);
+      ownerDocument.removeEventListener('pointercancel', stopCurrentPan);
+      stopPanning = undefined;
+    };
+
+    stopPanning = stopCurrentPan;
+    ownerDocument.addEventListener('pointermove', panViewport);
+    ownerDocument.addEventListener('pointerup', stopCurrentPan, { once: true });
+    ownerDocument.addEventListener('pointercancel', stopCurrentPan, {
+      once: true,
+    });
+  };
+
+  overviewMapElement?.addEventListener('pointerdown', startPanning);
+
+  return {
+    cleanup: () => {
+      stopPanning?.();
+      overviewMapElement?.removeEventListener('pointerdown', startPanning);
+      blockedEventTypes.forEach((eventType) => {
+        controlContainer?.removeEventListener(eventType, stopPropagation);
+      });
+    },
+    getCollapsed: () => overviewMapControl?.getCollapsed?.(),
+  };
 }
 
 export function addWSIMiniNavigationOverlayCss() {

--- a/packages/core/src/utilities/WSIUtilities.ts
+++ b/packages/core/src/utilities/WSIUtilities.ts
@@ -159,7 +159,15 @@ export function configureWSIOverviewMap(
   collapsed?: boolean
 ): WSIOverviewMapInteraction {
   const controlContainer = map.getOverlayContainerStopEvent?.();
-  const blockedEventTypes = ['pointerdown', 'mousedown', 'dblclick', 'wheel'];
+  const blockedEventTypes = [
+    'pointerdown',
+    'pointermove',
+    'pointerup',
+    'pointercancel',
+    'mousedown',
+    'dblclick',
+    'wheel',
+  ];
   const stopPropagation = (event: Event) => event.stopPropagation();
 
   blockedEventTypes.forEach((eventType) => {
@@ -200,16 +208,20 @@ export function configureWSIOverviewMap(
       map.getView().setCenter(overviewMap.getEventCoordinate(pointerEvent));
     };
     const stopCurrentPan = () => {
-      ownerDocument.removeEventListener('pointermove', panViewport);
-      ownerDocument.removeEventListener('pointerup', stopCurrentPan);
-      ownerDocument.removeEventListener('pointercancel', stopCurrentPan);
+      ownerDocument.removeEventListener('pointermove', panViewport, true);
+      ownerDocument.removeEventListener('pointerup', stopCurrentPan, true);
+      ownerDocument.removeEventListener('pointercancel', stopCurrentPan, true);
       stopPanning = undefined;
     };
 
     stopPanning = stopCurrentPan;
-    ownerDocument.addEventListener('pointermove', panViewport);
-    ownerDocument.addEventListener('pointerup', stopCurrentPan, { once: true });
+    ownerDocument.addEventListener('pointermove', panViewport, true);
+    ownerDocument.addEventListener('pointerup', stopCurrentPan, {
+      capture: true,
+      once: true,
+    });
     ownerDocument.addEventListener('pointercancel', stopCurrentPan, {
+      capture: true,
       once: true,
     });
   };

--- a/packages/core/src/utilities/WSIUtilities.ts
+++ b/packages/core/src/utilities/WSIUtilities.ts
@@ -54,8 +54,35 @@ export interface WSIMapViewLike {
   setZoom(zoom: number): void;
 }
 
+interface WSIOverviewViewOptions {
+  projection: ReturnType<WSIMapViewLike['getProjection']>;
+  rotation: number;
+  center: [number, number];
+  resolution: number;
+  minResolution: number;
+  maxResolution: number;
+  extent: number[];
+  constrainOnlyCenter: boolean;
+  showFullExtent: boolean;
+}
+
+interface WSIOverviewViewLike {
+  constructor: new (options: WSIOverviewViewOptions) => WSIOverviewViewLike;
+  getProjection(): ReturnType<WSIMapViewLike['getProjection']>;
+  getRotation(): number;
+  getMinResolution(): number;
+  getMaxResolution(): number;
+  on(eventName: 'change:rotation', handler: () => void): void;
+  un(eventName: 'change:rotation', handler: () => void): void;
+}
+
 export interface WSIOverviewMapLike {
   getEventCoordinate(event: Event): [number, number];
+  getSize(): number[] | undefined;
+  getView(): WSIOverviewViewLike;
+  setView(view: WSIOverviewViewLike): void;
+  on(eventName: 'change:size' | 'change:view', handler: () => void): void;
+  un(eventName: 'change:size' | 'change:view', handler: () => void): void;
 }
 
 export interface WSIMapControlLike {
@@ -152,7 +179,8 @@ export async function getDicomMicroscopyViewer(): Promise<DicomMicroscopyViewerL
 
 /**
  * Restores overview-map state, isolates its events from viewport tools, and
- * owns drag listeners without importing OpenLayers types from the peer viewer.
+ * fits the full slide to its rendered size. Owns listeners without importing
+ * OpenLayers types from the peer viewer.
  */
 export function configureWSIOverviewMap(
   map: WSIMapLike,
@@ -184,6 +212,62 @@ export function configureWSIOverviewMap(
   }
 
   const overviewMap = overviewMapControl?.getOverviewMap?.();
+  let overviewView: WSIOverviewViewLike;
+  let fittedOverviewView: WSIOverviewViewLike;
+  const fitOverviewMap = () => {
+    const size = overviewMap.getSize();
+    if (!size || size[0] <= 0 || size[1] <= 0) {
+      return;
+    }
+    const view = overviewMap.getView();
+    const projection = view.getProjection();
+    const extent = projection.getExtent();
+    const width = extent[2] - extent[0];
+    const height = extent[3] - extent[1];
+    const rotation = view.getRotation();
+    const cos = Math.abs(Math.cos(rotation));
+    const sin = Math.abs(Math.sin(rotation));
+    const resolution = Math.max(
+      (width * cos + height * sin) / size[0],
+      (width * sin + height * cos) / size[1]
+    );
+    if (
+      view.getMinResolution() === resolution &&
+      view.getMaxResolution() === resolution
+    ) {
+      return;
+    }
+    const center: [number, number] = [
+      (extent[0] + extent[2]) / 2,
+      (extent[1] + extent[3]) / 2,
+    ];
+    // The microscopy viewer locks zoom to its inline dimensions, which CSS can override.
+    fittedOverviewView = new view.constructor({
+      projection,
+      rotation,
+      center,
+      resolution,
+      minResolution: resolution,
+      maxResolution: resolution,
+      extent: center.concat(center),
+      constrainOnlyCenter: true,
+      showFullExtent: true,
+    });
+    overviewMap.setView(fittedOverviewView);
+  };
+  const bindOverviewView = () => {
+    overviewView?.un('change:rotation', fitOverviewMap);
+    overviewView = overviewMap.getView();
+    overviewView.on('change:rotation', fitOverviewMap);
+    if (overviewView !== fittedOverviewView) {
+      fitOverviewMap();
+    }
+  };
+  if (overviewMap) {
+    overviewMap.on('change:size', fitOverviewMap);
+    overviewMap.on('change:view', bindOverviewView);
+    bindOverviewView();
+  }
   const overviewMapElement = overviewMapControl?.element?.querySelector(
     '.ol-overviewmap-map'
   );
@@ -201,6 +285,7 @@ export function configureWSIOverviewMap(
       return;
     }
 
+    event.stopImmediatePropagation();
     stopPanning?.();
 
     const ownerDocument = map.getOwnerDocument();
@@ -209,29 +294,40 @@ export function configureWSIOverviewMap(
     };
     const stopCurrentPan = () => {
       ownerDocument.removeEventListener('pointermove', panViewport, true);
-      ownerDocument.removeEventListener('pointerup', stopCurrentPan, true);
-      ownerDocument.removeEventListener('pointercancel', stopCurrentPan, true);
+      ownerDocument.removeEventListener('pointerup', finishPanning, true);
+      ownerDocument.removeEventListener('pointercancel', finishPanning, true);
       stopPanning = undefined;
     };
 
+    const finishPanning = (pointerEvent: Event) => {
+      pointerEvent.stopPropagation();
+      stopCurrentPan();
+    };
     stopPanning = stopCurrentPan;
     ownerDocument.addEventListener('pointermove', panViewport, true);
-    ownerDocument.addEventListener('pointerup', stopCurrentPan, {
+    ownerDocument.addEventListener('pointerup', finishPanning, {
       capture: true,
       once: true,
     });
-    ownerDocument.addEventListener('pointercancel', stopCurrentPan, {
+    ownerDocument.addEventListener('pointercancel', finishPanning, {
       capture: true,
       once: true,
     });
   };
 
-  overviewMapElement?.addEventListener('pointerdown', startPanning);
+  overviewMapElement?.addEventListener('pointerdown', startPanning, true);
 
   return {
     cleanup: () => {
+      overviewView?.un('change:rotation', fitOverviewMap);
+      overviewMap?.un('change:size', fitOverviewMap);
+      overviewMap?.un('change:view', bindOverviewView);
       stopPanning?.();
-      overviewMapElement?.removeEventListener('pointerdown', startPanning);
+      overviewMapElement?.removeEventListener(
+        'pointerdown',
+        startPanning,
+        true
+      );
       blockedEventTypes.forEach((eventType) => {
         controlContainer?.removeEventListener(eventType, stopPropagation);
       });

--- a/packages/core/test/wsiOverviewMapInteractions.jest.js
+++ b/packages/core/test/wsiOverviewMapInteractions.jest.js
@@ -8,6 +8,9 @@ describe('configureWSIOverviewMap', () => {
     const overviewMapElement = document.createElement('div');
     const magnificationBox = document.createElement('div');
     const parentPointerDown = jest.fn();
+    const parentPointerMove = jest.fn();
+    const parentPointerUp = jest.fn();
+    const parentPointerCancel = jest.fn();
     const setCenter = jest.fn();
     const getEventCoordinate = jest.fn(() => [12, 34]);
     let collapsed = false;
@@ -19,6 +22,10 @@ describe('configureWSIOverviewMap', () => {
     controlContainer.appendChild(controlElement);
     parent.appendChild(controlContainer);
     parent.addEventListener('pointerdown', parentPointerDown);
+    parent.addEventListener('pointermove', parentPointerMove);
+    parent.addEventListener('pointerup', parentPointerUp);
+    parent.addEventListener('pointercancel', parentPointerCancel);
+    document.body.appendChild(parent);
 
     const interaction = configureWSIOverviewMap(
       {
@@ -46,15 +53,35 @@ describe('configureWSIOverviewMap', () => {
     magnificationBox.dispatchEvent(
       new MouseEvent('pointerdown', { bubbles: true })
     );
-    document.dispatchEvent(new MouseEvent('pointermove'));
+    magnificationBox.dispatchEvent(
+      new MouseEvent('pointermove', { bubbles: true })
+    );
 
     expect(parentPointerDown).not.toHaveBeenCalled();
+    expect(parentPointerMove).not.toHaveBeenCalled();
     expect(getEventCoordinate).toHaveBeenCalledTimes(1);
     expect(setCenter).toHaveBeenCalledWith([12, 34]);
 
-    document.dispatchEvent(new MouseEvent('pointerup'));
+    magnificationBox.dispatchEvent(
+      new MouseEvent('pointerup', { bubbles: true })
+    );
+    magnificationBox.dispatchEvent(
+      new MouseEvent('pointermove', { bubbles: true })
+    );
+
+    expect(parentPointerUp).not.toHaveBeenCalled();
+    expect(parentPointerMove).not.toHaveBeenCalled();
+    expect(setCenter).toHaveBeenCalledTimes(1);
+
+    magnificationBox.dispatchEvent(
+      new MouseEvent('pointerdown', { bubbles: true })
+    );
+    magnificationBox.dispatchEvent(
+      new MouseEvent('pointercancel', { bubbles: true })
+    );
     document.dispatchEvent(new MouseEvent('pointermove'));
 
+    expect(parentPointerCancel).not.toHaveBeenCalled();
     expect(setCenter).toHaveBeenCalledTimes(1);
 
     magnificationBox.dispatchEvent(
@@ -65,8 +92,22 @@ describe('configureWSIOverviewMap', () => {
     controlContainer.dispatchEvent(
       new MouseEvent('pointerdown', { bubbles: true })
     );
+    controlContainer.dispatchEvent(
+      new MouseEvent('pointermove', { bubbles: true })
+    );
+    controlContainer.dispatchEvent(
+      new MouseEvent('pointerup', { bubbles: true })
+    );
+    controlContainer.dispatchEvent(
+      new MouseEvent('pointercancel', { bubbles: true })
+    );
 
     expect(setCenter).toHaveBeenCalledTimes(1);
     expect(parentPointerDown).toHaveBeenCalledTimes(1);
+    expect(parentPointerMove).toHaveBeenCalledTimes(1);
+    expect(parentPointerUp).toHaveBeenCalledTimes(1);
+    expect(parentPointerCancel).toHaveBeenCalledTimes(1);
+
+    parent.remove();
   });
 });

--- a/packages/core/test/wsiOverviewMapInteractions.jest.js
+++ b/packages/core/test/wsiOverviewMapInteractions.jest.js
@@ -1,0 +1,72 @@
+import { configureWSIOverviewMap } from '../src/utilities/WSIUtilities';
+
+describe('configureWSIOverviewMap', () => {
+  it('restores state, isolates control events, pans while dragging, and cleans up listeners', () => {
+    const parent = document.createElement('div');
+    const controlContainer = document.createElement('div');
+    const controlElement = document.createElement('div');
+    const overviewMapElement = document.createElement('div');
+    const magnificationBox = document.createElement('div');
+    const parentPointerDown = jest.fn();
+    const setCenter = jest.fn();
+    const getEventCoordinate = jest.fn(() => [12, 34]);
+    let collapsed = false;
+
+    overviewMapElement.className = 'ol-overviewmap-map';
+    magnificationBox.className = 'ol-overviewmap-box';
+    overviewMapElement.appendChild(magnificationBox);
+    controlElement.appendChild(overviewMapElement);
+    controlContainer.appendChild(controlElement);
+    parent.appendChild(controlContainer);
+    parent.addEventListener('pointerdown', parentPointerDown);
+
+    const interaction = configureWSIOverviewMap(
+      {
+        getControls: () => ({
+          getArray: () => [
+            {
+              element: controlElement,
+              getCollapsed: () => collapsed,
+              getOverviewMap: () => ({ getEventCoordinate }),
+              setCollapsed: (value) => {
+                collapsed = value;
+              },
+            },
+          ],
+        }),
+        getOverlayContainerStopEvent: () => controlContainer,
+        getOwnerDocument: () => document,
+        getView: () => ({ setCenter }),
+      },
+      true
+    );
+
+    expect(interaction.getCollapsed()).toBe(true);
+
+    magnificationBox.dispatchEvent(
+      new MouseEvent('pointerdown', { bubbles: true })
+    );
+    document.dispatchEvent(new MouseEvent('pointermove'));
+
+    expect(parentPointerDown).not.toHaveBeenCalled();
+    expect(getEventCoordinate).toHaveBeenCalledTimes(1);
+    expect(setCenter).toHaveBeenCalledWith([12, 34]);
+
+    document.dispatchEvent(new MouseEvent('pointerup'));
+    document.dispatchEvent(new MouseEvent('pointermove'));
+
+    expect(setCenter).toHaveBeenCalledTimes(1);
+
+    magnificationBox.dispatchEvent(
+      new MouseEvent('pointerdown', { bubbles: true })
+    );
+    interaction.cleanup();
+    document.dispatchEvent(new MouseEvent('pointermove'));
+    controlContainer.dispatchEvent(
+      new MouseEvent('pointerdown', { bubbles: true })
+    );
+
+    expect(setCenter).toHaveBeenCalledTimes(1);
+    expect(parentPointerDown).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/test/wsiOverviewMapInteractions.jest.js
+++ b/packages/core/test/wsiOverviewMapInteractions.jest.js
@@ -1,5 +1,56 @@
 import { configureWSIOverviewMap } from '../src/utilities/WSIUtilities';
 
+class OverviewView extends EventTarget {
+  constructor(options) {
+    super();
+    this.options = options;
+  }
+
+  getProjection() {
+    return this.options.projection;
+  }
+  getRotation() {
+    return this.options.rotation;
+  }
+  getMinResolution() {
+    return this.options.minResolution;
+  }
+  getMaxResolution() {
+    return this.options.maxResolution;
+  }
+  on(type, handler) {
+    this.addEventListener(type, handler);
+  }
+  un(type, handler) {
+    this.removeEventListener(type, handler);
+  }
+}
+
+function createOverviewMap() {
+  let view = new OverviewView({
+    projection: { getExtent: () => [0, 0, 1000, 4000] },
+    rotation: 0,
+    minResolution: 10,
+    maxResolution: 10,
+  });
+  let size;
+  const map = new EventTarget();
+  return Object.assign(map, {
+    getView: () => view,
+    getSize: () => size,
+    setSize: (nextSize) => {
+      size = nextSize;
+      map.dispatchEvent(new Event('change:size'));
+    },
+    setView: jest.fn((nextView) => {
+      view = nextView;
+      map.dispatchEvent(new Event('change:view'));
+    }),
+    on: (type, handler) => map.addEventListener(type, handler),
+    un: (type, handler) => map.removeEventListener(type, handler),
+  });
+}
+
 describe('configureWSIOverviewMap', () => {
   it('restores state, isolates control events, pans while dragging, and cleans up listeners', () => {
     const parent = document.createElement('div');
@@ -14,6 +65,10 @@ describe('configureWSIOverviewMap', () => {
     const setCenter = jest.fn();
     const getEventCoordinate = jest.fn(() => [12, 34]);
     let collapsed = false;
+    const overviewMap = createOverviewMap();
+    overviewMap.getEventCoordinate = getEventCoordinate;
+    const nativeBoxPointerDown = jest.fn();
+    magnificationBox.addEventListener('pointerdown', nativeBoxPointerDown);
 
     overviewMapElement.className = 'ol-overviewmap-map';
     magnificationBox.className = 'ol-overviewmap-box';
@@ -34,7 +89,7 @@ describe('configureWSIOverviewMap', () => {
             {
               element: controlElement,
               getCollapsed: () => collapsed,
-              getOverviewMap: () => ({ getEventCoordinate }),
+              getOverviewMap: () => overviewMap,
               setCollapsed: (value) => {
                 collapsed = value;
               },
@@ -58,6 +113,7 @@ describe('configureWSIOverviewMap', () => {
     );
 
     expect(parentPointerDown).not.toHaveBeenCalled();
+    expect(nativeBoxPointerDown).not.toHaveBeenCalled();
     expect(parentPointerMove).not.toHaveBeenCalled();
     expect(getEventCoordinate).toHaveBeenCalledTimes(1);
     expect(setCenter).toHaveBeenCalledWith([12, 34]);
@@ -109,5 +165,74 @@ describe('configureWSIOverviewMap', () => {
     expect(parentPointerCancel).toHaveBeenCalledTimes(1);
 
     parent.remove();
+  });
+  it('fits the full slide after resizing, rotation, and view replacement, then removes listeners', () => {
+    const overviewMap = createOverviewMap();
+    const interaction = configureWSIOverviewMap({
+      getControls: () => ({
+        getArray: () => [{ getOverviewMap: () => overviewMap }],
+      }),
+    });
+    expect(overviewMap.setView).not.toHaveBeenCalled();
+    overviewMap.setSize([0, 0]);
+    expect(overviewMap.setView).not.toHaveBeenCalled();
+
+    overviewMap.setSize([200, 100]);
+    expect(overviewMap.getView().options).toMatchObject({
+      center: [500, 2000],
+      resolution: 40,
+      minResolution: 40,
+      maxResolution: 40,
+    });
+    expect(overviewMap.setView).toHaveBeenCalledTimes(1);
+
+    overviewMap.setSize([200, 400]);
+    expect(overviewMap.getView().options.resolution).toBe(10);
+    expect(overviewMap.setView).toHaveBeenCalledTimes(2);
+    overviewMap.setSize([200, 400]);
+    expect(overviewMap.setView).toHaveBeenCalledTimes(2);
+
+    const oldView = overviewMap.getView();
+    oldView.options.rotation = Math.PI / 2;
+    oldView.dispatchEvent(new Event('change:rotation'));
+    expect(overviewMap.getView().options.resolution).toBeCloseTo(20);
+    expect(overviewMap.setView).toHaveBeenCalledTimes(3);
+    oldView.dispatchEvent(new Event('change:rotation'));
+    expect(overviewMap.setView).toHaveBeenCalledTimes(3);
+
+    overviewMap.setView(
+      new OverviewView({
+        projection: { getExtent: () => [0, 0, 6000, 1000] },
+        rotation: Math.PI / 4,
+        minResolution: 1,
+        maxResolution: 1,
+      })
+    );
+    expect(overviewMap.getView().options.resolution).toBeCloseTo(24.748737);
+    expect(overviewMap.setView).toHaveBeenCalledTimes(5);
+
+    interaction.cleanup();
+    overviewMap.setSize([50, 50]);
+    overviewMap.getView().dispatchEvent(new Event('change:rotation'));
+    expect(overviewMap.setView).toHaveBeenCalledTimes(5);
+    overviewMap.setView(new OverviewView({}));
+    expect(overviewMap.setView).toHaveBeenCalledTimes(6);
+  });
+
+  it('does not refit its own replacement view even when resolution constraints differ', () => {
+    const overviewMap = createOverviewMap();
+    overviewMap.setSize([200, 100]);
+    const getMinResolution = jest
+      .spyOn(OverviewView.prototype, 'getMinResolution')
+      .mockReturnValue(0);
+    const interaction = configureWSIOverviewMap({
+      getControls: () => ({
+        getArray: () => [{ getOverviewMap: () => overviewMap }],
+      }),
+    });
+    expect(overviewMap.setView).toHaveBeenCalledTimes(1);
+    expect(overviewMap.getView().options.resolution).toBe(40);
+    interaction.cleanup();
+    getMinResolution.mockRestore();
   });
 });


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->

### Context

Whole-slide microscopy viewports already render an overview map, but its controls can pass pointer and wheel events to viewport tools. The magnification box also cannot pan the main slide. When application styles change the overview dimensions, its fixed zoom can crop the slide. Replacing WSI data in the legacy viewport loses the collapsed state and can leave document drag listeners attached.

This keeps the overview-map change separate from #2870, which covers right-drag region zoom.

### Changes & Results

- Configure overview-map interactions for both legacy and GenericViewport WSI paths.
- Fit the complete slide to the rendered overview size, including after resizing, rotation, or view replacement.
- Avoid recursive refitting when the fitting handler replaces the overview view.
- Stop overview control pointer, double-click, and wheel events from reaching viewport tools.
- Pan the main WSI map while the overview magnification box is dragged, taking precedence over the native box handler.
- Remove document drag listeners when the drag ends or the viewport data is replaced or disabled.
- Preserve the overview map's collapsed state when the legacy `WSIViewport` replaces its data.

Before, overview interactions could activate viewport tools, dragging the magnification box did not pan the slide, and WSI replacement could leave stale listeners. Styling the overview could also leave part of the slide outside its rendered bounds.

After, the full slide fits the overview, interactions remain within the control, drag-to-pan works, and listeners follow the WSI lifecycle.

### Testing

- Core Jest suite passes, including full-slide fitting after resize, rotation and view replacement; zero-size handling; listener cleanup; and protection against recursive refitting.
- Core TypeScript compilation and ESM build steps pass, run directly through Corepack because the local build wrapper could not resolve the pnpm shim.
- Targeted Oxlint, Prettier and Husky pre-commit checks pass.
- Equivalent fitting and drag changes were verified in a downstream viewer with portrait and landscape slides, slide switching, zoom, drag-to-pan, collapse/expand and viewport resizing. Its WSI screenshot regression passes without updating baselines, including an oversized overview in a short viewport. Rotation fitting was checked through the map API.

Manual verification steps:

1. Load a whole-slide image in a legacy or GenericViewport WSI viewport.
2. Resize the overview with application styles and confirm the full slide remains visible. Repeat after rotating or resizing the viewport.
3. Use the overview control and confirm its pointer, double-click and wheel events do not activate viewport tools.
4. Drag the magnification box and confirm the main slide follows until release or cancellation.
5. In the legacy viewport, collapse the overview map, replace the WSI data and confirm it remains collapsed.

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

- [x] The documentation page has been updated as necessary for any public API
  additions or removals. No documentation change is needed because this changes existing overview-map behavior without adding a user-facing option.

#### Tested Environment

- [x] "OS: Windows 11 Enterprise"
- [x] "Node version: 24.20.0"
- [x] "Browser: Chrome Headless 101.0.4950.0"



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved whole-slide image overview-map interactions.
  * Overview maps now support drag-based panning and preserve their collapsed or expanded state when slide data is replaced.
  * Maps automatically fit the slide when the view is resized, rotated, or replaced.
  * Pointer interactions are handled more smoothly, preventing unintended events from affecting surrounding viewer controls.

* **Bug Fixes**
  * Overview-map interactions and event listeners are now properly cleaned up when slide data or the viewer is removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->