### PR TITLE
fix(voi): switch the VOI LUT function on volume viewports

### DIFF
--- a/packages/core/examples/volumeVoiSigmoid/index.ts
+++ b/packages/core/examples/volumeVoiSigmoid/index.ts
@@ -10,6 +10,8 @@ import {
   createImageIdsAndCacheMetaData,
   setTitleAndDescription,
   addButtonToToolbar,
+  addLabelToToolbar,
+  createInfoSection,
 } from '../../../../utils/demo/helpers';
 
 import * as cornerstoneTools from '@cornerstonejs/tools';
@@ -35,44 +37,67 @@ const { ViewportType } = Enums;
 // ======== Set up page ======== //
 setTitleAndDescription(
   'Sigmoid VOI Volume',
-  'This example shows how to set a Sigmoid VOI on a Volume viewport.'
+  'This example shows how to set a Sigmoid VOI on a Volume viewport, and how it ' +
+    'differs from the linear VOI at the same window level.'
 );
+
+// Both buttons apply this same window (WW 1000 / WC -300) so that only the shape
+// of the VOI LUT curve changes between them, which is the point of the example.
+// The window is deliberately placed to clip both ends of this CT: the linear LUT
+// maps everything below -800 to solid black and everything above 200 to solid
+// white, while the sigmoid LUT rolls off instead of clipping and keeps mapping
+// values out to about WC +/- 1.73 * WW. The lung and the bone are therefore
+// where the two functions differ - flat with the linear LUT, and still showing
+// gradation with the sigmoid one, up to about 30 of 255 grey levels of it right
+// at the window edges. In the middle of the window the two curves nearly
+// coincide, which is why an unconstrained window looks the same either way.
+const voiRange = { lower: -800, upper: 200 };
+
+let voiLabel: HTMLLabelElement;
+
+function getViewport() {
+  // Get the rendering engine
+  const renderingEngine = getRenderingEngine(renderingEngineId);
+
+  // Get the volume viewport
+  return renderingEngine.getViewport(viewportId) as Types.IVolumeViewport;
+}
+
+function setVOILUTFunction(VOILUTFunction: Enums.VOILUTFunctionType) {
+  // The same voiRange is set with both functions, so the only thing that
+  // changes is how the values inside (and outside) that range are mapped.
+  const viewport = getViewport();
+
+  viewport.setProperties({ VOILUTFunction, voiRange });
+  viewport.render();
+  updateVoiLabel();
+}
+
+// Shows which function is active and on which window, since the window level
+// tool can change the window afterwards.
+function updateVoiLabel() {
+  const { voiRange: range, VOILUTFunction } = getViewport().getProperties();
+  const windowWidth = Math.round(range.upper - range.lower);
+  const windowCenter = Math.round((range.lower + range.upper) / 2);
+
+  voiLabel.innerText = `${VOILUTFunction} - WW ${windowWidth} / WC ${windowCenter}`;
+}
 
 addButtonToToolbar({
   title: 'Set Linear VOI',
-  onClick: () => {
-    // Get the rendering engine
-    const renderingEngine = getRenderingEngine(renderingEngineId);
-
-    // Get the volume viewport
-    const viewport = renderingEngine.getViewport(
-      viewportId
-    ) as Types.IVolumeViewport;
-
-    // Set a range to highlight bones
-    viewport.setProperties({ VOILUTFunction: Enums.VOILUTFunctionType.LINEAR });
-
-    viewport.render();
-  },
+  onClick: () => setVOILUTFunction(Enums.VOILUTFunctionType.LINEAR),
 });
 
 addButtonToToolbar({
   title: 'Set Sigmoid VOI',
-  onClick: () => {
-    // Get the rendering engine
-    const renderingEngine = getRenderingEngine(renderingEngineId);
+  onClick: () => setVOILUTFunction(Enums.VOILUTFunctionType.SAMPLED_SIGMOID),
+});
 
-    // Get the volume viewport
-    const viewport = renderingEngine.getViewport(
-      viewportId
-    ) as Types.IVolumeViewport;
-
-    // Set a range to highlight bones
-    viewport.setProperties({
-      VOILUTFunction: Enums.VOILUTFunctionType.SAMPLED_SIGMOID,
-    });
-
-    viewport.render();
+voiLabel = addLabelToToolbar({
+  id: 'voiState',
+  title: 'VOI:',
+  style: {
+    paddingLeft: '10px',
   },
 });
 
@@ -83,6 +108,20 @@ element.style.width = '512px';
 element.style.height = '512px';
 
 content.appendChild(element);
+
+createInfoSection(content)
+  .addInstruction(
+    'Both buttons apply the same window (WW 1000 / WC -300), so only the VOI LUT function changes'
+  )
+  .addInstruction(
+    'Linear clips at the window: lung and air below -800 go solid black, bone above 200 goes solid white'
+  )
+  .addInstruction(
+    'Sigmoid rolls off instead of clipping, so the lung and the bone keep some gradation - that is where to look for the difference'
+  )
+  .addInstruction(
+    'Left click drag window levels the volume, and both functions follow the new window'
+  );
 // ============================= //
 
 /**
@@ -156,10 +195,14 @@ async function run() {
   volume.load();
 
   // Set the volume on the viewport
-  viewport.setVolumes([{ volumeId }]);
+  await viewport.setVolumes([{ volumeId }]);
 
-  // Render the image
-  viewport.render();
+  // Keeps the label honest while the window level tool is used.
+  element.addEventListener(Enums.Events.VOI_MODIFIED, updateVoiLabel);
+
+  // Start off in the linear state that the buttons switch between, so that the
+  // first click on either button is a pure change of the VOI LUT function.
+  setVOILUTFunction(Enums.VOILUTFunctionType.LINEAR);
 }
 
 run();

--- a/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
@@ -462,22 +462,18 @@ abstract class BaseVolumeViewport extends Viewport {
       throw new Error(`No actor found for the given volumeId: ${volumeId}`);
     }
 
-    const volumeActor = applicableVolumeActorInfo.volumeActor;
-
-    const transferFunction = volumeActor
-      .getProperty()
-      .getRGBTransferFunction(0);
-
-    const range = transferFunction.getMappingRange();
-
     const matchedColormap = this.getColormap(volumeId);
-    const { VOILUTFunction, invert } = this.getProperties(volumeId);
+    // The mapping range of the transfer function is only the VOI for a linear
+    // function. A sampled sigmoid bakes its curve into the nodes, so its
+    // mapping range is the whole node domain (~3.3x the window width, and
+    // off-center) - getProperties decodes the real window back out of it.
+    const { VOILUTFunction, invert, voiRange } = this.getProperties(volumeId);
 
     return {
       viewportId: this.id,
       range: {
-        lower: range[0],
-        upper: range[1],
+        lower: voiRange.lower,
+        upper: voiRange.upper,
       },
       volumeId: applicableVolumeActorInfo.volumeId,
       VOILUTFunction: VOILUTFunction,

--- a/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
+++ b/packages/core/src/RenderingEngine/BaseVolumeViewport.ts
@@ -45,6 +45,7 @@ import triggerEvent from '../utilities/triggerEvent';
 import * as colormapUtils from '../utilities/colormap';
 import invertRgbTransferFunction from '../utilities/invertRgbTransferFunction';
 import createSigmoidRGBTransferFunction from '../utilities/createSigmoidRGBTransferFunction';
+import createLinearRGBTransferFunction from '../utilities/createLinearRGBTransferFunction';
 import transformWorldToIndex from '../utilities/transformWorldToIndex';
 import {
   findMatchingColormap,
@@ -273,9 +274,23 @@ abstract class BaseVolumeViewport extends Viewport {
     if (!Object.values(VOILUTFunctionType).includes(voiLUTFunction)) {
       voiLUTFunction = VOILUTFunctionType.LINEAR;
     }
+
+    // The range has to be read while the old function is still recorded, since
+    // getProperties extracts it differently for a sampled sigmoid function.
     const { voiRange } = this.getProperties();
-    this.setVOI(voiRange, volumeId, suppressEvents);
+    const previousVOILUTFunction = this.viewportProperties.VOILUTFunction;
+
+    // A sampled function bakes its curve into the nodes of the transfer
+    // function, so moving away from one has to build a new function rather than
+    // just rescale the existing (still sigmoid shaped) one.
+    const forceRecreateLUTFunction =
+      previousVOILUTFunction !== voiLUTFunction &&
+      previousVOILUTFunction === VOILUTFunctionType.SAMPLED_SIGMOID;
+
+    // Record it before setVOI, which reads it back to decide which transfer
+    // function to apply.
     this.viewportProperties.VOILUTFunction = voiLUTFunction;
+    this.setVOI(voiRange, volumeId, suppressEvents, forceRecreateLUTFunction);
   }
 
   /**
@@ -521,11 +536,16 @@ abstract class BaseVolumeViewport extends Viewport {
    * @param voiRange - Sets the lower and upper voi
    * @param volumeId - The volume id to set the properties for (if undefined, the first volume)
    * @param suppressEvents - If true, the viewport will not emit events
+   * @param forceRecreateLUTFunction - If true, the RGB transfer function is
+   *   rebuilt instead of having its range updated. Required when the VOI LUT
+   *   function changed, since a sampled (sigmoid) function keeps its curve in
+   *   the transfer function nodes.
    */
   private setVOI(
     voiRange: VOIRange,
     volumeId?: string,
-    suppressEvents = false
+    suppressEvents = false,
+    forceRecreateLUTFunction = false
   ): void {
     const applicableVolumeActorInfo = this._getApplicableVolumeActor(volumeId);
 
@@ -558,15 +578,22 @@ abstract class BaseVolumeViewport extends Viewport {
     // https://github.com/Kitware/vtk-js/blob/c6f2e12cddfe5c0386a73f0793eb6d9ab20d573e/Sources/Rendering/OpenGL/VolumeMapper/index.js#L957-L972
     if (VOILUTFunction === VOILUTFunctionType.SAMPLED_SIGMOID) {
       const cfun = createSigmoidRGBTransferFunction(voiRangeToUse);
+      if (this.viewportProperties.invert) {
+        invertRgbTransferFunction(cfun);
+      }
+      volumeActor.getProperty().setRGBTransferFunction(0, cfun);
+    } else if (forceRecreateLUTFunction) {
+      // Coming back from a sampled function, whose curve lives in the nodes of
+      // the transfer function - rescaling that range would keep the sigmoid
+      // shape, so a plain linear function is built instead. Any colormap was
+      // already dropped when the sampled function replaced it.
+      // TODO: make this work for PET series (colormap)
+      const cfun = createLinearRGBTransferFunction(voiRangeToUse);
+      if (this.viewportProperties.invert) {
+        invertRgbTransferFunction(cfun);
+      }
       volumeActor.getProperty().setRGBTransferFunction(0, cfun);
     } else {
-      // TODO: refactor and make it work for PET series (inverted/colormap)
-      // const cfun = createLinearRGBTransferFunction(voiRangeToUse);
-      // volumeActor.getProperty().setRGBTransferFunction(0, cfun);
-
-      // Todo: Moving from LINEAR to SIGMOID and back to LINEAR will not
-      // work until we implement it in a different way because the
-      // LINEAR transfer function is not recreated.
       const { lower, upper } = voiRangeToUse;
       volumeActor
         .getProperty()
@@ -1095,16 +1122,19 @@ abstract class BaseVolumeViewport extends Viewport {
       this.setThreshold(colormap, volumeId);
     }
 
+    // The VOI LUT function has to be applied before the range, otherwise the
+    // range would first be applied with the previous function and then be read
+    // back out of the transfer function by setVOILUTFunction.
+    if (VOILUTFunction !== undefined) {
+      this.setVOILUTFunction(VOILUTFunction, volumeId, suppressEvents);
+    }
+
     if (voiRange !== undefined) {
       this.setVOI(voiRange, volumeId, suppressEvents);
     }
 
     if (typeof interpolationType !== 'undefined') {
       this.setInterpolationType(interpolationType);
-    }
-
-    if (VOILUTFunction !== undefined) {
-      this.setVOILUTFunction(VOILUTFunction, volumeId, suppressEvents);
     }
 
     if (preset !== undefined) {
@@ -1227,12 +1257,14 @@ abstract class BaseVolumeViewport extends Viewport {
       this.setOpacity(properties.colormap, volumeId);
     }
 
-    if (properties.voiRange !== undefined) {
-      this.setVOI(properties.voiRange, volumeId);
-    }
-
+    // As in setProperties, the VOI LUT function comes first so that the range
+    // is applied with the function it belongs to.
     if (properties.VOILUTFunction !== undefined) {
       this.setVOILUTFunction(properties.VOILUTFunction, volumeId);
+    }
+
+    if (properties.voiRange !== undefined) {
+      this.setVOI(properties.voiRange, volumeId);
     }
 
     if (properties.invert !== undefined) {

--- a/packages/core/src/RenderingEngine/GenericViewport/Planar/planarLegacyCompatibility.ts
+++ b/packages/core/src/RenderingEngine/GenericViewport/Planar/planarLegacyCompatibility.ts
@@ -209,6 +209,13 @@ export function toPlanarDataPresentation(
     presentation.voiRange = cloneVOIRange(properties.voiRange);
   }
 
+  // The legacy property is named VOILUTFunction, the presentation one
+  // voiLUTFunction - without this mapping a sigmoid VOI LUT function set through
+  // setProperties never reaches the render path.
+  if (properties.VOILUTFunction !== undefined) {
+    presentation.voiLUTFunction = properties.VOILUTFunction;
+  }
+
   if (properties.invert !== undefined) {
     presentation.invert = properties.invert;
   }

--- a/packages/core/src/RenderingEngine/GenericViewport/Planar/planarVolumePresentation.ts
+++ b/packages/core/src/RenderingEngine/GenericViewport/Planar/planarVolumePresentation.ts
@@ -55,6 +55,7 @@ export function applyPlanarVolumePresentation(args: {
     colormap: props?.colormap,
     invert: props?.invert,
     voiRange,
+    voiLUTFunction: props?.voiLUTFunction,
   });
 
   property.setUseLookupTableScalarRange(true);

--- a/packages/core/src/utilities/getVoiFromSigmoidRGBTransferFunction.ts
+++ b/packages/core/src/utilities/getVoiFromSigmoidRGBTransferFunction.ts
@@ -19,5 +19,9 @@ export default function getVoiFromSigmoidRGBTransferFunction(
   const x2 = cfunDomain[256 * 3];
   const ww = Math.round((4 * (x2 - x1)) / (logy1 - logy2));
   const wc = Math.round(x1 + (ww * logy1) / 4);
-  return [Math.round(wc - ww / 2), Math.round(wc + ww / 2)];
+  // An inverted function decreases with x, which flips the sign of the window
+  // width derived above (the center is unaffected). Return the range in order
+  // regardless, so callers do not get a lower bound above the upper one.
+  const windowWidth = Math.abs(ww);
+  return [Math.round(wc - windowWidth / 2), Math.round(wc + windowWidth / 2)];
 }

--- a/packages/core/src/utilities/getVoiFromSigmoidRGBTransferFunction.ts
+++ b/packages/core/src/utilities/getVoiFromSigmoidRGBTransferFunction.ts
@@ -1,5 +1,19 @@
 import type vtkColorTransferFunction from '@kitware/vtk.js/Rendering/Core/ColorTransferFunction';
+import VOILUTFunctionType from '../enums/VOILUTFunctionType';
+import { toLowHighRange } from './windowLevel';
 
+/**
+ * Recovers the VOI range a sampled sigmoid transfer function was built from.
+ *
+ * The nodes hold the DICOM sigmoid (PS3.3 C.11.2.1.3.1)
+ * `y = 1 / (1 + exp(-4 * (x - c) / w))`, so window width and center are solved
+ * for analytically from two samples of the curve. Converting those back to a
+ * range has to use the same convention as `createSigmoidRGBTransferFunction`,
+ * which reads the range through `toWindowLevel` - hence `toLowHighRange` here
+ * rather than a plain `c +/- w/2`. The two are exact inverses, so a range
+ * survives any number of round trips unchanged. If the sigmoid branch of one of
+ * them ever diverges from the linear convention, the other has to follow.
+ */
 export default function getVoiFromSigmoidRGBTransferFunction(
   cfun: vtkColorTransferFunction
 ): [number, number] {
@@ -17,11 +31,20 @@ export default function getVoiFromSigmoidRGBTransferFunction(
   const y2 = cfunRange[256 * 3];
   const logy2 = Math.log((1 - y2) / y2);
   const x2 = cfunDomain[256 * 3];
-  const ww = Math.round((4 * (x2 - x1)) / (logy1 - logy2));
-  const wc = Math.round(x1 + (ww * logy1) / 4);
+  // Kept unrounded - the window center is derived from the width, and the
+  // center is a half integer whenever the range bounds sum to an even number,
+  // so rounding either one here would shift the range by up to one.
+  const ww = (4 * (x2 - x1)) / (logy1 - logy2);
+  const wc = x1 + (ww * logy1) / 4;
   // An inverted function decreases with x, which flips the sign of the window
   // width derived above (the center is unaffected). Return the range in order
   // regardless, so callers do not get a lower bound above the upper one.
   const windowWidth = Math.abs(ww);
-  return [Math.round(wc - windowWidth / 2), Math.round(wc + windowWidth / 2)];
+  const { lower: voiLower, upper: voiUpper } = toLowHighRange(
+    windowWidth,
+    wc,
+    VOILUTFunctionType.SAMPLED_SIGMOID
+  );
+
+  return [Math.round(voiLower), Math.round(voiUpper)];
 }

--- a/packages/core/test/utilities/getVoiFromSigmoidRGBTransferFunction.jest.js
+++ b/packages/core/test/utilities/getVoiFromSigmoidRGBTransferFunction.jest.js
@@ -1,0 +1,30 @@
+import { describe, it, expect } from '@jest/globals';
+import createSigmoidRGBTransferFunction from '../../src/utilities/createSigmoidRGBTransferFunction';
+import getVoiFromSigmoidRGBTransferFunction from '../../src/utilities/getVoiFromSigmoidRGBTransferFunction';
+import invertRgbTransferFunction from '../../src/utilities/invertRgbTransferFunction';
+
+describe('getVoiFromSigmoidRGBTransferFunction', function () {
+  it('Should recover the range a sigmoid function was built from', () => {
+    const cfun = createSigmoidRGBTransferFunction({ lower: -800, upper: 200 });
+
+    const [lower, upper] = getVoiFromSigmoidRGBTransferFunction(cfun);
+
+    expect(lower).toBeCloseTo(-800, -1);
+    expect(upper).toBeCloseTo(200, -1);
+  });
+
+  it('Should return the range in order for an inverted sigmoid function', () => {
+    const cfun = createSigmoidRGBTransferFunction({ lower: -800, upper: 200 });
+
+    invertRgbTransferFunction(cfun);
+
+    const [lower, upper] = getVoiFromSigmoidRGBTransferFunction(cfun);
+
+    // Without ordering, the window width comes out negative for an inverted
+    // function and the range is reversed, which flips a linear function rebuilt
+    // from it (see BaseVolumeViewport.setVOI).
+    expect(lower).toBeLessThan(upper);
+    expect(lower).toBeCloseTo(-800, -1);
+    expect(upper).toBeCloseTo(200, -1);
+  });
+});

--- a/packages/core/test/utilities/getVoiFromSigmoidRGBTransferFunction.jest.js
+++ b/packages/core/test/utilities/getVoiFromSigmoidRGBTransferFunction.jest.js
@@ -9,8 +9,34 @@ describe('getVoiFromSigmoidRGBTransferFunction', function () {
 
     const [lower, upper] = getVoiFromSigmoidRGBTransferFunction(cfun);
 
-    expect(lower).toBeCloseTo(-800, -1);
-    expect(upper).toBeCloseTo(200, -1);
+    expect(lower).toBe(-800);
+    expect(upper).toBe(200);
+  });
+
+  it('Should recover a range whose bounds sum to an even number', () => {
+    // The window center is a half integer here, so rounding it before
+    // converting back to a range would shift the result by one.
+    const cfun = createSigmoidRGBTransferFunction({
+      lower: -1000,
+      upper: 1000,
+    });
+
+    const [lower, upper] = getVoiFromSigmoidRGBTransferFunction(cfun);
+
+    expect(lower).toBe(-1000);
+    expect(upper).toBe(1000);
+  });
+
+  it('Should not drift when the range is round tripped repeatedly', () => {
+    let range = { lower: -800, upper: 200 };
+
+    for (let i = 0; i < 50; i++) {
+      const cfun = createSigmoidRGBTransferFunction(range);
+      const [lower, upper] = getVoiFromSigmoidRGBTransferFunction(cfun);
+      range = { lower, upper };
+    }
+
+    expect(range).toEqual({ lower: -800, upper: 200 });
   });
 
   it('Should return the range in order for an inverted sigmoid function', () => {
@@ -24,7 +50,7 @@ describe('getVoiFromSigmoidRGBTransferFunction', function () {
     // function and the range is reversed, which flips a linear function rebuilt
     // from it (see BaseVolumeViewport.setVOI).
     expect(lower).toBeLessThan(upper);
-    expect(lower).toBeCloseTo(-800, -1);
-    expect(upper).toBeCloseTo(200, -1);
+    expect(lower).toBe(-800);
+    expect(upper).toBe(200);
   });
 });

--- a/tests/volumeVoiSigmoid.spec.ts
+++ b/tests/volumeVoiSigmoid.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from 'playwright-test-coverage';
+import type { Page } from '@playwright/test';
+import { visitExample, waitForRenderSettled } from './utils/index';
+
+test.beforeEach(async ({ page }) => {
+  await visitExample(page, 'volumeVoiSigmoid');
+});
+
+/**
+ * Grey level of every canvas pixel, read back through a 2D canvas so it works
+ * for the WebGL canvases as well.
+ */
+async function readCanvasGreyLevels(page: Page): Promise<number[]> {
+  return page.evaluate(() => {
+    const canvas = document.querySelector(
+      '.cornerstone-canvas'
+    ) as HTMLCanvasElement;
+    const copy = document.createElement('canvas');
+
+    copy.width = canvas.width;
+    copy.height = canvas.height;
+
+    const context = copy.getContext('2d');
+
+    context.drawImage(canvas, 0, 0);
+
+    const { data } = context.getImageData(0, 0, copy.width, copy.height);
+    const greyLevels: number[] = [];
+
+    for (let index = 0; index < data.length; index += 4) {
+      greyLevels.push(data[index]);
+    }
+
+    return greyLevels;
+  });
+}
+
+function meanGreyDifference(a: number[], b: number[]): number {
+  expect(a.length).toBe(b.length);
+  expect(a.length).toBeGreaterThan(0);
+
+  let total = 0;
+
+  for (let index = 0; index < a.length; index++) {
+    total += Math.abs(a[index] - b[index]);
+  }
+
+  return total / a.length;
+}
+
+test.describe('Sigmoid VOI Volume', async () => {
+  test('should render differently for the sigmoid and the linear VOI LUT function.', async ({
+    page,
+  }) => {
+    const label = page.locator('#voiState');
+
+    await expect(label).toHaveText(/LINEAR/);
+
+    const linear = await readCanvasGreyLevels(page);
+
+    await page.getByRole('button', { name: 'Set Sigmoid VOI' }).click();
+    await waitForRenderSettled(page);
+
+    await expect(label).toHaveText(/SIGMOID/);
+
+    const sigmoid = await readCanvasGreyLevels(page);
+
+    // Both functions use the same window, so this is purely the difference
+    // between the two curves. The example picks a window that clips the lung and
+    // the bone with the linear function, where the sigmoid one still has a
+    // gradient, which measures at about 11 grey levels on average.
+    expect(meanGreyDifference(linear, sigmoid)).toBeGreaterThan(3);
+
+    await page.getByRole('button', { name: 'Set Linear VOI' }).click();
+    await waitForRenderSettled(page);
+
+    await expect(label).toHaveText(/LINEAR/);
+
+    // Going back has to restore the linear render rather than leaving the
+    // sampled sigmoid curve in place with a rescaled range.
+    const linearAgain = await readCanvasGreyLevels(page);
+
+    expect(meanGreyDifference(linear, linearAgain)).toBeLessThan(1);
+  });
+});


### PR DESCRIPTION
> ## Closed: folded into #2856
>
> Every fix here now lives on the `voi-lut-support` branch of #2856, which is
> where it belongs. #2856 is what makes a SIGMOID tagged series apply a sigmoid
> on a volume viewport at all — the `setDefaultVolumeVOI` gap listed under
> **Notes** below — so the read back and inversion fixes in this PR are only
> fully exercised once that lands. Landing them separately would have put the
> window drift and the lost inversion into `main` for however long the rebase
> took.
>
> | Here | In #2856 |
> | --- | --- |
> | `616e2d81c` read the sigmoid VOI range back exactly | taken whole, with its four case jest test |
> | `2ccfc2d7b` report the decoded window in `VOI_MODIFIED` | cherry-picked clean |
> | `b9af62ce6` inversion re-applied on a rebuilt curve | hand ported, and widened to cover a VOI LUT Sequence curve |
> | `b9af62ce6` `volumeVoiSigmoid` example and `tests/volumeVoiSigmoid.spec.ts` | taken whole |
>
> **Not carried over:** the `setVOILUTFunction` ordering fix, the
> `forceRecreateLUTFunction` port, and the planar `VOILUTFunction` mapping.
> #2856 arrived at all three independently, and its per volume curve tracking
> also covers the `useVOILUTSequence: false` transition that a flag keyed on a
> change of function misses. The `setProperties` / `resetToDefaultProperties`
> reorder was dropped as well: it was only needed because the range was read
> back through the inexact sigmoid decode, and with that decode exact both
> orders land on the same curve and the same window.
>
> #2856 also picked up one further defect found while merging: `getProperties`
> solved whatever was on the actor for a window whenever the VOI LUT Function
> was SIGMOID. A colormap and a VOI LUT Sequence each replace the curve while
> that attribute stays in effect, so a colormapped SIGMOID series returned a
> range of `NaN` and window level went dead on the viewport.
>
> **Two corrections to the Notes section below.** The claim that this PR is
> "complementary to #2856 and conflict free (no shared files)" was true when
> written and is not any more — #2856 grew to cover the volume path and now
> shares `BaseVolumeViewport.ts`, `planarLegacyCompatibility.ts` and
> `planarVolumePresentation.ts`. And two of the three items listed there as
> still open are fixed by #2856: a SIGMOID tagged series rendering linear on a
> volume viewport, and a colormap being dropped on a switch to sigmoid.
>
> The original description follows unchanged, as the record of the analysis.

---

### Context

Fixes #2458 - clicking either **Set Linear VOI** or **Set Sigmoid VOI** in the [volumevoisigmoid](https://www.cornerstonejs.org/live-examples/volumevoisigmoid) example does nothing, with no console error.

The example was not the only problem. Two ordering defects in `BaseVolumeViewport` meant the switch never reached the transfer function:

- `setVOILUTFunction` called `setVOI` **before** recording the new function, so `setVOI` always built the transfer function for the *previous* mode. The first sigmoid click did nothing; a later click applied it off by one.
- Coming back from a sampled sigmoid only called `setRange` on the existing 1024 node sigmoid shaped function, so the curve stayed sigmoid (the `Todo:` that was in that branch).

And on the generic/planar viewports `VOILUTFunction` was dropped entirely: `toPlanarDataPresentation` never mapped it onto the presentation's `voiLUTFunction`, and `applyPlanarVolumePresentation` never passed it to the transfer function builder.

Separately, the example could not have shown the difference even once fixed: with an unconstrained window the two curves nearly coincide, which is what the issue thread observed.

### Changes & Results

Core:

- Record the VOI LUT function before `setVOI` reads it back, and rebuild the transfer function when leaving a sampled one instead of rescaling it, re-applying `invert` so an inverted volume stays inverted across a switch. A colormap is untouched when the function does not change.
- Apply the VOI LUT function before the range in `setProperties` / `resetToDefaultProperties`, so a combined `{ VOILUTFunction, voiRange }` call does not apply the range through the previous curve and then read it back out.
- Map `VOILUTFunction` onto the planar data presentation and pass `voiLUTFunction` to the volume slice transfer function, so the generic viewport applies it too. This also affects the stack sigmoid example in compatibility mode (mean grey difference between the two functions measured 0 before, 19.6 after), and it is what makes `props.voiLUTFunction` reachable at all from `setProperties` on those viewports.
- `getVOIModifiedEventDetail` read the emitted range off the transfer function's **mapping range**. That is the VOI only for a linear function - a sampled sigmoid bakes its curve into the nodes, so its mapping range is the whole node domain, `[c - 1.733w, c + 1.560w]`, about **3.3x** the window width and off center. Once the two fixes above make the sigmoid actually apply on the first click, that bogus range reaches every `VOI_MODIFIED` consumer: `voiSyncCallback` copies `detail.range` verbatim into `setProperties({ voiRange })` on the target, and `ViewportColorbar` reads the same field, so a synced or colorbar'd viewport washed out at `WW 3293 / WC -387` for a `-800..200` window. It now takes `voiRange` off the `getProperties(volumeId)` call the method already makes, which decodes the sigmoid back to the real window. Linear viewports are byte identical - vtk's `getRange()` *is* `getMappingRange()`, which is what `getProperties` returns on the non sigmoid branch. Pre existing on `main` (the same range was emitted on the next window level drag), but this PR is what makes it reachable from a single click.
- `getVoiFromSigmoidRGBTransferFunction` had two defects. It returned a **reversed** range for an inverted curve, since the derived window width comes out negative, which flipped a linear function rebuilt from it; the range is now returned in order. And it converted window width/center to a range as `c ± w/2` - LINEAR_EXACT semantics - while every other range/window conversion in the codebase uses the C.11.2.1.2.1 note 4 convention that `createSigmoidRGBTransferFunction` reads the range through. The mismatch widened the window by one on every round trip (`-800..200` came back as `-800..201`, drifting to about `WW 1050` after 50 LINEAR/SIGMOID toggles without a re-supplied `voiRange`). It now converts through `toLowHighRange`, the exact inverse of that `toWindowLevel` call, so a range survives any number of round trips unchanged. Two rounding calls went with it: the window width was rounded before being used to derive the center, and the center is a half integer whenever the range bounds sum to an even number, so `Math.round(-299.5)` shifted the range half a unit in each direction.

`toWindowLevel` is deliberately **not** touched. Its `+1` / `+0.5` terms cancel against `toLowHighRange`, so the sigmoid curve built from DICOM tags was already spec exact (PS3.3 C.11.2.1.3.1, `y = 1 / (1 + exp(-4(x - c)/w))`, with `logit` its exact analytical inverse and no LINEAR `-0.5`/`(w-1)` offsets applied). Adding a sigmoid branch to only one side of that pair would inject a one unit drift per drag into `WindowLevelTool` and `Colorbar`, which call both.

Example:

- Both buttons apply the **same** window, `WW 1000 / WC -300`, so only the shape of the curve changes. The window is placed to clip both ends of this CT: the linear LUT maps lung/air below -800 to solid black and bone above 200 to solid white, where the sigmoid rolls off instead and keeps a gradient. Measured on the canvas: **86% of pixels change, 61% of them by 10 or more grey levels, mean 11.6/255, peak 31/255** - 31 is the maximum possible at identical WW/WC, since the curves differ by 0.119 at the window edges.
- A toolbar label shows the active function and window (the issue also noted there was no feedback that anything happened), and an info section says where to look. With the exact read back it now reads `WW 1000 / WC -300` under **both** functions, rather than `WW 1001 / WC -299` under the sigmoid - which is the point of the example, the same window with only the curve changing.

| Linear | Sigmoid |
| --- | --- |
| lung and bone flat | vertebral bodies and lung keep gradation |

### Testing

1. Visit the `volumeVoiSigmoid` example.
2. Click **Set Sigmoid VOI**: the blown out vertebral bodies gain internal texture and the lung/air lifts off pure black. The label reads `SIGMOID - WW 1000 / WC -300`.
3. Click **Set Linear VOI**: the render returns exactly to the starting image, and the label reads `LINEAR` on the same window.
4. Left click drag still window levels, and both functions follow the new window.

Automated:

- `tests/volumeVoiSigmoid.spec.ts` - new, snapshot free (canvas pixel comparison): the sigmoid render must differ from the linear one, and switching back must restore it. Passes in legacy and compatibility modes, and **fails with `Received: 0` when the core changes are reverted**, so it guards the reported bug.
- `packages/core/test/utilities/getVoiFromSigmoidRGBTransferFunction.jest.js` - new, 4 cases: the ordered range for an inverted curve, exact recovery of the range a sigmoid was built from, a range whose bounds sum to an even number (half integer center, which the old rounding shifted), and 50 consecutive round trips with no drift.
- Full jest suite passes (118 suites, 1850 tests, 4 skipped). `volumeBasic` snapshot unchanged.

### Notes

- Complementary to #2856 and conflict free (no shared files). That PR fixes the stack/CPU/metadata side and keeps the same `forceRecreateLUTFunction` mechanism on the stack path that this ports to the volume path; it does not touch volume viewport switching. One follow up once it lands: use its shared `getValidVOILUTFunction` in `setVOILUTFunction` instead of the inline enum check. (The other follow up previously listed here, an exactly invertible `getVoiFromSigmoidRGBTransferFunction`, is done in this PR - the 1 HU rounding in the label is gone.)
- Still open, and not addressed here: a SIGMOID tagged series renders linear on a volume viewport, because `setDefaultVolumeVOI` writes only the range to the actor and never sets `viewportProperties.VOILUTFunction` - it takes an actor, not a viewport, so it cannot.
- A colormap is still dropped when switching to sigmoid. Pre existing, and the `TODO` for PET is carried forward rather than widened.
- Also still open: `toLowHighRange` has no sigmoid branch of its own - it routes `SAMPLED_SIGMOID` through the linear formula, with the asymptotic 1%/99% version sitting commented out. Consistent as it stands, and changing it would change range semantics app wide, so it is left alone.
- Known sampling deviation, unchanged by this PR: the standard's sigmoid is asymptotic over all x, while the implementation samples 1024 nodes uniformly in y over `[1/1026, 1024/1026]`, so vtk clamps outside the node domain at y = 0.00097 and y = 0.99805 rather than 0 and 1 - about 0.2% of full output range at the bright end. Uniform in y is the right way round, since it puts the dense samples where the slope is steep. It is also the asymmetry of that interval that makes the node domain off center, and hence why the mapping range could not be used as the VOI above.

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments, etc.)

#### Public Documentation Updates

- [x] The documentation page has been updated as necessary for any public API additions or removals.

#### Tested Environment

- [x] "OS: Windows 11"
- [x] "Node version: 24.2.0"
- [x] "Browser: Chromium (Playwright)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for switching volume visualization between linear and sampled-sigmoid VOI modes.
  - Updated the example interface with the active VOI mode and guidance for comparing rendering results.
  - Window-level changes now update the displayed VOI state.

- **Bug Fixes**
  - Preserved VOI ranges and inversion when switching transfer functions.
  - Ensured inverted sigmoid VOI ranges remain correctly ordered.
  - Improved compatibility with legacy VOI LUT settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

