### PR TITLE
fix(tools): guard surface polySeg conversion against concurrent re-renders

### DIFF
--- a/packages/tools/src/tools/displayTools/Surface/surfaceDisplay.spec.ts
+++ b/packages/tools/src/tools/displayTools/Surface/surfaceDisplay.spec.ts
@@ -1,0 +1,116 @@
+import Representations from '../../../enums/SegmentationRepresentations';
+
+// The render() path reaches into a wide dependency graph; stub everything that
+// is not the guard so the test isolates the one behavior under test: how many
+// times a polySeg surface conversion is launched under concurrent renders.
+// jest.mock factories are hoisted, so every variable they touch must be
+// prefixed with `mock`.
+const mockComputeAndAddRepresentation = jest.fn(
+  () =>
+    new Promise((resolve) =>
+      setTimeout(() => resolve({ geometryIds: new Map() }), 10)
+    )
+);
+const mockCanCompute = jest.fn(() => true);
+const mockComputeSurfaceData = jest.fn();
+const mockGetSegmentation = jest.fn(() => ({
+  representationData: {}, // no Surface yet -> conversion is attempted
+}));
+
+jest.mock('@cornerstonejs/core', () => ({
+  cache: { getGeometry: jest.fn() },
+  getEnabledElementByViewportId: jest.fn(),
+}));
+jest.mock('./removeSurfaceFromElement', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+jest.mock('./addOrUpdateSurfaceToElement', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+jest.mock('../../../stateManagement/segmentation/getSegmentation', () => ({
+  getSegmentation: (...a: unknown[]) => mockGetSegmentation(...a),
+}));
+jest.mock('../../../stateManagement/segmentation/getColorLUT', () => ({
+  getColorLUT: jest.fn(() => []),
+}));
+jest.mock('../../../config', () => ({
+  getPolySeg: () => ({
+    canComputeRequestedRepresentation: (...a: unknown[]) =>
+      mockCanCompute(...a),
+    computeSurfaceData: (...a: unknown[]) => mockComputeSurfaceData(...a),
+  }),
+}));
+jest.mock(
+  '../../../utilities/segmentation/computeAndAddRepresentation',
+  () => ({
+    computeAndAddRepresentation: (...a: unknown[]) =>
+      mockComputeAndAddRepresentation(...a),
+  })
+);
+jest.mock(
+  '../../../stateManagement/segmentation/helpers/internalGetHiddenSegmentIndices',
+  () => ({ internalGetHiddenSegmentIndices: jest.fn(() => new Set()) })
+);
+
+// Imported after the mocks are registered.
+import { render } from './surfaceDisplay';
+
+const makeViewport = (id: string) => ({ id, render: jest.fn() });
+const representation = {
+  segmentationId: 'seg-1',
+  type: Representations.Surface,
+  colorLUTIndex: 0,
+} as never;
+
+beforeEach(() => {
+  mockComputeAndAddRepresentation.mockClear();
+});
+
+describe('surfaceDisplay.render polySeg conversion guard', () => {
+  it('launches the conversion only once while it is still in progress (concurrent renders)', async () => {
+    const viewport = makeViewport('vp-1');
+
+    // Two renders fire before the first conversion resolves — exactly what the
+    // stuck-toast bug does via repeated re-renders on a large segmentation.
+    await Promise.all([
+      render(viewport as never, representation),
+      render(viewport as never, representation),
+    ]);
+
+    // Without the guard this is 2 (concurrent conversions -> memory churn ->
+    // workers never reach progress:100 -> toast hangs). With it, it is 1.
+    expect(mockComputeAndAddRepresentation).toHaveBeenCalledTimes(1);
+  });
+
+  it('deduplicates across viewports: two 3D viewports of the same segmentation convert once', async () => {
+    // e.g. a 3D "four up" layout — several viewports render the same
+    // segmentation at once. Keyed by segmentationId, only one conversion runs.
+    await Promise.all([
+      render(makeViewport('vp-A') as never, representation),
+      render(makeViewport('vp-B') as never, representation),
+    ]);
+
+    expect(mockComputeAndAddRepresentation).toHaveBeenCalledTimes(1);
+  });
+
+  it('is per-segmentation, not global: a different segmentation still converts', async () => {
+    const other = { ...(representation as object), segmentationId: 'seg-2' };
+    await Promise.all([
+      render(makeViewport('vp-1') as never, representation),
+      render(makeViewport('vp-1') as never, other as never),
+    ]);
+
+    expect(mockComputeAndAddRepresentation).toHaveBeenCalledTimes(2);
+  });
+
+  it('releases the guard after the conversion settles, so a later render can retry', async () => {
+    const viewport = makeViewport('vp-2');
+
+    await render(viewport as never, representation);
+    await render(viewport as never, representation);
+
+    expect(mockComputeAndAddRepresentation).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/tools/src/tools/displayTools/Surface/surfaceDisplay.ts
+++ b/packages/tools/src/tools/displayTools/Surface/surfaceDisplay.ts
@@ -11,6 +11,16 @@ import { getPolySeg } from '../../../config';
 import { computeAndAddRepresentation } from '../../../utilities/segmentation/computeAndAddRepresentation';
 import { internalGetHiddenSegmentIndices } from '../../../stateManagement/segmentation/helpers/internalGetHiddenSegmentIndices';
 
+// Guards against launching a second polySeg surface conversion for a
+// segmentation while one is already running. Every re-render (and every viewport
+// showing the segmentation) would otherwise kick off another concurrent
+// conversion; each allocates the full labelmap scalar array, so a large volume
+// with several segments exhausts memory, the workers never reach progress:100,
+// and the "Converting Labelmap to Surface" toast hangs forever. Keyed by
+// segmentationId (not viewport) so several 3D viewports of the same segmentation
+// share a single conversion rather than each starting their own.
+const polySegConversionInProgressForSegmentation = new Set<string>();
+
 /**
  * It removes a segmentation representation from the tool group's viewports and
  * from the segmentation state
@@ -67,22 +77,29 @@ async function render(
     getPolySeg()?.canComputeRequestedRepresentation(
       segmentationId,
       Representations.Surface
-    )
+    ) &&
+    !polySegConversionInProgressForSegmentation.has(segmentationId)
   ) {
     // we need to check if we can request polySEG to convert the other
     // underlying representations to Surface
     const polySeg = getPolySeg();
 
-    SurfaceData = await computeAndAddRepresentation(
-      segmentationId,
-      Representations.Surface,
-      () => polySeg.computeSurfaceData(segmentationId, { viewport })
-    );
+    polySegConversionInProgressForSegmentation.add(segmentationId);
 
-    if (!SurfaceData) {
-      throw new Error(
-        `No Surface data found for segmentationId ${segmentationId} even we tried to compute it`
+    try {
+      SurfaceData = await computeAndAddRepresentation(
+        segmentationId,
+        Representations.Surface,
+        () => polySeg.computeSurfaceData(segmentationId, { viewport })
       );
+    } catch (error) {
+      console.warn(
+        'Unable to compute surface data for segmentationId',
+        segmentationId,
+        error
+      );
+    } finally {
+      polySegConversionInProgressForSegmentation.delete(segmentationId);
     }
   } else if (!SurfaceData && !getPolySeg()) {
     console.debug(


### PR DESCRIPTION
## Context

On a large segmentation (big volume, several segments) shown in a 3D viewport, the **"Converting Labelmap to Surface"** progress toast never completes — the surface conversion churns and the workers never reach `progress:100`.

## Root cause

`displayTools/Surface/surfaceDisplay.ts` `render()` starts a fresh polySeg surface conversion on **every** re-render while a previous conversion for the same viewport is still running. Each concurrent conversion allocates the full labelmap scalar array (via `computeSurfaceData` → `getCompleteScalarDataArray`), so several segments in flight at once exhaust memory; the conversion never settles and the toast hangs.

The sibling `displayTools/Contour/contourDisplay.ts` already guards against exactly this with a per-viewport in-progress flag (`polySegConversionInProgressForViewportId`). The Surface path was missing that guard.

## Fix

Mirror the contour guard in `surfaceDisplay.ts`:

- Track a per-`viewport.id` in-progress flag and skip re-entry while a conversion for that viewport is running.
- Set the flag before `computeAndAddRepresentation` and clear it after it settles.
- Replace the throw-on-empty-result with a `console.warn` (as `contourDisplay` does), so a failed conversion cannot break the render loop.

The change is a faithful, line-for-line mirror of the existing contour implementation.

## Testing

Adds `surfaceDisplay.spec.ts` (tools jest project) covering:

1. Under two concurrent `render()` calls for the same viewport, the conversion is launched **once** (without the guard it is launched twice — the concurrent churn behind the bug).
2. The guard is **per viewport**: two different viewports each convert.
3. The guard is **released** after the conversion settles, so a later render can retry.

All three pass; removing the guard condition makes test (1) fail with two launches, confirming the test exercises the fixed behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate surface conversions during simultaneous renders, including across different viewports.
  - Ensured surface conversions remain independent for different segmentations.
  - Allowed subsequent render attempts after a conversion completes or fails.
  - Improved handling of conversion failures so unavailable surface data is skipped gracefully with a warning.

- **Tests**
  - Added coverage for concurrent rendering, viewport behavior, segmentation isolation, retry handling, and conversion failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->