### PR TITLE
[WIP] fix(4d): resolve imageIds within the active dimension group

### DIFF
--- a/packages/core/src/RenderingEngine/StackViewport.ts
+++ b/packages/core/src/RenderingEngine/StackViewport.ts
@@ -58,6 +58,9 @@ import { isEqual } from '../utilities/isEqual';
 import invertRgbTransferFunction from '../utilities/invertRgbTransferFunction';
 import imageRetrieveMetadataProvider from '../utilities/imageRetrieveMetadataProvider';
 import imageIdToURI from '../utilities/imageIdToURI';
+import getDimensionGroupIndexMap, {
+  areInDifferentDimensionGroups,
+} from '../utilities/getDimensionGroupIndexMap';
 import getVOIRangeFromWindowLevel from '../utilities/getVOIRangeFromWindowLevel';
 
 import Viewport from './Viewport';
@@ -154,6 +157,14 @@ class StackViewport extends Viewport {
    * the imageId or URI is present without having to scan the imageIds array.
    */
   private imageKeyToIndexMap = new Map<string, number>();
+  /**
+   * Maps each imageId of a 4D stack to the index of the dimension group (time
+   * point, b-value, echo, ...) it belongs to. Built lazily because it needs the
+   * 4D metadata of every image in the stack, and left undefined for a stack
+   * that only has a single dimension group. Cleared whenever the stack changes.
+   */
+  private imageIdToDimensionGroupIndexMap: Map<string, number> | undefined;
+  private hasResolvedDimensionGroups = false;
 
   // current imageIdIndex that is rendered in the viewport
   private currentImageIdIndex = 0;
@@ -1755,6 +1766,12 @@ class StackViewport extends Viewport {
 
   /**
    * Matches images for overlay by comparing their orientation, position, and dimensions.
+   *
+   * Geometry alone cannot separate the dimension groups of a 4D stack - slice k
+   * carries the same position and orientation at every time point - so a
+   * geometric match is additionally rejected when the two images are known to
+   * belong to different dimension groups of the same stack.
+   *
    * @param currentImageId - The ID of the current image.
    * @param targetOverlayImageId - The ID of the target overlay image.
    * @returns The ID of the matched image, or undefined if no match is found.
@@ -1827,7 +1844,53 @@ class StackViewport extends Viewport {
       }
     };
 
-    return matchImagesForOverlay(currentImageId);
+    const matchedImageId = matchImagesForOverlay(currentImageId);
+
+    if (
+      !matchedImageId ||
+      this.isDifferentDimensionGroup(currentImageId, targetOverlayImageId)
+    ) {
+      return;
+    }
+
+    return matchedImageId;
+  }
+
+  /**
+   * Returns true when both images resolve to a known - and different -
+   * dimension group of this stack. Anything unknown (a 3D stack, or an overlay
+   * belonging to some other series) returns false so the geometric match
+   * stands.
+   */
+  private isDifferentDimensionGroup(
+    currentImageId: string,
+    overlayImageId: string
+  ): boolean {
+    return areInDifferentDimensionGroups(
+      this.getDimensionGroupIndexMap(),
+      currentImageId,
+      // A derived image (a labelmap slice, for instance) is not itself part of
+      // the stack, so compare using the image it was derived from.
+      cache.getImage(overlayImageId)?.referencedImageId ?? overlayImageId
+    );
+  }
+
+  /**
+   * Lazily splits this stack into dimension groups, returning undefined when it
+   * is not 4D. Computed on first use rather than in setStack because it reads
+   * the 4D metadata of every image and most stacks never need it.
+   */
+  private getDimensionGroupIndexMap(): Map<string, number> | undefined {
+    if (this.hasResolvedDimensionGroups) {
+      return this.imageIdToDimensionGroupIndexMap;
+    }
+
+    this.hasResolvedDimensionGroups = true;
+    this.imageIdToDimensionGroupIndexMap = getDimensionGroupIndexMap(
+      this.imageIds
+    );
+
+    return this.imageIdToDimensionGroupIndexMap;
   }
 
   /**
@@ -1968,6 +2031,8 @@ class StackViewport extends Viewport {
       this.imageKeyToIndexMap.set(imageId, index);
       this.imageKeyToIndexMap.set(imageIdToURI(imageId), index);
     });
+    this.imageIdToDimensionGroupIndexMap = undefined;
+    this.hasResolvedDimensionGroups = false;
     this.currentImageIdIndex = currentImageIdIndex;
     this.targetImageIdIndex = currentImageIdIndex;
     const imageRetrieveConfiguration = metaData.get(

--- a/packages/core/src/types/IDynamicImageVolume.ts
+++ b/packages/core/src/types/IDynamicImageVolume.ts
@@ -21,6 +21,13 @@ interface IDynamicImageVolume extends IImageVolume {
   get numDimensionGroups(): number;
 
   /**
+   * Returns the imageIds of the active dimension group only. The volume's
+   * `imageIds` span every dimension group, so anything resolving an imageId
+   * for what is currently on screen needs this subset instead.
+   */
+  getCurrentDimensionGroupImageIds(): string[];
+
+  /**
    * Scroll through dimension groups, handling wrapping at start/end
    * @param delta - The number of dimension groups to scroll by (positive or negative)
    */

--- a/packages/core/src/utilities/getClosestImageId.ts
+++ b/packages/core/src/utilities/getClosestImageId.ts
@@ -10,12 +10,43 @@ import { EPSILON } from '../constants';
 
 const log = coreLog.getLogger('utilities', 'getClosestImageId');
 
+type ClosestImageIdVolume =
+  | IImageVolume
+  | { direction: mat3; spacing: Point3; imageIds: string[] };
+
+/**
+ * A dynamic volume's `imageIds` span every dimension group, and each group
+ * repeats the same set of image positions. Searching that flat list by distance
+ * alone would resolve to whichever group happens to be stored first rather than
+ * the one on screen, so restrict the search to the active dimension group.
+ */
+function getImageIdsToSearch(imageVolume: ClosestImageIdVolume): string[] {
+  const dynamicVolume = imageVolume as Partial<IImageVolume> & {
+    getCurrentDimensionGroupImageIds?: () => string[];
+  };
+
+  if (
+    typeof dynamicVolume.isDynamicVolume !== 'function' ||
+    !dynamicVolume.isDynamicVolume() ||
+    typeof dynamicVolume.getCurrentDimensionGroupImageIds !== 'function'
+  ) {
+    return imageVolume.imageIds;
+  }
+
+  return (
+    dynamicVolume.getCurrentDimensionGroupImageIds() ?? imageVolume.imageIds
+  );
+}
+
 /**
  * Given an image volume, a point in world space, and the view plane normal,
  * it returns the closest imageId based on the specified options.
  * If `options.ignoreSpacing` is true, it returns the imageId with the minimum
  * distance along the view plane normal, regardless of voxel spacing.
  * Otherwise, it returns the closest imageId within half voxel spacing along the normal.
+ *
+ * For dynamic (4D) volumes only the active dimension group is searched, so the
+ * returned imageId always belongs to the dimension group currently displayed.
  *
  * @param imageVolume - The image volume or object containing direction, spacing, and imageIds.
  * @param worldPos - The position in the world coordinate system.
@@ -26,14 +57,13 @@ const log = coreLog.getLogger('utilities', 'getClosestImageId');
  * @returns The closest imageId based on the criteria, or undefined if none found.
  */
 export default function getClosestImageId(
-  imageVolume:
-    | IImageVolume
-    | { direction: mat3; spacing: Point3; imageIds: string[] },
+  imageVolume: ClosestImageIdVolume,
   worldPos: Point3,
   viewPlaneNormal: Point3,
   options?: { ignoreSpacing?: boolean }
 ): string | undefined {
-  const { direction, spacing, imageIds } = imageVolume;
+  const { direction, spacing } = imageVolume;
+  const imageIds = getImageIdsToSearch(imageVolume);
   const { ignoreSpacing = false } = options || {};
 
   if (!imageIds?.length) {

--- a/packages/core/src/utilities/getDimensionGroupIndexMap.ts
+++ b/packages/core/src/utilities/getDimensionGroupIndexMap.ts
@@ -1,0 +1,66 @@
+import { utilities as metadataUtilities } from '@cornerstonejs/metadata';
+
+/**
+ * Splits imageIds into their 4D dimension groups (time point, b-value, echo,
+ * ...) and returns a map from each imageId to the index of the group it belongs
+ * to.
+ *
+ * Returns undefined when the imageIds do not form a 4D set, so callers can tell
+ * "everything is in one group" apart from "these two images are in different
+ * groups" without having to inspect the map.
+ *
+ * Note this reads the 4D metadata of every imageId, so callers that use it on a
+ * hot path should cache the result for as long as the imageIds are unchanged.
+ *
+ * @param imageIds - the imageIds to split
+ * @returns imageId to dimension group index, or undefined if not 4D
+ */
+export default function getDimensionGroupIndexMap(
+  imageIds: string[]
+): Map<string, number> | undefined {
+  if (!imageIds || imageIds.length < 2) {
+    return;
+  }
+
+  const { imageIdGroups } =
+    metadataUtilities.splitImageIdsBy4DTags(imageIds) ?? {};
+
+  if (!imageIdGroups || imageIdGroups.length < 2) {
+    return;
+  }
+
+  const dimensionGroupIndexMap = new Map<string, number>();
+
+  imageIdGroups.forEach((imageIdGroup, groupIndex) => {
+    imageIdGroup.forEach((imageId) => {
+      dimensionGroupIndexMap.set(imageId, groupIndex);
+    });
+  });
+
+  return dimensionGroupIndexMap;
+}
+
+/**
+ * Returns true only when both imageIds are known to sit in different dimension
+ * groups. An unknown imageId - one from another series, or from a set that is
+ * not 4D at all - means the dimension groups cannot be compared, which reads as
+ * "not different" so callers fall back to whatever else they were using.
+ *
+ * @param dimensionGroupIndexMap - map from getDimensionGroupIndexMap, may be undefined
+ * @param imageIdA - first imageId to compare
+ * @param imageIdB - second imageId to compare
+ */
+export function areInDifferentDimensionGroups(
+  dimensionGroupIndexMap: Map<string, number> | undefined,
+  imageIdA: string,
+  imageIdB: string
+): boolean {
+  if (!dimensionGroupIndexMap) {
+    return false;
+  }
+
+  const groupA = dimensionGroupIndexMap.get(imageIdA);
+  const groupB = dimensionGroupIndexMap.get(imageIdB);
+
+  return groupA !== undefined && groupB !== undefined && groupA !== groupB;
+}

--- a/packages/core/src/utilities/index.ts
+++ b/packages/core/src/utilities/index.ts
@@ -98,6 +98,7 @@ import { _getScalingDescriptor } from './getScalingDescriptor';
 import { resolveGenericViewportVolumeId } from './resolveGenericViewportVolumeId';
 import cache from '../cache/cache';
 import getDynamicVolumeInfo from './getDynamicVolumeInfo';
+import getDimensionGroupIndexMap from './getDimensionGroupIndexMap';
 import autoLoad from './autoLoad';
 import scaleArray from './scaleArray';
 import splitImageIdsBy4DTags, {
@@ -236,6 +237,7 @@ export {
   color,
   hasFloatScalingParameters,
   getDynamicVolumeInfo,
+  getDimensionGroupIndexMap,
   autoLoad,
   scaleArray,
   deepClone,

--- a/packages/core/test/dynamicVolumeImageResolution.jest.js
+++ b/packages/core/test/dynamicVolumeImageResolution.jest.js
@@ -1,0 +1,134 @@
+jest.mock('../src/metaData', () => ({
+  addProvider: jest.fn(),
+  get: jest.fn(),
+}));
+
+import * as metaData from '../src/metaData';
+import { MetadataModules } from '../src/enums';
+import getClosestImageId from '../src/utilities/getClosestImageId';
+import { areInDifferentDimensionGroups } from '../src/utilities/getDimensionGroupIndexMap';
+
+// A 3 slice / 2 dimension group volume. Every dimension group repeats the same
+// three image positions, which is exactly why distance alone cannot pick one.
+const SLICE_SPACING = 2;
+const GROUP_ONE_IMAGE_IDS = ['t1-s0', 't1-s1', 't1-s2'];
+const GROUP_TWO_IMAGE_IDS = ['t2-s0', 't2-s1', 't2-s2'];
+const IDENTITY_DIRECTION = [1, 0, 0, 0, 1, 0, 0, 0, 1];
+
+function sliceIndexOf(imageId) {
+  return Number(imageId.slice(-1));
+}
+
+function createDynamicVolume({ isDynamic = true, activeGroup = 2 } = {}) {
+  return {
+    direction: IDENTITY_DIRECTION,
+    spacing: [1, 1, SLICE_SPACING],
+    // The flat imageIds always list dimension group 1 first, so a time-blind
+    // search resolves there no matter which group is on screen.
+    imageIds: [...GROUP_ONE_IMAGE_IDS, ...GROUP_TWO_IMAGE_IDS],
+    isDynamicVolume: () => isDynamic,
+    getCurrentDimensionGroupImageIds: () =>
+      activeGroup === 1 ? GROUP_ONE_IMAGE_IDS : GROUP_TWO_IMAGE_IDS,
+  };
+}
+
+describe('resolving imageIds on dynamic (4D) volumes', () => {
+  beforeEach(() => {
+    metaData.get.mockImplementation((type, imageId) => {
+      if (type !== MetadataModules.IMAGE_PLANE) {
+        return;
+      }
+
+      return {
+        imagePositionPatient: [0, 0, sliceIndexOf(imageId) * SLICE_SPACING],
+        imageOrientationPatient: [1, 0, 0, 0, 1, 0],
+        rows: 8,
+        columns: 8,
+      };
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getClosestImageId', () => {
+    it('resolves within the active dimension group rather than the first one', () => {
+      const volume = createDynamicVolume({ activeGroup: 2 });
+
+      expect(getClosestImageId(volume, [0, 0, 2], [0, 0, 1])).toBe('t2-s1');
+    });
+
+    it('follows the active dimension group as it changes', () => {
+      expect(
+        getClosestImageId(
+          createDynamicVolume({ activeGroup: 1 }),
+          [0, 0, 4],
+          [0, 0, 1]
+        )
+      ).toBe('t1-s2');
+
+      expect(
+        getClosestImageId(
+          createDynamicVolume({ activeGroup: 2 }),
+          [0, 0, 4],
+          [0, 0, 1]
+        )
+      ).toBe('t2-s2');
+    });
+
+    it('searches every imageId when the volume is not dynamic', () => {
+      const volume = createDynamicVolume({ isDynamic: false });
+
+      expect(getClosestImageId(volume, [0, 0, 2], [0, 0, 1])).toBe('t1-s1');
+    });
+
+    it('falls back to the full imageId list when the volume cannot report a group', () => {
+      const volume = createDynamicVolume();
+      delete volume.getCurrentDimensionGroupImageIds;
+
+      expect(getClosestImageId(volume, [0, 0, 2], [0, 0, 1])).toBe('t1-s1');
+    });
+
+    it('still returns nothing when the view is oblique to the volume', () => {
+      const volume = createDynamicVolume();
+
+      expect(getClosestImageId(volume, [0, 0, 2], [0, 1, 0])).toBeUndefined();
+    });
+  });
+
+  describe('areInDifferentDimensionGroups', () => {
+    const dimensionGroupIndexMap = new Map([
+      ...GROUP_ONE_IMAGE_IDS.map((imageId) => [imageId, 0]),
+      ...GROUP_TWO_IMAGE_IDS.map((imageId) => [imageId, 1]),
+    ]);
+
+    it('separates the same slice in different dimension groups', () => {
+      expect(
+        areInDifferentDimensionGroups(dimensionGroupIndexMap, 't1-s1', 't2-s1')
+      ).toBe(true);
+    });
+
+    it('does not separate images inside one dimension group', () => {
+      expect(
+        areInDifferentDimensionGroups(dimensionGroupIndexMap, 't1-s0', 't1-s2')
+      ).toBe(false);
+    });
+
+    it('treats an unknown imageId as not comparable', () => {
+      expect(
+        areInDifferentDimensionGroups(
+          dimensionGroupIndexMap,
+          't1-s1',
+          'other-series-s1'
+        )
+      ).toBe(false);
+    });
+
+    it('treats a non-4D stack as not comparable', () => {
+      expect(areInDifferentDimensionGroups(undefined, 't1-s1', 't2-s1')).toBe(
+        false
+      );
+    });
+  });
+});

--- a/packages/core/test/getDimensionGroupIndexMap.jest.js
+++ b/packages/core/test/getDimensionGroupIndexMap.jest.js
@@ -1,0 +1,118 @@
+import { metaData } from '@cornerstonejs/metadata';
+import getDimensionGroupIndexMap from '../src/utilities/getDimensionGroupIndexMap';
+
+// Exercises the real 4D splitting rather than a stub, because whether a stack
+// splits at all is what decides if callers can separate dimension groups.
+const SLICE_SPACING = 2;
+
+function makeImageId(timePoint, sliceIndex) {
+  return `4d:t${timePoint}-s${sliceIndex}`;
+}
+
+/** Flat imageIds in acquisition order: all slices of t1, then all of t2, ... */
+function make4DImageIds(timePointCount, sliceCount) {
+  const imageIds = [];
+
+  for (let timePoint = 1; timePoint <= timePointCount; timePoint++) {
+    for (let sliceIndex = 0; sliceIndex < sliceCount; sliceIndex++) {
+      imageIds.push(makeImageId(timePoint, sliceIndex));
+    }
+  }
+
+  return imageIds;
+}
+
+function parseImageId(imageId) {
+  const match = /^4d:t(\d+)-s(\d+)$/.exec(imageId);
+
+  return match
+    ? { timePoint: Number(match[1]), sliceIndex: Number(match[2]) }
+    : undefined;
+}
+
+/**
+ * Provides just enough for splitImageIdsBy4DTags: a position per slice (shared
+ * across time points) and a TemporalPositionIdentifier per time point.
+ */
+function provider(type, imageId) {
+  const parsed = typeof imageId === 'string' && parseImageId(imageId);
+
+  if (!parsed) {
+    return;
+  }
+
+  if (type === 'imagePlaneModule') {
+    return {
+      imagePositionPatient: [0, 0, parsed.sliceIndex * SLICE_SPACING],
+      imageOrientationPatient: [1, 0, 0, 0, 1, 0],
+      rows: 8,
+      columns: 8,
+    };
+  }
+
+  if (type === 'TemporalPositionIdentifier') {
+    return parsed.timePoint;
+  }
+}
+
+describe('getDimensionGroupIndexMap', () => {
+  beforeAll(() => {
+    metaData.addProvider(provider, 10000);
+  });
+
+  afterAll(() => {
+    metaData.removeProvider(provider);
+  });
+
+  it('maps every imageId of a 4D stack to its dimension group', () => {
+    const imageIds = make4DImageIds(3, 2);
+
+    const dimensionGroupIndexMap = getDimensionGroupIndexMap(imageIds);
+
+    expect(dimensionGroupIndexMap).toBeDefined();
+    expect(dimensionGroupIndexMap.size).toBe(imageIds.length);
+
+    imageIds.forEach((imageId) => {
+      // Groups are ordered by TemporalPositionIdentifier, which is 1-based.
+      expect(dimensionGroupIndexMap.get(imageId)).toBe(
+        parseImageId(imageId).timePoint - 1
+      );
+    });
+  });
+
+  it('puts the same slice at different time points in different groups', () => {
+    const dimensionGroupIndexMap = getDimensionGroupIndexMap(
+      make4DImageIds(3, 2)
+    );
+
+    expect(dimensionGroupIndexMap.get(makeImageId(1, 1))).not.toBe(
+      dimensionGroupIndexMap.get(makeImageId(3, 1))
+    );
+  });
+
+  it('puts different slices at the same time point in one group', () => {
+    const dimensionGroupIndexMap = getDimensionGroupIndexMap(
+      make4DImageIds(3, 2)
+    );
+
+    expect(dimensionGroupIndexMap.get(makeImageId(2, 0))).toBe(
+      dimensionGroupIndexMap.get(makeImageId(2, 1))
+    );
+  });
+
+  it('returns undefined for a plain 3D stack', () => {
+    expect(getDimensionGroupIndexMap(make4DImageIds(1, 4))).toBeUndefined();
+  });
+
+  it('returns undefined for stacks too small to split', () => {
+    expect(getDimensionGroupIndexMap([])).toBeUndefined();
+    expect(getDimensionGroupIndexMap([makeImageId(1, 0)])).toBeUndefined();
+    expect(getDimensionGroupIndexMap(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when the images carry no 4D metadata', () => {
+    expect(
+      getDimensionGroupIndexMap(['unknown:a', 'unknown:b', 'unknown:c'])
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Context

When a segmentation is drawn on a 4D (3D + time) series, it shows up on every time point. Investigating that turned up several independent time-blind mechanisms; two of them are plain bugs in imageId resolution that are wrong regardless of segmentations, and both are prerequisites for making segmentations time-aware. This PR fixes those two. It deliberately does **not** change segmentation storage or behaviour — that is a follow-up.

## 1. `getClosestImageId` ignored the active dimension group

A dynamic volume's `imageIds` span every dimension group, and each group repeats the same set of image positions. `getClosestImageId` scanned that flat list and kept the first strict minimum distance, so it resolved to whichever group happens to be stored first.

Net effect: `VolumeViewport.getCurrentImageId()` and `getViewReference()` reported a **first time point** imageId on every 4D viewport, no matter which dimension group was on screen.

Now the search is restricted to the active dimension group. `getCurrentDimensionGroupImageIds()` is added to `IDynamicImageVolume` since it is now part of the contract callers depend on (`StreamingDynamicImageVolume` already implemented it).

## 2. `StackViewport.matchImagesForOverlay` could not tell time points apart

The overlay match compares image orientation, image position and row/column counts. All three are identical for slice k at every time point of a 4D stack, so an overlay derived from one time point matched all of them.

A geometric match is now vetoed when the two images fall in different dimension groups of the stack. Rather than duplicating the 4D tag list, this reuses the same `splitImageIdsBy4DTags` grouping the dynamic volume loader uses, via a new `getDimensionGroupIndexMap` utility. The split is computed lazily on first overlay query and cached until the stack changes, because it reads the 4D metadata of every image and most stacks never need it. A derived overlay image (a labelmap slice, say) is not itself in the stack, so it is compared via the image it was derived from.

## Inert outside 4D

Both changes are no-ops for non-4D data by construction:

- a volume that does not report `isDynamicVolume()` still searches every imageId;
- a stack that does not split into more than one dimension group never vetoes a geometric match;
- an imageId that is not in the map (an overlay from another series, for instance) is treated as not comparable, so the geometric match stands.

## Testing

Two new suites, 15 tests, in `packages/core/test`:

- `dynamicVolumeImageResolution.jest.js` — `getClosestImageId` resolves inside the active group, follows the group as it changes, and falls back to the full list for non-dynamic volumes or volumes that cannot report a group; plus the `areInDifferentDimensionGroups` predicate.
- `getDimensionGroupIndexMap.jest.js` — exercises the **real** 4D splitting through a registered metadata provider rather than a stub, covering the 4D case, a plain 3D stack, undersized stacks, and images with no 4D metadata.

Full `core` jest suite passes (35 suites / 566 tests). `core`, `tools` and `metadata` all typecheck clean.

## Follow-up

The remaining time-blindness is in segmentation storage and rendering: OHIF creates a labelmap against a single time point's imageIds, and the volume render path mounts it as a world-space `vtkVolume` with nothing listening for `DYNAMIC_VOLUME_DIMENSION_GROUP_CHANGED`. A separate PR will make the derived labelmap volume itself dynamic. Note that today's apply-to-all-time behaviour is load-bearing for the Kinetic Analysis / time-activity-curve workflow, which samples one 3D mask across every dimension group, so that must remain available as an explicit mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved image selection for dynamic 4D volumes by limiting searches to the active dimension group.
  * Prevented overlays from matching images across different dimension groups when group information is available.
  * Added utilities for identifying and comparing 4D dimension groups.

* **Bug Fixes**
  * Improved handling of repeated slice positions across time points.
  * Preserved fallback behavior when dimension-group information is unavailable.

* **Tests**
  * Added coverage for dynamic-volume resolution, dimension-group separation, fallback behavior, and non-4D stacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->