### PR TITLE
fix(dicomImageLoader): Fix expected number of LUT entries when tag value is 0

### DIFF
--- a/packages/dicomImageLoader/src/imageLoader/wadouri/metaData/getLUTs.ts
+++ b/packages/dicomImageLoader/src/imageLoader/wadouri/metaData/getLUTs.ts
@@ -5,7 +5,8 @@ function getLUT(pixelRepresentation: number, lutDataSet: DataSet): LutType {
   let numLUTEntries = lutDataSet.uint16('x00283002', 0);
 
   if (numLUTEntries === 0) {
-    numLUTEntries = 65535;
+    // DICOM PS3.3 C.11.1.1.1
+    numLUTEntries = 65536;
   }
   let firstValueMapped = 0;
 


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

The code was incorrectly interpreting value `0` as `65535` instead of `65536`, unlike what DICOM PS3.3 C.11.1.1.1 specifies.

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

Fixed the code -> file now decodes fine.

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

Tested with an XRay file from a GE scanner I unfortunately can't share here.

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: macOS
- [x] Node version: 24
- [x] Browser: Firefox 153

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected lookup table handling for DICOM images when the encoded entry count is zero.
  * Ensures 65,536 entries are used as specified, improving image rendering accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->