### PR TITLE
fix(core): register generalSeriesModule for locally created images

### DIFF
--- a/packages/core/src/loaders/imageLoader.ts
+++ b/packages/core/src/loaders/imageLoader.ts
@@ -47,6 +47,12 @@ interface LocalImageOptions {
   direction?: Mat3;
   referencedImageId?: string;
   /**
+   * Optional DICOM modality. Stored on generalSeriesModule so StackViewport
+   * can read it during load. Ignored when a referenced image already has a
+   * generalSeriesModule (derived images copy that module instead).
+   */
+  modality?: string;
+  /**
    * Skip creation of the actual buffer object.
    * In fact, this creates a very short buffer, as there are lots of places
    * assuming a buffer exists.
@@ -424,6 +430,7 @@ export function createAndCacheLocalImage(
     frameOfReferenceUID,
     voxelRepresentation,
     referencedImageId,
+    modality,
   } = options;
 
   const dimensions = options.dimensions;
@@ -520,13 +527,23 @@ export function createAndCacheLocalImage(
     highBit,
   } as ImagePixelModuleMetadata;
 
+  const referencedSeries =
+    referencedImageId &&
+    metaData.get(MetadataModules.GENERAL_SERIES, referencedImageId);
+  const generalSeriesModule = referencedSeries || { modality };
+
   const metadata = {
     imagePlaneModule,
     imagePixelModule,
+    generalSeriesModule,
   };
 
   // Add metadata to genericMetadataProvider
-  [MetadataModules.IMAGE_PLANE, MetadataModules.IMAGE_PIXEL].forEach((type) => {
+  [
+    MetadataModules.IMAGE_PLANE,
+    MetadataModules.IMAGE_PIXEL,
+    MetadataModules.GENERAL_SERIES,
+  ].forEach((type) => {
     genericMetadataProvider.add(imageId, {
       type,
       metadata: metadata[type] || {},

--- a/packages/core/test/imageLoader_localImage.jest.js
+++ b/packages/core/test/imageLoader_localImage.jest.js
@@ -1,8 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import {
-  createAndCacheDerivedImage,
-  createAndCacheLocalImage,
-} from '../src/loaders/imageLoader';
+import { createAndCacheLocalImage } from '../src/loaders/imageLoader';
 import cache from '../src/cache/cache';
 import * as metaData from '../src/metaData';
 import MetadataModules from '../src/enums/MetadataModules';
@@ -53,25 +50,22 @@ describe('createAndCacheLocalImage metadata', () => {
     expect(buildMetadata(image).modality).toBe('CT');
   });
 
-  it('keeps a referenced image generalSeriesModule on derived images', () => {
+  it('copies generalSeriesModule from a referenced image', () => {
     const referencedImageId = 'local:ref';
-    createLocalSlice(referencedImageId);
     genericMetadataProvider.add(referencedImageId, {
       type: MetadataModules.GENERAL_SERIES,
       metadata: { modality: 'PT', seriesInstanceUID: '1.2.3' },
     });
 
-    const derived = createAndCacheDerivedImage(referencedImageId, {
-      imageId: 'derived:slice0',
-    });
+    const imageId = 'local:from-ref';
+    const image = createLocalSlice(imageId, { referencedImageId });
 
-    expect(
-      metaData.get(MetadataModules.GENERAL_SERIES, derived.imageId)
-    ).toEqual(
+    expect(metaData.get(MetadataModules.GENERAL_SERIES, imageId)).toEqual(
       expect.objectContaining({
         modality: 'PT',
         seriesInstanceUID: '1.2.3',
       })
     );
+    expect(buildMetadata(image).modality).toBe('PT');
   });
 });

--- a/packages/core/test/imageLoader_localImage.jest.js
+++ b/packages/core/test/imageLoader_localImage.jest.js
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import {
+  createAndCacheDerivedImage,
+  createAndCacheLocalImage,
+} from '../src/loaders/imageLoader';
+import cache from '../src/cache/cache';
+import * as metaData from '../src/metaData';
+import MetadataModules from '../src/enums/MetadataModules';
+import { buildMetadata } from '../src/utilities/buildMetadata';
+import genericMetadataProvider from '../src/utilities/genericMetadataProvider';
+
+function createLocalSlice(imageId, extra = {}) {
+  return createAndCacheLocalImage(imageId, {
+    scalarData: new Int16Array(4).fill(-1000),
+    dimensions: [2, 2],
+    spacing: [1, 1],
+    origin: [0, 0, 0],
+    direction: [1, 0, 0, 0, 1, 0, 0, 0, 1],
+    ...extra,
+  });
+}
+
+describe('createAndCacheLocalImage metadata', () => {
+  beforeEach(() => {
+    cache.purgeCache();
+    genericMetadataProvider.clear();
+    metaData.removeAllProviders();
+    metaData.addProvider(genericMetadataProvider.get);
+  });
+
+  afterEach(() => {
+    cache.purgeCache();
+    genericMetadataProvider.clear();
+  });
+
+  it('registers generalSeriesModule so buildMetadata can read modality', () => {
+    const imageId = 'local:slice0';
+    const image = createLocalSlice(imageId);
+
+    expect(metaData.get(MetadataModules.GENERAL_SERIES, imageId)).toEqual(
+      expect.any(Object)
+    );
+    expect(() => buildMetadata(image)).not.toThrow();
+  });
+
+  it('stores an explicit modality on generalSeriesModule', () => {
+    const imageId = 'local:ct';
+    const image = createLocalSlice(imageId, { modality: 'CT' });
+
+    expect(metaData.get(MetadataModules.GENERAL_SERIES, imageId)).toEqual(
+      expect.objectContaining({ modality: 'CT' })
+    );
+    expect(buildMetadata(image).modality).toBe('CT');
+  });
+
+  it('keeps a referenced image generalSeriesModule on derived images', () => {
+    const referencedImageId = 'local:ref';
+    createLocalSlice(referencedImageId);
+    genericMetadataProvider.add(referencedImageId, {
+      type: MetadataModules.GENERAL_SERIES,
+      metadata: { modality: 'PT', seriesInstanceUID: '1.2.3' },
+    });
+
+    const derived = createAndCacheDerivedImage(referencedImageId, {
+      imageId: 'derived:slice0',
+    });
+
+    expect(
+      metaData.get(MetadataModules.GENERAL_SERIES, derived.imageId)
+    ).toEqual(
+      expect.objectContaining({
+        modality: 'PT',
+        seriesInstanceUID: '1.2.3',
+      })
+    );
+  });
+});


### PR DESCRIPTION
### Context

`createAndCacheLocalImage` now registers `generalSeriesModule`, so `StackViewport` load can read `modality` by destructuring that module in `buildMetadata`. Fixes #2828.

`imageLoader.createAndCacheLocalImage()` registered `imagePlaneModule` and `imagePixelModule` but not `generalSeriesModule`. `buildMetadata` destructures that module for `modality`, so a local image throws:

```
Cannot destructure property 'modality' of '...' as it is undefined.
```

On the GPU path that throw is caught inside `ProgressiveRetrieveImages`, `setStack()` still resolves, and the canvas stays black with no console error.

### Changes & Results

- `createAndCacheLocalImage` now registers a `generalSeriesModule`.
- If the local image has a `referencedImageId` that already has a series module, that module is copied (so `createAndCacheDerivedImage`, which already copied series and then calls this helper, is not overwritten with an empty module).
- Otherwise it stores `{ modality }` from an optional `LocalImageOptions.modality`. The object is present even when modality is omitted, so the destructure no longer throws.

Before: a local image had no series module, `buildMetadata` threw, and the canvas stayed black.
After: the local image has a series module, `buildMetadata` returns, and callers can set `modality: 'CT'` without a custom provider.

The missing module is registered on the local-image helper, same pattern as derived images, the nifti loader, and the webLoader example. The alternative is to guard `buildMetadata` with `|| {}`, and/or log/`errorCallback` `successCallback` failures in the progressive loader. The issue says either fix is enough on its own; registering the module on the local-image helper is the smallest reversible change that fixes local images the way the repo already does for derived images. A follow-up can add the `buildMetadata` guard or progressive-loader error surfacing if missing-module failures should be noisy for every image source.

### Testing

```
pnpm exec jest --selectProjects core --testPathPatterns=imageLoader_localImage --no-coverage
pnpm exec jest --selectProjects core --no-coverage
```

- Local image without extra metadata: `generalSeriesModule` is an object; `buildMetadata` does not throw.
- `modality: 'CT'` is stored and returned from `buildMetadata`.
- A local image with `referencedImageId` copies that image's series module (`PT` + `seriesInstanceUID` in the test).

Manual: the issue's `repro:` scheme snippet should now get `viewport.getImageData()` after `setStack()`. Unit tests cover the metadata / `buildMetadata` throw site (pre-GL), not a full WebGL canvas.

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments, etc.)

#### Public Documentation Updates

- [x] The documentation page has been updated as necessary for any public API additions or removals.
      (`modality?` is on the unexported `LocalImageOptions`; no docs site change. A docs note can go in if this is treated as public API.)

#### Tested Environment

- [x] OS: macOS 15.6 (darwin 24.6.0, arm64)
- [x] Node version: v26.5.1
- [x] Browser: not used; unit-tested the metadata / `buildMetadata` throw site (pre-GL)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Local DICOM images can now include an optional modality when created.
  - General-series metadata is automatically available alongside image metadata, allowing modality details to be read consistently.
  - Existing general-series information is preserved when creating an image from a referenced image.
- **Tests**
  - Added coverage for modality registration, explicit modality values, and metadata preservation from referenced images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->