### PR TITLE
fix(security): override smol-toml to 1.7.1 (GHSA-7w5x-hrqm-74c2)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,7 @@ overrides:
   ip-address@<10.5.0: 10.5.0
   nx@>=20.8.0 <22.7.8: 22.7.8
   pacote@>=11.2.7 <21.5.1: 21.5.1
+  smol-toml@<1.7.1: 1.7.1
 
 importers:
   .:
@@ -17773,10 +17774,10 @@ packages:
       }
     engines: { node: '>= 6.0.0', npm: '>= 3.0.0' }
 
-  smol-toml@1.6.1:
+  smol-toml@1.7.1:
     resolution:
       {
-        integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==,
+        integrity: sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==,
       }
     engines: { node: '>= 18' }
 
@@ -30650,7 +30651,7 @@ snapshots:
       safe-buffer: 5.2.1
       semver: 7.7.4
       signal-exit: 3.0.7
-      smol-toml: 1.6.1
+      smol-toml: 1.7.1
       string-width: 4.2.3
       string_decoder: 1.3.0
       strip-ansi: 6.0.1
@@ -32925,7 +32926,7 @@ snapshots:
 
   smart-buffer@4.2.0: {}
 
-  smol-toml@1.6.1: {}
+  smol-toml@1.7.1: {}
 
   snake-case@3.0.4:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -78,6 +78,7 @@ overrides:
   'ip-address@<10.5.0': 10.5.0
   'nx@>=20.8.0 <22.7.8': 22.7.8
   'pacote@>=11.2.7 <21.5.1': 21.5.1
+  'smol-toml@<1.7.1': 1.7.1
 
 auditConfig:
   ignoreGhsas:


### PR DESCRIPTION
### Context

The advisory GHSA-7w5x-hrqm-74c2 (CVE-2026-85730) applies to `smol-toml`. The
package enters an infinite loop when it parses a malformed TOML document. The
example in the advisory is `parse('a=[1 #')`: the parser resets the cursor to
the start of the document, and the call never returns. GitHub rates the
advisory as high, with a CVSS v4 score of 8.2. All versions up to and including
1.7.0 are affected. Version 1.7.1 has the patch.

The tree of this repository contains `smol-toml@1.6.1`. The CircleCI job
"Security Audit - High Risk Vulnerabilities" runs `pnpm audit --audit-level
high` when a pull request changes `pnpm-lock.yaml`. Today that command reports
the advisory and exits 1. Each pull request that touches `pnpm-lock.yaml`
therefore fails this gate, and the failure is not related to the work in that
pull request.

`smol-toml` is a development dependency only. `pnpm why smol-toml` shows these
paths:

```
smol-toml@1.6.1
└─┬ nx@22.7.8
  ├─┬ @lerna/create@9.0.4
  │ └─┬ lerna@9.0.4
  │   └── root (devDependencies)
  ├─┬ @nx/devkit@22.7.4
  │ ├── @lerna/create@9.0.4 [deduped]
  │ └── lerna@9.0.4 [deduped]
  └── lerna@9.0.4 [deduped]
```

An earlier review comment gave two options for the fix: an upgrade of `nx` or
`lerna`, or an entry in `auditConfig.ignoreGhsas`. An upgrade does not work.
Every `nx` release pins `smol-toml` at exactly `1.6.1`, and the newest release
`nx@23.2.1` also pins `1.6.1`. An `nx` upgrade or a `lerna` upgrade therefore
keeps the vulnerable version in the tree.

An entry in `auditConfig.ignoreGhsas` hides the advisory, but the vulnerable
code stays in the tree. A patched version exists, so this pull request uses an
override instead. The override is the same mechanism that this repository
already uses for `nx`, `pacote`, `brace-expansion`, and other transitive
packages.

### Changes & Results

- Add the override `'smol-toml@<1.7.1': 1.7.1` to `pnpm-workspace.yaml`. The
  override is one line, and it carries no comment. The commit message records
  the advisory and the reason for the override.
- Update `pnpm-lock.yaml`. The lockfile moves `smol-toml` from `1.6.1` to
  `1.7.1`. `pnpm why smol-toml` finds one version of the package.

Before the change:

```
5 high (4 ignored) | 1 critical (1 ignored)
EXIT=1
```

After the change:

```
4 high (4 ignored) | 1 critical (1 ignored)
EXIT=0
```

The change adds no new ignore entry. The count of ignored advisories stays at
four high advisories and one critical advisory.

### Testing

Run these commands in the root of the repository:

1. `pnpm install --lockfile-only --no-frozen-lockfile` — the command makes no
   further change to `pnpm-lock.yaml`.
2. `pnpm audit --audit-level high` — the command exits 0, and the report does
   not contain `smol-toml`.
3. `pnpm why smol-toml` — the command shows `smol-toml@1.7.1` only.

The change is limited to the development tool chain. The published packages do
not contain `smol-toml`.

### Checklist

#### PR

- [x] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [x] My code has been well-documented (function documentation, inline comments,
  etc.)

#### Public Documentation Updates

- [x] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [x] "OS: Windows 11"
- [x] "Node version: 24"
- [x] "Browser: not applicable — the change is a build dependency only"

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency resolution to use `smol-toml` version 1.7.1 or later.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
