### PR TITLE
fix(adapters): index segment metadata by SegmentNumber for LABELMAP support

### DIFF
--- a/packages/adapters/src/adapters/Cornerstone/Segmentation_4X.js
+++ b/packages/adapters/src/adapters/Cornerstone/Segmentation_4X.js
@@ -1786,13 +1786,23 @@ export function alignPixelDataWithSourceData(
 
 export function getSegmentMetadata(multiframe, seriesInstanceUid) {
   const segmentSequence = multiframe.SegmentSequence;
-  let data = [];
+  const data = [];
 
-  if (Array.isArray(segmentSequence)) {
-    data = [undefined, ...segmentSequence];
-  } else {
-    // Only one segment, will be stored as an object.
-    data = [undefined, segmentSequence];
+  const segments = Array.isArray(segmentSequence)
+    ? segmentSequence
+    : [segmentSequence];
+
+  /**
+   * Index segments by their SegmentNumber rather than array position.
+   * This is required for LABELMAP segmentations where SegmentNumber may
+   * start at 0 (for background) or have gaps. The DICOM standard only
+   * requires SegmentNumber >= 1 for BINARY/FRACTIONAL types, but LABELMAP
+   * allows more flexibility (see DICOM Part 3, Section C.8.20.2.4).
+   */
+  for (const segment of segments) {
+    if (segment?.SegmentNumber !== undefined) {
+      data[segment.SegmentNumber] = segment;
+    }
   }
 
   return {

--- a/packages/adapters/src/adapters/Cornerstone/Segmentation_4X.js
+++ b/packages/adapters/src/adapters/Cornerstone/Segmentation_4X.js
@@ -1788,10 +1788,6 @@ export function getSegmentMetadata(multiframe, seriesInstanceUid) {
   const segmentSequence = multiframe.SegmentSequence;
   const data = [];
 
-  const segments = Array.isArray(segmentSequence)
-    ? segmentSequence
-    : [segmentSequence];
-
   /**
    * Index segments by their SegmentNumber rather than array position.
    * This is required for LABELMAP segmentations where SegmentNumber may
@@ -1799,8 +1795,8 @@ export function getSegmentMetadata(multiframe, seriesInstanceUid) {
    * requires SegmentNumber >= 1 for BINARY/FRACTIONAL types, but LABELMAP
    * allows more flexibility (see DICOM Part 3, Section C.8.20.2.4).
    */
-  for (const segment of segments) {
-    if (segment?.SegmentNumber !== undefined) {
+  for (const segment of csUtilities.asArray(segmentSequence)) {
+    if (segment?.SegmentNumber >= 0) {
       data[segment.SegmentNumber] = segment;
     }
   }


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->

### Context

When loading DICOM LABELMAP segmentations with `SegmentNumber` starting at 0 (e.g., for background segments), the segment colors are incorrectly mapped. This causes each segment to display the **previous** segment's color.

**Root Cause Investigation:**

The `getSegmentMetadata()` function in `Segmentation_4X.js` creates a `data` array by prepending `undefined` and spreading the `SegmentSequence`:

```javascript
data = [undefined, ...segmentSequence];
```

This assumes `SegmentNumber` always starts at 1 (per DICOM standard for BINARY/FRACTIONAL types). However, for **LABELMAP** segmentations, the DICOM standard allows more flexibility:

> "If Segmentation Type (0062,0001) is BINARY or FRACTIONAL, Segment Number (0062,0004) shall start at a value of 1, and increase monotonically by 1."

For LABELMAP, this restriction does not apply (see [DICOM Part 3, Section C.8.20.2.4](https://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.8.20.2.4.html)).

**Example of the bug:**

Given a LABELMAP SEG with segments:
- SegmentNumber=0: Background
- SegmentNumber=1: Kidney (pink color)
- SegmentNumber=2: Mass (green color)

The old code creates:
```
data[0] = undefined
data[1] = Background segment
data[2] = Kidney segment
data[3] = Mass segment
```

But the labelmap pixel values use `SegmentNumber` directly:
- Pixel value 1 = Kidney → looks up `data[1]` → gets **Background's color** (wrong!)
- Pixel value 2 = Mass → looks up `data[2]` → gets **Kidney's color** (wrong!)

This was discovered when loading LABELMAP SEGs created by [dcmqi](https://github.com/QIICR/dcmqi), which intentionally creates a Background segment with `SegmentNumber=0` for LABELMAP conversions (see [dcmqi#534](https://github.com/QIICR/dcmqi/issues/534)).

### Changes & Results

**Change:** Modified `getSegmentMetadata()` to index segments by their `SegmentNumber` rather than array position.

**Before:**
```javascript
if (Array.isArray(segmentSequence)) {
  data = [undefined, ...segmentSequence];
} else {
  data = [undefined, segmentSequence];
}
```

**After:**
```javascript
const segments = Array.isArray(segmentSequence)
  ? segmentSequence
  : [segmentSequence];

for (const segment of segments) {
  if (segment?.SegmentNumber !== undefined) {
    data[segment.SegmentNumber] = segment;
  }
}
```

**Result:**
- `data[0]` = Background segment (SegmentNumber=0)
- `data[1]` = Kidney segment (SegmentNumber=1)
- `data[2]` = Mass segment (SegmentNumber=2)

Now `colorLUT[N]` correctly maps to the segment with `SegmentNumber=N`.

### Testing

1. Load a LABELMAP SEG that has `SegmentNumber=0` for background (e.g., created by dcmqi)
2. Verify segment colors match the `RecommendedDisplayCIELabValue` from DICOM metadata
3. Also verify BINARY/FRACTIONAL SEGs still work correctly (they always have SegmentNumber >= 1)

**Test data:** IDC study `1.3.6.1.4.1.14519.5.2.1.1357.4011.258217882991704941618731006997` from GCP Healthcare API contains LABELMAP SEGs with SegmentNumber=0 that can be used for testing.

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] OS: macOS 14
- [x] Node version: 20.x
- [x] Browser: Chrome 128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved segmentation metadata handling for LABELMAP data.
  - Preserved valid segment numbers and gaps, including background segments.
  - Excluded invalid negative or undefined segment numbers to improve the accuracy and reliability of displayed segmentation information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->