### PR TITLE
fix(tools): restore cursor when LabelTool prompt is cancelled

### DIFF
--- a/packages/tools/src/tools/annotation/LabelTool.ts
+++ b/packages/tools/src/tools/annotation/LabelTool.ts
@@ -233,13 +233,13 @@ class LabelTool extends AnnotationTool {
 
     triggerAnnotationRenderForViewportIds(viewportIdsToRender);
     this.configuration.getTextCallback((label) => {
+      resetElementCursor(element);
       if (!label) {
         removeAnnotation(annotation.annotationUID);
         triggerAnnotationRenderForViewportIds(viewportIdsToRender);
         this.isDrawing = false;
         return;
       }
-      resetElementCursor(element);
       annotation.data.label = label;
 
       triggerAnnotationCompleted(annotation);


### PR DESCRIPTION
## Summary
- `LabelTool.addNewAnnotation` calls `hideElementCursor` before the text prompt, but only called `resetElementCursor` when a label was accepted
- Cancelling the prompt left the viewport stuck with `cursor: none`
- Move `resetElementCursor` above the cancel/confirm branch so the cursor is always restored when the prompt finishes

## Test plan
- [x] Activate the Label tool and click the image to open the annotation prompt
- [x] Click Cancel and confirm the mouse cursor is visible again over the viewport
- [x] Repeat and accept a label; confirm the cursor still restores and the annotation is created


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved annotation labeling behavior by ensuring the cursor returns to its normal state after the label prompt is completed, including when no label is entered.
  * Canceling an annotation without providing a label continues to remove the unfinished annotation and exit drawing mode correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->