### PR TITLE
fix(WindowLevelRegionTool): make region WL sampling image-space invariant

### DIFF
--- a/packages/tools/src/tools/WindowLevelRegionTool.ts
+++ b/packages/tools/src/tools/WindowLevelRegionTool.ts
@@ -324,14 +324,13 @@ class WindowLevelRegionTool extends AnnotationTool {
     const { data } = annotation;
     const { points } = data.handles;
 
-    const canvasCoordinates = points.map((p) => viewport.worldToCanvas(p));
-    const startCanvas = canvasCoordinates[0];
-    const endCanvas = canvasCoordinates[3];
+    const startImage = imageData.worldToImage(points[0]);
+    const endImage = imageData.worldToImage(points[3]);
 
-    let left = Math.min(startCanvas[0], endCanvas[0]);
-    let top = Math.min(startCanvas[1], endCanvas[1]);
-    let width = Math.abs(startCanvas[0] - endCanvas[0]);
-    let height = Math.abs(startCanvas[1] - endCanvas[1]);
+    let left = Math.min(startImage[0], endImage[0]);
+    let top = Math.min(startImage[1], endImage[1]);
+    let width = Math.abs(startImage[0] - endImage[0]);
+    let height = Math.abs(startImage[1] - endImage[1]);
 
     left = utilities.clip(left, 0, imageData.width);
     top = utilities.clip(top, 0, imageData.height);

--- a/packages/tools/src/utilities/voi/windowlevel/extractWindowLevelRegionToolData.ts
+++ b/packages/tools/src/utilities/voi/windowlevel/extractWindowLevelRegionToolData.ts
@@ -5,6 +5,7 @@ import {
   StackViewport,
   VolumeViewport,
 } from '@cornerstonejs/core';
+import { vec3 } from 'gl-matrix';
 
 function extractWindowLevelRegionToolData(viewport: Types.IViewport) {
   if (viewport instanceof VolumeViewport) {
@@ -25,8 +26,9 @@ function extractWindowLevelRegionToolData(viewport: Types.IViewport) {
 }
 
 function extractImageDataVolume(viewport: Types.IVolumeViewport) {
-  const { scalarData, width, height } =
+  const { scalarData, width, height, indexToSliceMatrix } =
     csUtils.getCurrentVolumeViewportSlice(viewport);
+  const imageData = viewport.getImageData().imageData;
   const { min: minPixelValue, max: maxPixelValue } =
     csUtils.getMinMax(scalarData);
   return {
@@ -37,6 +39,19 @@ function extractImageDataVolume(viewport: Types.IVolumeViewport) {
     height,
     rows: width,
     columns: height,
+    worldToImage: (worldPoint: Types.Point3): Types.Point2 => {
+      const indexPoint = csUtils.transformWorldToIndexContinuous(
+        imageData,
+        worldPoint
+      );
+      const slicePoint = vec3.transformMat4(
+        [0, 0, 0],
+        indexPoint,
+        indexToSliceMatrix
+      );
+
+      return [slicePoint[0], slicePoint[1]];
+    },
     // color,
   };
 }
@@ -59,6 +74,14 @@ function extractImageDataStack(viewport: Types.IStackViewport) {
     rows,
     columns,
     color,
+    worldToImage: (worldPoint: Types.Point3): Types.Point2 => {
+      const indexPoint = csUtils.transformWorldToIndexContinuous(
+        imageData,
+        worldPoint
+      );
+
+      return [indexPoint[0], indexPoint[1]];
+    },
   };
 }
 
@@ -89,6 +112,14 @@ function extractImageDataGeneric(viewport: Types.IGenericViewport) {
   const { rows, columns, color } = image;
   const { min: minPixelValue, max: maxPixelValue } =
     csUtils.getMinMax(scalarData);
+  const worldToImage = (worldPoint: Types.Point3): Types.Point2 => {
+    const imagePoint = csUtils.worldToImageCoords(imageId, worldPoint);
+    if (!imagePoint) {
+      throw new Error('Viewport not supported');
+    }
+
+    return [imagePoint[0], imagePoint[1]];
+  };
 
   return {
     scalarData,
@@ -99,6 +130,7 @@ function extractImageDataGeneric(viewport: Types.IGenericViewport) {
     rows,
     columns,
     color,
+    worldToImage,
   };
 }
 

--- a/packages/tools/test/WindowLevelRegionTool.jest.js
+++ b/packages/tools/test/WindowLevelRegionTool.jest.js
@@ -1,0 +1,126 @@
+const mockGetEnabledElement = jest.fn();
+const mockExtractWindowLevelRegionToolData = jest.fn();
+const mockGetLuminanceFromRegion = jest.fn();
+const mockCalculateMinMaxMean = jest.fn();
+const mockToLowHighRange = jest.fn();
+
+jest.mock('@cornerstonejs/core', () => {
+  const actual = jest.requireActual('@cornerstonejs/core');
+  return {
+    ...actual,
+    getEnabledElement: (...args) => mockGetEnabledElement(...args),
+    utilities: {
+      ...actual.utilities,
+      clip: (value, min, max) => Math.min(Math.max(value, min), max),
+      windowLevel: {
+        ...actual.utilities.windowLevel,
+        toLowHighRange: (...args) => mockToLowHighRange(...args),
+      },
+      viewportSupportsDisplaySetPresentation: jest.fn(() => false),
+    },
+  };
+});
+
+jest.mock('../src/utilities/voi', () => ({
+  windowLevel: {
+    extractWindowLevelRegionToolData: (...args) =>
+      mockExtractWindowLevelRegionToolData(...args),
+    getLuminanceFromRegion: (...args) => mockGetLuminanceFromRegion(...args),
+    calculateMinMaxMean: (...args) => mockCalculateMinMaxMean(...args),
+  },
+}));
+
+const WindowLevelRegionTool =
+  require('../src/tools/WindowLevelRegionTool').default;
+
+describe('WindowLevelRegionTool', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses image-space ROI sampling (not canvas-space) when applying window/level region', () => {
+    const viewport = {
+      worldToCanvas: jest.fn((world) => [world[0] * 20, world[1] * 20]),
+      getProperties: jest.fn(() => ({})),
+      setProperties: jest.fn(),
+      render: jest.fn(),
+    };
+    const imageData = {
+      width: 256,
+      height: 256,
+      minPixelValue: 0,
+      maxPixelValue: 255,
+      worldToImage: jest
+        .fn()
+        .mockReturnValueOnce([10, 20])
+        .mockReturnValueOnce([40, 60]),
+    };
+    const annotation = {
+      data: {
+        handles: {
+          points: [
+            [5, 5, 0],
+            [5, 5, 0],
+            [5, 5, 0],
+            [10, 10, 0],
+          ],
+        },
+      },
+    };
+
+    mockGetEnabledElement.mockReturnValue({ viewport });
+    mockExtractWindowLevelRegionToolData.mockReturnValue(imageData);
+    mockGetLuminanceFromRegion.mockReturnValue([11, 12, 13]);
+    mockCalculateMinMaxMean.mockReturnValue({ min: 100, max: 102, mean: 101 });
+    mockToLowHighRange.mockReturnValue({ lower: 96, upper: 106 });
+
+    const tool = new WindowLevelRegionTool();
+    tool.applyWindowLevelRegion(annotation, {});
+
+    expect(imageData.worldToImage).toHaveBeenCalledTimes(2);
+    expect(viewport.worldToCanvas).not.toHaveBeenCalled();
+    expect(mockGetLuminanceFromRegion).toHaveBeenCalledWith(
+      imageData,
+      10,
+      20,
+      30,
+      40
+    );
+    expect(mockToLowHighRange).toHaveBeenCalledWith(10, 101, undefined);
+    expect(viewport.setProperties).toHaveBeenCalledWith({
+      voiRange: { lower: 96, upper: 106 },
+    });
+    expect(viewport.render).toHaveBeenCalled();
+  });
+
+  it('returns early when no backing image data is available', () => {
+    const viewport = {
+      setProperties: jest.fn(),
+      render: jest.fn(),
+    };
+
+    mockGetEnabledElement.mockReturnValue({ viewport });
+    mockExtractWindowLevelRegionToolData.mockReturnValue(undefined);
+
+    const tool = new WindowLevelRegionTool();
+    tool.applyWindowLevelRegion(
+      {
+        data: {
+          handles: {
+            points: [
+              [0, 0, 0],
+              [0, 0, 0],
+              [0, 0, 0],
+              [1, 1, 0],
+            ],
+          },
+        },
+      },
+      {}
+    );
+
+    expect(mockGetLuminanceFromRegion).not.toHaveBeenCalled();
+    expect(viewport.setProperties).not.toHaveBeenCalled();
+    expect(viewport.render).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context
This PR is to address and fix issue https://github.com/cornerstonejs/cornerstone3D/issues/2423
<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

### Changes & Results

WindowLevelRegionTool was deriving ROI extents in canvas space, so resizing the viewport changed sampled pixels and produced different WW/WL for the same visual region. This update makes ROI sampling image-space invariant while preserving existing no-backing-image behavior for unsupported native reformatted/oblique slices.

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected window-level region calculations to use image coordinates, improving ROI sampling accuracy across viewport types.
  * Ensured regions without available image data exit safely without applying changes or triggering unnecessary rendering.

* **Tests**
  * Added coverage for image-space ROI sampling, window-level range calculation, property updates, rendering, and missing image data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->